### PR TITLE
[Feat] 맵 기본 화면 구현 완료 (지도, 위치, 기본버튼)

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BNomad/Application/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "당신의 위치를 저희가 쓰겠습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -498,6 +499,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BNomad/Application/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "당신의 위치를 저희가 쓰겠습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -144,22 +144,13 @@ class MapViewController: UIViewController {
     func configueMapUI() {
         map.delegate = self
         view.addSubview(map)
-        map.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-        map.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-        map.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-        map.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        map.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
 
         map.addSubview(mapButtons)
-        mapButtons.topAnchor.constraint(equalTo: map.topAnchor, constant: 50) .isActive = true
-        mapButtons.rightAnchor.constraint(equalTo: map.rightAnchor, constant: -20).isActive = true
-        mapButtons.widthAnchor.constraint(equalToConstant: 40).isActive = true
-        mapButtons.heightAnchor.constraint(equalToConstant: 140).isActive = true
+        mapButtons.anchor(top: map.topAnchor, right: map.rightAnchor, paddingTop: 50, paddingRight: 20, width: 40, height: 140)
         
         map.addSubview(compass)
-        compass.topAnchor.constraint(equalTo: map.topAnchor, constant: 50) .isActive = true
-        compass.leftAnchor.constraint(equalTo: map.leftAnchor, constant: 20).isActive = true
-        compass.widthAnchor.constraint(equalToConstant: 40).isActive = true
-        compass.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        compass.anchor(top: map.topAnchor, left: map.leftAnchor, paddingTop: 50, paddingLeft: 20, width: 40, height: 40)
         
         map.addOverlay(circleOverlay)
 
@@ -167,6 +158,7 @@ class MapViewController: UIViewController {
     
 }
 
+// MARK: - MKMapViewDelegate
 
 extension MapViewController: MKMapViewDelegate {
     

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -6,24 +6,173 @@
 //
 
 import UIKit
+import MapKit
 
 class MapViewController: UIViewController {
+    
+    // MARK: - Properties
+
+    private let locationManager = CLLocationManager()
+    
+    let userLocation = MKUserLocation()
+    let span = MKCoordinateSpan(latitudeDelta: 1, longitudeDelta: 1) // span을 바꾸어 적용하려고 해도 잘 안됩니다. setRegion에 변화를 줄 수 있는 방법을 계속 찾아볼 예정입니다.
+    lazy var startRegion: MKCoordinateRegion = MKCoordinateRegion(center: userLocation.coordinate, span: span)
+    
+    // 맵 띄우기
+    lazy var map: MKMapView = {
+        let map = MKMapView()
+        map.setRegion(startRegion, animated: false)
+        map.pointOfInterestFilter = .some(MKPointOfInterestFilter(including: [.airport, .beach, .campground, .publicTransport]))
+        map.showsScale = false
+        map.showsCompass = false
+        map.userTrackingMode = .follow
+        map.showsUserLocation = true
+        map.translatesAutoresizingMaskIntoConstraints = false
+        return map
+    }()
+    
+    // 맵 회전 시에만 일시적으로 등장하는 나침반
+    lazy var compass: MKCompassButton = {
+        let compass = MKCompassButton(mapView: map)
+        compass.compassVisibility = .adaptive
+        compass.translatesAutoresizingMaskIntoConstraints = false
+        return compass
+    }()
+    
+    // 기본 버튼들 (프로필, 세팅, 유저 위치)
+    private let profileBtn: UIButton = {
+        let btn = UIButton()
+        btn.setImage(UIImage(systemName: "person"), for: .normal)
+        btn.tintColor = .systemGray
+        btn.backgroundColor = .white
+        btn.layer.cornerRadius = 10
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
+    }()
+    
+    private let divider: UIView = {
+        let divider = UIView()
+        divider.backgroundColor = .systemGray
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        divider.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        divider.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        return divider
+    }()
+    
+    private let settingBtn: UIButton = {
+        let btn = UIButton()
+        btn.setImage(UIImage(systemName: "gearshape"), for: .normal)
+        btn.tintColor = .systemGray
+        btn.backgroundColor = .white
+        btn.layer.cornerRadius = 10
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
+    }()
+    
+    lazy var profileAndSetting: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [profileBtn, divider, settingBtn])
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = 1
+        stackView.distribution = .fillProportionally
+        stackView.backgroundColor = .white
+        stackView.layer.cornerRadius = 10
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    lazy var userTrackingBtn: MKUserTrackingButton = {
+        let btn = MKUserTrackingButton(mapView: map)
+        btn.backgroundColor = .white
+        btn.tintColor = .systemGray
+        btn.layer.cornerRadius = 10
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
+    }()
+    
+    lazy var mapButtons: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [profileAndSetting, userTrackingBtn])
+        stackView.sizeToFit()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.spacing = 2
+        stackView.distribution = .equalCentering
+        stackView.backgroundColor = .clear
+        stackView.layer.cornerRadius = 10
+        profileAndSetting.widthAnchor.constraint(equalToConstant: 40).isActive = true
+        profileAndSetting.heightAnchor.constraint(equalToConstant: 90).isActive = true
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    // 추후 유저 위치 중심으로 circle overlay 그릴 예정 (현재는 적용이 안되고 있습니다)
+    lazy var circleOverlay: MKCircle = {
+        let circle = MKCircle(center: CLLocationCoordinate2D(latitude: 36, longitude: 129), radius: 1000)
+        return circle
+    }()
+
+    // MARK: - LifeCycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        locationAuthorization()
+        configueMapUI()
+        
+        
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    // MARK: - Actions
+    
+    // 맵을 회전시켜 나침반이 등장한 상태로 유저 위치로 가기 버튼을 누르면 맵 회전된 상태 그대로 위치만 이동하고 있어서, 유저 위치로 갈 때 자동으로 정북 방향으로 회전까지 같이 시켜주는 방안 고민중입니다.
+    func userTrackingToCompass() {
+        if userTrackingBtn.isExclusiveTouch {
+            
+        }
     }
-    */
+    
+    
+    // MARK: - Helpers
+    
+    // 위치 권한 받아서 현재 위치 확인
+    func locationAuthorization() {
+        locationManager.requestWhenInUseAuthorization()
+        locationManager.startUpdatingLocation()
+    }
+    
+    // 맵 UI 그리기
+    func configueMapUI() {
+        map.delegate = self
+        view.addSubview(map)
+        map.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        map.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        map.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+        map.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
 
+        map.addSubview(mapButtons)
+        mapButtons.topAnchor.constraint(equalTo: map.topAnchor, constant: 50) .isActive = true
+        mapButtons.rightAnchor.constraint(equalTo: map.rightAnchor, constant: -20).isActive = true
+        mapButtons.widthAnchor.constraint(equalToConstant: 40).isActive = true
+        mapButtons.heightAnchor.constraint(equalToConstant: 140).isActive = true
+        
+        map.addSubview(compass)
+        compass.topAnchor.constraint(equalTo: map.topAnchor, constant: 50) .isActive = true
+        compass.leftAnchor.constraint(equalTo: map.leftAnchor, constant: 20).isActive = true
+        compass.widthAnchor.constraint(equalToConstant: 40).isActive = true
+        compass.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        
+        map.addOverlay(circleOverlay)
+
+    }
+    
+}
+
+
+extension MapViewController: MKMapViewDelegate {
+    
+    // 맵 오버레이 관련 func
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        MKCircleRenderer(circle: circleOverlay)
+    }
+    
 }


### PR DESCRIPTION
## 관련 이슈들
- #7 

## 작업 내용
- 지도 안에 시장, 학원, 학교 등 다양한 정보가 다 뜨는 것이 지저분해서 공항, 교통, 해변, 캠핑장 등 일부 정보만 남겼습니다. 애플 맵 카테고리 중 선택할 수 있으니 어떤 카테고리들을 맵에 같이 보여줄지 함께 정하면 좋겠습니다.
- 현재 위치로 가는 버튼은 잘 작동하나 나침반 회전 상태에서 현재 위치로 갈 때 회전이 초기화되지 않습니다. 이 부분 추후 해결할 예정입니다.
- 현재 위치 중심으로 원형 overlay 도 잘 구현되지 않아 추후 보완하겠습니다.
- 버튼들은 UI 만 만들어놓았고 액션은 다른 뷰가 구현된 뒤에 연결할 예정입니다.

## 리뷰 노트
- 맵을 시작할 때 setRegion이 없으면 대한민국 전도부터 시작을 해서 setRegion을 통해 현재 위치 중심으로 시작하게 바꾸었습니다. 그런데 span 값으로 현재 위치 중심에서 줌인/아웃 정도까지 조절할 수 있는 것으로 알고 있는데, span 값을 달리 줘도 시작하는 화면에 변화가 없습니다. 이 부분이 궁금합니다.
- user tracking 버튼을 눌러 현재 위치로 갈 때 나침반 초기화까지 같이 하는 게 자연스럽다고 생각했는데 네이버 지도를 보니 나침반과 위치를 별개로 동작하게 하긴 하네요. 뭐가 좋을지 의견들이 궁금합니다.
- overlay 그리는 것은 결국 custom annotation 그리는 것과 같은 맥락이라서 다음 이슈에서 pin 들을 그려넣을 때 같이 해결하겠습니다.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012800/196329827-d9780ee9-dbe1-4c6f-92eb-fe2e008db307.png" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
