### PR TITLE
[Feat] #46 NewPlaceViewBeforeCheckIn UI

### DIFF
--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -123,7 +123,35 @@ class MapViewController: UIViewController {
     }()
     
     var userCheckedIn: Bool = false
+    
+    lazy var listViewButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .white
+        button.setTitle("리스트 보기", for:.normal)
+        button.titleLabel!.font = .preferredFont(forTextStyle: .subheadline, weight: .bold)
+        button.setTitleColor(CustomColor.nomadBlue, for: .normal)
+        button.layer.cornerRadius = 20
+        button.layer.borderColor = CustomColor.nomadBlue?.cgColor
+        button.layer.borderWidth = 1
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(presentPlaceViewModal), for: .touchUpInside)
+        return button
+    }()
 
+    @objc private func presentPlaceViewModal() {
+        let sheet = CustomModalViewController()
+        sheet.modalPresentationStyle = .pageSheet
+        if let sheet = sheet.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.delegate = self
+            sheet.prefersGrabberVisible = false
+            sheet.largestUndimmedDetentIdentifier = .medium
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+            sheet.preferredCornerRadius = 12
+        }
+        present(sheet, animated: true, completion: nil)
+    }
+    
     // MARK: - LifeCycle
     
     override func viewWillAppear(_ animated: Bool) {
@@ -188,6 +216,9 @@ class MapViewController: UIViewController {
             view.addSubview(workingView)
             workingView.anchor(top: view.topAnchor, left: view.leftAnchor, right: mapButtons.leftAnchor, paddingTop: 50, paddingLeft: 50, paddingRight: 30, height: 44)
         }
+        
+        map.addSubview(listViewButton)
+        listViewButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, paddingLeft: 15, paddingBottom: 70, width: 88, height: 43.73)
     }
     
     func registerAnnotationViewClasses() {
@@ -257,5 +288,13 @@ extension MapViewController: ClearSelectedAnnotation {
                 map.selectedAnnotations.append(annotation)
             }
         }
+    }
+}
+
+// MARK: - SheetModalView in MapView
+
+extension MapViewController: UISheetPresentationControllerDelegate {
+    func sheetPresentationControllerDidChangeSelectedDetentIdentifier(_ sheetPresentationController: UISheetPresentationController) {
+        print(sheetPresentationController.selectedDetentIdentifier == .large ? "large" : "medium")
     }
 }

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -294,7 +294,5 @@ extension MapViewController: ClearSelectedAnnotation {
 // MARK: - SheetModalView in MapView
 
 extension MapViewController: UISheetPresentationControllerDelegate {
-    func sheetPresentationControllerDidChangeSelectedDetentIdentifier(_ sheetPresentationController: UISheetPresentationController) {
-        print(sheetPresentationController.selectedDetentIdentifier == .large ? "large" : "medium")
-    }
+
 }

--- a/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
+++ b/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
@@ -57,7 +57,6 @@ class CustomModalViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.layer.backgroundColor = UIColor(red: 0.967, green: 0.967, blue: 0.967, alpha: 1).cgColor
-        self.view.layer.cornerRadius = 20
         self.view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         self.view.layer.shadowColor = UIColor.black.cgColor
         self.view.layer.shadowOffset = .init(width: 0, height: -2)
@@ -85,7 +84,7 @@ class CustomModalViewController: UIViewController {
 
 extension CustomModalViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 3
+        return 9
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {


### PR DESCRIPTION
## 관련 이슈들
- #2
- #46 

## 작업 내용
- Navigation View 를 통해서 Map 에서 다른 뷰로 이동할때 이전 2번 Issue 에서 했었던 Custom Modal View 가 사라지지 않는 문제점이 발생하였습니다. 또한, 팀원들과 논의한 결과 현재로서는 중요한 기능이 아니라고 판단되어서 애플에서 제공하는 SheetPresentationController 로 대체하였습니다.
- Sheet View 가 중간까지만 펴질 수 있게 detent 를 .medium() 만 설정하였습니다.

## 리뷰 노트
- Modal View 를 올리는 버튼을 Map 에서 정확히 어느 부분에 위치시켜야 할 지 고민해봐야 할 것 같습니다.
- Modal View 에서의 Grabber 를 애플에서 자체적으로 제공하는 Grabber 로 통일해야 할지, 아니면 디자인대로 Custom Grabber 를 보여줘야 할지 고민해봐야 할 것 같습니다.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/95157024/197487478-ad851ea0-3f36-4334-b793-4f2644d4be77.png" width="300">
<img src="https://user-images.githubusercontent.com/95157024/197487612-fda57194-704d-481b-b2db-de6ccc6f3969.png" width="300">

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
