### PR TITLE
[Feat] UI디자인 변경에 따른 뷰 수정

### DIFF
--- a/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
@@ -12,35 +12,9 @@ class PlaceInfoCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-    var configDetailedCheckinButton: UIButton.Configuration = {
-        var configDetailedCheckinButton = UIButton.Configuration.filled()
-        
-        var titleFontstyle = AttributeContainer()
-        titleFontstyle.font = UIFont.preferredFont(forTextStyle: .body, weight: .regular)
-        titleFontstyle.foregroundColor = CustomColor.nomadBlack
-        var subTitleFontstyle = AttributeContainer()
-        subTitleFontstyle.font = UIFont.preferredFont(forTextStyle: .subheadline, weight: .regular)
-        subTitleFontstyle.foregroundColor = CustomColor.nomadGray1
-        
-        configDetailedCheckinButton.cornerStyle = .fixed
-        configDetailedCheckinButton.background.cornerRadius = 12
-        configDetailedCheckinButton.image = UIImage(named: "ProfileChecked")
-        configDetailedCheckinButton.imagePlacement = .trailing
-        configDetailedCheckinButton.imagePadding = 49
-        configDetailedCheckinButton.attributedTitle = AttributedString("23명 체크인", attributes: titleFontstyle)
-        configDetailedCheckinButton.attributedSubtitle = AttributedString("평균 5시간 근무", attributes: subTitleFontstyle)
-        configDetailedCheckinButton.titlePadding = 7
-        configDetailedCheckinButton.titleAlignment = .leading
-        configDetailedCheckinButton.buttonSize = .large
-        configDetailedCheckinButton.baseBackgroundColor = CustomColor.nomadGray3
-        configDetailedCheckinButton.baseForegroundColor = .black
-        configDetailedCheckinButton.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 17, bottom: 10, trailing: 17)
-        return configDetailedCheckinButton
-    }()
-    
     private var placeNameLabel: UILabel = {
         let placeNameLabel = UILabel()
-        placeNameLabel.text = "노마딕 제주"
+        placeNameLabel.text = "쌍사벅스"
         placeNameLabel.textColor = CustomColor.nomadBlack
         placeNameLabel.font = .preferredFont(forTextStyle: .title1, weight: .bold)
         return placeNameLabel
@@ -53,36 +27,46 @@ class PlaceInfoCell: UICollectionViewCell {
         distanceLabel.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
         return distanceLabel
     }()
-    private var dateLabel: UILabel = {
-        let dateLabel = UILabel()
-        dateLabel.text = "2022년 10월 23일"
-        dateLabel.textColor = CustomColor.nomadBlack
-        dateLabel.font = .preferredFont(forTextStyle: .subheadline, weight: .semibold)
-        return dateLabel
-    }()
+    
+    private let detailedCheckinViewLabel: UILabel = {
+        let detailedLabel = UILabel()
+        detailedLabel.backgroundColor = .white
+        detailedLabel.layer.backgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha: 1).cgColor
+        detailedLabel.layer.cornerRadius = 12
+        detailedLabel.layer.borderWidth = 1
+        detailedLabel.layer.borderColor = UIColor(red: 0.898, green: 0.898, blue: 0.918, alpha: 1).cgColor
 
+        return detailedLabel
+    }()
+    
+
+    
     var configCallButton: UIButton.Configuration = {
         var configCallButton = UIButton.Configuration.filled()
-        configCallButton.image = UIImage(named: "Phone")
+        configCallButton.image = UIImage(systemName: "phone")
         configCallButton.imagePadding = 1
         configCallButton.buttonSize = .mini
         configCallButton.baseBackgroundColor = .white
+        configCallButton.baseForegroundColor = .black
         return configCallButton
     }()
     
-    var configmapButton: UIButton.Configuration = {
-        var configmapButton = UIButton.Configuration.filled()
-        configmapButton.image = UIImage(named: "Map")
-        configmapButton.imagePadding = 1
-        configmapButton.buttonSize = .mini
-        configmapButton.baseBackgroundColor = .white
-        return configmapButton
-    }()
     private let dotImg : UIImageView = {
         let dotImg = UIImageView()
         dotImg.image = UIImage(named: "Dot")
         return dotImg
     }()
+    
+    var configmapButton: UIButton.Configuration = {
+        var configmapButton = UIButton.Configuration.filled()
+        configmapButton.image = UIImage(systemName: "map")
+        configmapButton.imagePadding = 1
+        configmapButton.buttonSize = .mini
+        configmapButton.baseBackgroundColor = .white
+        configmapButton.baseForegroundColor = .black
+        return configmapButton
+    }()
+
     private let dotImg2 : UIImageView = {
         let dotImg2 = UIImageView()
         dotImg2.image = UIImage(named: "Dot")
@@ -96,6 +80,7 @@ class PlaceInfoCell: UICollectionViewCell {
         operatingStatusLabel.textColor = CustomColor.nomadBlack
          return operatingStatusLabel
      }()
+    
     private var operatingTimeLabel: UILabel = {
          var operatingTimeLabel = UILabel()
         operatingTimeLabel.text = "9 : 00 ~ 21 : 00"
@@ -104,18 +89,72 @@ class PlaceInfoCell: UICollectionViewCell {
          return operatingTimeLabel
      }()
     
-    lazy var detailedCheckinViewButton = UIButton(configuration: self.configDetailedCheckinButton, primaryAction: nil)
+    private var dateLabel: UILabel = {
+        let dateLabel = UILabel()
+        dateLabel.text = "2022년 10월 23일"
+        dateLabel.textColor = CustomColor.nomadBlack
+        dateLabel.font = .preferredFont(forTextStyle: .subheadline, weight: .semibold)
+        return dateLabel
+    }()
+    
+    private var checkInCountLable: UILabel = {
+        let countLabel = UILabel()
+        countLabel.text = "3명 체크인"
+        countLabel.textColor = CustomColor.nomadBlack
+        countLabel.font = .preferredFont(forTextStyle: .body, weight: .regular)
+        return countLabel
+    }()
+    
+    
+    lazy var checkInViewAllButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("전체보기", for: .normal)
+        button.setTitleColor(CustomColor.nomadGray1, for: .normal)
+        button.titleLabel?.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
+        button.addTarget(self, action: #selector(checkInViewAllButtonTaped), for: .touchUpInside)
+        return button
+    }()
+    
+    private let personImage : UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "person.circle.fill")
+        image.tintColor = CustomColor.nomadGray2
+        image.frame = CGRect(x: 0, y: 0, width: 60, height: 60)
+        
+        return image
+    }()
+    
+    private let personImage2 : UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "person.circle.fill")
+        image.tintColor = CustomColor.nomadGray2
+        image.frame = CGRect(x: 0, y: 0, width: 60, height: 60)
+        return image
+    }()
+    
+    private let personImage3 : UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "person.circle.fill")
+        image.tintColor = CustomColor.nomadGray2
+        image.frame = CGRect(x: 0, y: 0, width: 60, height: 60)
+        return image
+    }()
+    
     lazy var callButton = UIButton(configuration: self.configCallButton, primaryAction: UIAction(handler: { action in
         print("전화로 이어주게나,,")
     }))
-    lazy var mapButton = UIButton(configuration: self.configmapButton, primaryAction: nil)
+    lazy var mapButton = UIButton(configuration: self.configmapButton, primaryAction: UIAction(handler: { action in print("지도로 이어주게나,,")
+    }))
+    @objc func checkInViewAllButtonTaped(_button: UIButton){
+        print("전체로 보아라,,")
+    }
+
     
     // MARK: - Lifecycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .white
-        
         configureUI()
     }
     
@@ -126,33 +165,50 @@ class PlaceInfoCell: UICollectionViewCell {
     // MARK: - Helpers
     
     private func configureUI() {
+        self.addSubview(detailedCheckinViewLabel)
         self.addSubview(placeNameLabel)
         self.addSubview(distanceLabel)
         self.addSubview(dateLabel)
-        self.addSubview(detailedCheckinViewButton)
         self.addSubview(callButton)
         self.addSubview(mapButton)
         self.addSubview(dotImg)
         self.addSubview(dotImg2)
         self.addSubview(operatingStatusLabel)
         self.addSubview(operatingTimeLabel)
+        self.addSubview(checkInCountLable)
+        self.addSubview(checkInViewAllButton)
+        self.addSubview(personImage)
+        self.addSubview(personImage2)
+        self.addSubview(personImage3)
+        
         
         setAttributes()
     }
     
     private func setAttributes() {
         
-        placeNameLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 45, paddingLeft: 18)
-        distanceLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 56, paddingLeft: 167)
-        dateLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 97, paddingLeft: 18)
-        detailedCheckinViewButton.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 121, paddingLeft: 17)
-        callButton.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 230, paddingLeft: 20)
-        mapButton.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 230, paddingLeft: 74)
-        dotImg.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 243, paddingLeft: 64)
-        dotImg2.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 243, paddingLeft: 119)
-        operatingStatusLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 235, paddingLeft: 138)
-        operatingTimeLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 235, paddingLeft: 197)
-
+        placeNameLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 45, paddingLeft: 25)
+        distanceLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 56, paddingLeft: 135)
+     
+        detailedCheckinViewLabel.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 125, paddingLeft: 20, paddingRight: 20, height: 122)
+        callButton.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 91, paddingLeft: 13)
+        mapButton.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 91, paddingLeft: 69)
+        dotImg.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 104, paddingLeft: 60)
+        dotImg2.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 104, paddingLeft: 118)
+        operatingStatusLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 96, paddingLeft: 135)
+        operatingTimeLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 96, paddingLeft: 194)
+        dateLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 141, paddingLeft: 38)
+        checkInCountLable.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 139, paddingLeft: 168)
+        checkInViewAllButton.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 135, paddingLeft: 298)
+        personImage.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 174, paddingLeft: 38)
+        personImage.widthAnchor.constraint(equalToConstant: 60).isActive = true
+        personImage.heightAnchor.constraint(equalToConstant: 60).isActive = true
+        personImage2.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 174, paddingLeft: 75)
+        personImage2.widthAnchor.constraint(equalToConstant: 60).isActive = true
+        personImage2.heightAnchor.constraint(equalToConstant: 60).isActive = true
+        personImage3.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 174, paddingLeft: 115)
+        personImage3.widthAnchor.constraint(equalToConstant: 60).isActive = true
+        personImage3.heightAnchor.constraint(equalToConstant: 60).isActive = true
     }
 
 }


### PR DESCRIPTION


## 관련 이슈들
- #51 

## 작업 내용
- 기존 컴포넌트들 위치 수정했습니다. -하나의 버튼으로 구현되어있던 DetailedCheckInButton을 삭제하고 각각 레이블, 이미지, 버튼으로 변경했습니다. 기존의 버튼과 같은 기능흘 하는 현재의 버튼은 '전체보기' 버튼입니다.
 -현재 체크인 버튼은 플로팅버튼으로 구현되어있는데 디자인 수정으로 인해 PlaceInfoCell로 이동해야 합니다.
- 체크인 버튼 로직 수정 필요합니다.

## 리뷰 노트 
- 현재 구현되어있는 모달사이즈와 UI프로토타입의 사이즈가 상이합니다. 프로토 타입상의 모달 사이즈로 구현시 커스텀해야하는데 일단 medium, large 사이즈로 구현되어 있어서 디자인을 수정할지 모달을 커스텀 할지 팀회의시 의견을 나누어야 할 것 같습니다. 

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012086/197546080-2db582b1-7e45-4a77-ab6e-8455a7477dc7.png" width="300">

## Reference
- 

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
