### PR TITLE
[Feat] #63 SignUpView 글자수 제한 추가, 입력값 firebase 저장

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		DF9618B228FCEFEA00E21D30 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9618B128FCEFEA00E21D30 /* FirebaseManager.swift */; };
 		DFE747B928FD75980048E70A /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE747B828FD75980048E70A /* UIView+Extension.swift */; };
 		DFE747CA29000FC80048E70A /* ProfileEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE747C929000FC80048E70A /* ProfileEditViewController.swift */; };
+		E251E6DA2907E49600638C15 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E251E6D92907E49600638C15 /* UIViewController+Extension.swift */; };
 		E25A675228F7E1CE004614B0 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A675128F7E1CE004614B0 /* User.swift */; };
 		E25A675428F7E2C6004614B0 /* Place.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A675328F7E2C6004614B0 /* Place.swift */; };
 		E25A675828F7E515004614B0 /* DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A675728F7E515004614B0 /* DummyData.swift */; };
@@ -96,6 +97,7 @@
 		DF9618B128FCEFEA00E21D30 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		DFE747B828FD75980048E70A /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		DFE747C929000FC80048E70A /* ProfileEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewController.swift; sourceTree = "<group>"; };
+		E251E6D92907E49600638C15 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		E25A675128F7E1CE004614B0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		E25A675328F7E2C6004614B0 /* Place.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Place.swift; sourceTree = "<group>"; };
 		E25A675728F7E515004614B0 /* DummyData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyData.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				7EC6F9F128FE3A19003D8A95 /* UILabel+Extension.swift */,
 				E2E6B23128FE757D005C0D77 /* Date+Extension.swift */,
 				E2E6B23328FE75F7005C0D77 /* String+Extension.swift */,
+				E251E6D92907E49600638C15 /* UIViewController+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -427,6 +430,7 @@
 				E25A675428F7E2C6004614B0 /* Place.swift in Sources */,
 				159F831428FF711D00DBF98B /* PlaceCheckInViewController.swift in Sources */,
 				DF9618B028FCEFCB00E21D30 /* ProfileViewController.swift in Sources */,
+				E251E6DA2907E49600638C15 /* UIViewController+Extension.swift in Sources */,
 				E2ADB25E2907863300082596 /* ViewController.swift in Sources */,
 				159F831C28FFC2FD00DBF98B /* CheckedProfileListHeader.swift in Sources */,
 				159F831828FF79B700DBF98B /* CheckedProfileListViewCell.swift in Sources */,

--- a/BNomad/Utils/Extensions/UIViewController+Extension.swift
+++ b/BNomad/Utils/Extensions/UIViewController+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  UIViewController+Extension.swift
+//  BNomad
+//
+//  Created by Eunbee Kang on 2022/10/25.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    // 화면 빈 곳 터치하면 키보드 내리기
+    func hideKeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -121,7 +121,7 @@ class SignUpViewController: UIViewController {
     
     private let statusField: UITextField = {
         let textfield = UITextField()
-        textfield.placeholder = "상태"
+        textfield.placeholder = "커피챗 환영합니다:)"
         textfield.font = .preferredFont(forTextStyle: .title3)
         textfield.borderStyle = .none
         textfield.clearButtonMode = .whileEditing
@@ -221,6 +221,7 @@ class SignUpViewController: UIViewController {
             paddingLeft: 0,
             width: textFieldWidth
         )
+        nicknameField.becomeFirstResponder()
         
         view.addSubview(nicknameLineView)
         nicknameLineView.anchor(
@@ -321,6 +322,7 @@ class SignUpViewController: UIViewController {
                 occupationField.isHidden = false
                 occupationLineView.isHidden = false
                 occupationCounterLabel.isHidden = false
+                occupationField.becomeFirstResponder()
                 dot1View.backgroundColor = CustomColor.nomadGray2
                 dot2View.backgroundColor = CustomColor.nomadBlue
                 
@@ -336,6 +338,7 @@ class SignUpViewController: UIViewController {
                 statusField.isHidden = false
                 statusLineView.isHidden = false
                 statusCounterLabel.isHidden = false
+                statusField.becomeFirstResponder()
                 dot2View.backgroundColor = CustomColor.nomadGray2
                 dot3View.backgroundColor = CustomColor.nomadBlue
                 

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -311,6 +311,26 @@ class SignUpViewController: UIViewController {
         requestLabel.text = "노마드가 되기 위해\n\(requestItem[index])을 알려주세요!"
     }
     
+    func showAlert() {
+        let alertLabel = UILabel()
+        alertLabel.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
+        alertLabel.text = "빈칸없이 입력해주세요!"
+        alertLabel.textColor = .red
+        alertLabel.alpha = 1.0
+        self.view.addSubview(alertLabel)
+        alertLabel.anchor(
+            top: statusLineView.bottomAnchor,
+            left: statusLineView.leftAnchor,
+            paddingTop: 21
+        )
+
+        UIView.animate(withDuration: 1.0, delay: 1, options: .curveEaseOut, animations: {
+            alertLabel.alpha = 0.0
+        }, completion: {(isCompleted) in
+            alertLabel.removeFromSuperview()
+        })
+    }
+    
     // MARK: - Actions
     
     // TODO: - 입력된 user 정보 기반을 user 생성 & firebase에 user 정보 업데이트
@@ -352,7 +372,8 @@ class SignUpViewController: UIViewController {
                 if nickname.isEmpty == false && occupation.isEmpty == false && intro.isEmpty == false {
                     setUser(nickname: nickname, occupation: occupation, intro: intro)
                 } else {
-                    print("빈칸있음, 저장안함")
+                    showAlert()
+                    print("빈칸있음")
                 }
             }
         }

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -351,7 +351,11 @@ class SignUpViewController: UIViewController {
             if let nickname = nicknameField.text {
                 if let occupation = occupationField.text {
                     if let intro = statusField.text {
-                        setUser(nickname: nickname, occupation: occupation, intro: intro)
+                        if nickname.isEmpty == false && occupation.isEmpty == false && intro.isEmpty == false {
+                            setUser(nickname: nickname, occupation: occupation, intro: intro)
+                        } else {
+                            print("빈칸있음, 저장안함")
+                        }
                     }
                 }
             }

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 class SignUpViewController: UIViewController {
     
     // MARK: - Properties
-
+    
     private let requestItem = ["닉네임", "직업", "상태"]
     private var index = 0
         
@@ -157,6 +157,10 @@ class SignUpViewController: UIViewController {
     
     // MARK: - Methods
     
+    func setUser(nickname: String, occupation: String, intro: String) {
+        FirebaseManager.shared.setUser(user: User(userUid: UUID().uuidString, nickname: nickname, occupation: occupation, introduction: intro, checkInHistory: []))
+    }
+    
     func configUI() {
         let viewWidth = view.bounds.width
         let contentInset: CGFloat = 24
@@ -253,7 +257,6 @@ class SignUpViewController: UIViewController {
     
     // TODO: - 입력된 user 정보 기반을 user 생성 & firebase에 user 정보 업데이트
     @objc func didTapInputConfirmButton() {
-
         if occupationField.isHidden == true {
             if nicknameField.text?.isEmpty == true {
                 print("닉네임을 입력하세요.")
@@ -283,7 +286,16 @@ class SignUpViewController: UIViewController {
             }
             
         } else {
+            if let nickname = nicknameField.text {
+                if let occupation = occupationField.text {
+                    if let intro = statusField.text {
+                        setUser(nickname: nickname, occupation: occupation, intro: intro)
+                        print("setUser")
+                    }
+                }
+            }
             print("이용자 정보 입력완료")
+            
         }
     }
 }

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -192,9 +192,14 @@ class SignUpViewController: UIViewController {
     // MARK: - Methods
     
     func setUser(nickname: String, occupation: String, intro: String) {
-        let id = UUID().uuidString
-        FirebaseManager.shared.setUser(user: User(userUid: id, nickname: nickname, occupation: occupation, introduction: intro, checkInHistory: []))
-        print(id)
+        let deviceUid = UIDevice.current.identifierForVendor?.uuidString
+        guard let userUid = deviceUid else { return }
+        // userdefaults 추가
+        UserDefaults.standard.set(userUid, forKey: "userUid")
+        print(userUid)
+
+        let user = User(userUid: userUid, nickname: nickname, occupation: occupation, introduction: intro)
+        FirebaseManager.shared.setUser(user: user)
     }
     
     func configUI() {

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -13,6 +13,9 @@ class SignUpViewController: UIViewController {
     
     private let requestItem = ["닉네임", "직업", "상태"]
     private var index = 0
+    private let nicknameLimit = 20
+    private let occupationLimit = 40
+    private let statusLimit = 50
         
     lazy var requestLabel: UILabel = {
         let label = UILabel()
@@ -81,6 +84,15 @@ class SignUpViewController: UIViewController {
         return view
     }()
     
+    private lazy var nicknameCounterLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
+        label.text = "0 / \(nicknameLimit)"
+        label.textColor = CustomColor.nomadGray1
+        
+        return label
+    }()
+    
     private let occupationField: UITextField = {
         let textfield = UITextField()
         textfield.placeholder = "직업"
@@ -98,6 +110,15 @@ class SignUpViewController: UIViewController {
         return view
     }()
     
+    private lazy var occupationCounterLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
+        label.text = "0 / \(occupationLimit)"
+        label.textColor = CustomColor.nomadGray1
+        
+        return label
+    }()
+    
     private let statusField: UITextField = {
         let textfield = UITextField()
         textfield.placeholder = "상태"
@@ -113,6 +134,15 @@ class SignUpViewController: UIViewController {
         view.backgroundColor = CustomColor.nomadGray1
         
         return view
+    }()
+    
+    private lazy var statusCounterLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
+        label.text = "0 / \(statusLimit)"
+        label.textColor = CustomColor.nomadGray1
+        
+        return label
     }()
     
     private let inputConfirmButton: UIButton = {
@@ -149,8 +179,10 @@ class SignUpViewController: UIViewController {
         
         occupationField.isHidden = true
         occupationLineView.isHidden = true
+        occupationCounterLabel.isHidden = true
         statusField.isHidden = true
         statusLineView.isHidden = true
+        statusCounterLabel.isHidden = true
         
         inputConfirmButton.addTarget(self, action: #selector(didTapInputConfirmButton), for: .touchUpInside)
         
@@ -199,6 +231,13 @@ class SignUpViewController: UIViewController {
             height: lineHeight
         )
         
+        view.addSubview(nicknameCounterLabel)
+        nicknameCounterLabel.anchor(
+            top: nicknameLineView.bottomAnchor,
+            right: nicknameLineView.rightAnchor,
+            paddingTop: 8
+        )
+        
         view.addSubview(occupationField)
         occupationField.inputAccessoryView = keyboardAccView
         occupationField.anchor(
@@ -219,6 +258,13 @@ class SignUpViewController: UIViewController {
             height: lineHeight
         )
         
+        view.addSubview(occupationCounterLabel)
+        occupationCounterLabel.anchor(
+            top: occupationLineView.bottomAnchor,
+            right: occupationLineView.rightAnchor,
+            paddingTop: 8
+        )
+        
         view.addSubview(statusField)
         statusField.inputAccessoryView = keyboardAccView
         statusField.anchor(
@@ -237,6 +283,13 @@ class SignUpViewController: UIViewController {
             paddingLeft: 0,
             width: textFieldWidth,
             height: lineHeight
+        )
+        
+        view.addSubview(statusCounterLabel)
+        statusCounterLabel.anchor(
+            top: statusLineView.bottomAnchor,
+            right: statusLineView.rightAnchor,
+            paddingTop: 8
         )
         
         keyboardAccView.addSubview(inputConfirmButton)
@@ -267,6 +320,7 @@ class SignUpViewController: UIViewController {
             } else {
                 occupationField.isHidden = false
                 occupationLineView.isHidden = false
+                occupationCounterLabel.isHidden = false
                 dot1View.backgroundColor = CustomColor.nomadGray2
                 dot2View.backgroundColor = CustomColor.nomadBlue
                 
@@ -281,6 +335,7 @@ class SignUpViewController: UIViewController {
             } else {
                 statusField.isHidden = false
                 statusLineView.isHidden = false
+                statusCounterLabel.isHidden = false
                 dot2View.backgroundColor = CustomColor.nomadGray2
                 dot3View.backgroundColor = CustomColor.nomadBlue
                 
@@ -322,5 +377,23 @@ extension SignUpViewController: UITextFieldDelegate {
         } else {
             statusLineView.backgroundColor = CustomColor.nomadGray1
         }
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let currentText = textField.text ?? ""
+        guard let stringRange = Range(range, in: currentText) else { return false }
+        let updateText = currentText.replacingCharacters(in: stringRange, with: string)
+        if textField == nicknameField {
+            nicknameCounterLabel.text = "\(updateText.count) / \(nicknameLimit)"
+            return updateText.count < nicknameLimit
+        } else if textField == occupationField {
+            occupationCounterLabel.text = "\(updateText.count) / \(occupationLimit)"
+            return updateText.count < occupationLimit
+        } else if textField == statusField {
+            statusCounterLabel.text = "\(updateText.count) / \(statusLimit)"
+            return updateText.count < statusLimit
+        }
+        
+        return true
     }
 }

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -153,12 +153,16 @@ class SignUpViewController: UIViewController {
         statusLineView.isHidden = true
         
         inputConfirmButton.addTarget(self, action: #selector(didTapInputConfirmButton), for: .touchUpInside)
+        
+        hideKeyboardWhenTappedAround()
     }
     
     // MARK: - Methods
     
     func setUser(nickname: String, occupation: String, intro: String) {
-        FirebaseManager.shared.setUser(user: User(userUid: UUID().uuidString, nickname: nickname, occupation: occupation, introduction: intro, checkInHistory: []))
+        let id = UUID().uuidString
+        FirebaseManager.shared.setUser(user: User(userUid: id, nickname: nickname, occupation: occupation, introduction: intro, checkInHistory: []))
+        print(id)
     }
     
     func configUI() {
@@ -290,12 +294,9 @@ class SignUpViewController: UIViewController {
                 if let occupation = occupationField.text {
                     if let intro = statusField.text {
                         setUser(nickname: nickname, occupation: occupation, intro: intro)
-                        print("setUser")
                     }
                 }
             }
-            print("이용자 정보 입력완료")
-            
         }
     }
 }

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -348,15 +348,11 @@ class SignUpViewController: UIViewController {
             }
             
         } else {
-            if let nickname = nicknameField.text {
-                if let occupation = occupationField.text {
-                    if let intro = statusField.text {
-                        if nickname.isEmpty == false && occupation.isEmpty == false && intro.isEmpty == false {
-                            setUser(nickname: nickname, occupation: occupation, intro: intro)
-                        } else {
-                            print("빈칸있음, 저장안함")
-                        }
-                    }
+            if let nickname = nicknameField.text, let occupation = occupationField.text, let intro = statusField.text {
+                if nickname.isEmpty == false && occupation.isEmpty == false && intro.isEmpty == false {
+                    setUser(nickname: nickname, occupation: occupation, intro: intro)
+                } else {
+                    print("빈칸있음, 저장안함")
                 }
             }
         }


### PR DESCRIPTION
## 관련 이슈들
- #63 

## 작업 내용
- `setUser()`를 사용하여 회원가입 시 입력하는 정보를 firebase에 저장합니다.
- `textField` 입력 글자 수 제한 및 카운터가 추가되었습니다. (ProfileEditView 참고함)
- 화면 빈 곳을 터치하면 키보드가 내려가는 UIViewController extension 추가하였습니다.
- (추가) 확인 버튼을 누르면 다음 칸으로 자동 포커스되도록 하였습니다.

## 리뷰 노트
- `setUser()` 함수에 넣을 닉네임, 직업, 소개글을 3중 if let으로 unwrapping했는데 이렇게 해도 될까요..
- 이제 뭐하죠

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012157/197728584-cdc589be-71d7-4cca-b87f-9d162ea30fb0.gif" width="300">

### firebase database에 저장됨:
<img width="341" alt="Screen Shot 2022-10-25 at 4 31 07 PM" src="https://user-images.githubusercontent.com/103012157/197711194-d730aac7-d26d-4949-920d-5590f3c4cead.png">

## Reference
- [화면 터치 시 키보드 내리기](https://open95.tistory.com/4)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
