### PR TITLE
[Feat] 로그인 판단 & 체크인 view 분기 & user 데이터 가져오기

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		DFE747B928FD75980048E70A /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE747B828FD75980048E70A /* UIView+Extension.swift */; };
 		DFE747CA29000FC80048E70A /* ProfileEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE747C929000FC80048E70A /* ProfileEditViewController.swift */; };
 		E251E6DA2907E49600638C15 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E251E6D92907E49600638C15 /* UIViewController+Extension.swift */; };
+		E251E6DC2907F07E00638C15 /* CombineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E251E6DB2907F07E00638C15 /* CombineViewModel.swift */; };
 		E25A675228F7E1CE004614B0 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A675128F7E1CE004614B0 /* User.swift */; };
 		E25A675428F7E2C6004614B0 /* Place.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A675328F7E2C6004614B0 /* Place.swift */; };
 		E25A675828F7E515004614B0 /* DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A675728F7E515004614B0 /* DummyData.swift */; };
@@ -98,6 +99,7 @@
 		DFE747B828FD75980048E70A /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		DFE747C929000FC80048E70A /* ProfileEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewController.swift; sourceTree = "<group>"; };
 		E251E6D92907E49600638C15 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
+		E251E6DB2907F07E00638C15 /* CombineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineViewModel.swift; sourceTree = "<group>"; };
 		E25A675128F7E1CE004614B0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		E25A675328F7E2C6004614B0 /* Place.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Place.swift; sourceTree = "<group>"; };
 		E25A675728F7E515004614B0 /* DummyData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyData.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				DF288B5928F7D710002838A4 /* LaunchScreen.storyboard */,
 				DF288B5C28F7D710002838A4 /* Info.plist */,
 				F6B5E67D28FFA5B400557596 /* GoogleService-Info.plist */,
+				E251E6DB2907F07E00638C15 /* CombineViewModel.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -442,6 +445,7 @@
 				DFE747CA29000FC80048E70A /* ProfileEditViewController.swift in Sources */,
 				DF9618A628FCEF6A00E21D30 /* MapViewController.swift in Sources */,
 				DF9618AC28FCEFB600E21D30 /* LoginViewController.swift in Sources */,
+				E251E6DC2907F07E00638C15 /* CombineViewModel.swift in Sources */,
 				6383330E2900CDBA005AB0C3 /* PlaceInfoCell.swift in Sources */,
 				6383330E2900CDBA005AB0C3 /* PlaceInfoCell.swift in Sources */,
 				041351A528FF8EBE005D19CC /* LiteralContents.swift in Sources */,

--- a/BNomad/API/FirebaseManager.swift
+++ b/BNomad/API/FirebaseManager.swift
@@ -63,6 +63,17 @@ class FirebaseManager {
     //            occupation
     //            introduction
     //
+
+    /// userUid 존재하는지 체크
+    func checkUserExist(userUid: String, completion: @escaping(Bool) -> Void) {
+        ref.child("users").child(userUid).observeSingleEvent(of: .value, with: { snapshot in
+            if snapshot.exists() {
+                completion(true)
+            } else {
+                completion(false)
+            }
+        })
+    }
     
     /// userData 가져오기
     func fetchUser(id userUid: String, completion: @escaping(User) -> Void) {

--- a/BNomad/Application/CombineViewModel.swift
+++ b/BNomad/Application/CombineViewModel.swift
@@ -10,6 +10,8 @@ import Combine
 
 class CombineViewModel: ObservableObject {
     
+    static let shared = CombineViewModel()
+    
     @Published var user: User?
     @Published var placeInCurrentMap: [Place] = [DummyData.place1, DummyData.place1, DummyData.place2] //
     var isLogIn = false

--- a/BNomad/Application/CombineViewModel.swift
+++ b/BNomad/Application/CombineViewModel.swift
@@ -1,0 +1,16 @@
+//
+//  CombineViewModel.swift
+//  BNomad
+//
+//  Created by hyo on 2022/10/25.
+//
+
+import Foundation
+import Combine
+
+class CombineViewModel: ObservableObject {
+    
+    @Published var user: User?
+    @Published var placeInCurrentMap: [Place] = [DummyData.place1, DummyData.place1, DummyData.place2] //
+    var isLogIn = false
+}

--- a/BNomad/Application/CombineViewModel.swift
+++ b/BNomad/Application/CombineViewModel.swift
@@ -10,9 +10,10 @@ import Combine
 
 class CombineViewModel: ObservableObject {
     
-    static let shared = CombineViewModel()
+    static let shared: CombineViewModel = CombineViewModel()
     
     @Published var user: User?
     @Published var placeInCurrentMap: [Place] = [DummyData.place1, DummyData.place1, DummyData.place2] //
-    var isLogIn = false
+    
+    var isLogIn: Bool { user != nil }
 }

--- a/BNomad/Application/SceneDelegate.swift
+++ b/BNomad/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        window?.rootViewController = UINavigationController(rootViewController: MapViewController()) 
+        window?.rootViewController = UINavigationController(rootViewController: ViewController()) 
         window?.makeKeyAndVisible()
     }
 

--- a/BNomad/Application/ViewController.swift
+++ b/BNomad/Application/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: UIViewController {
         
     }
     
-    func handeLogin() {
+    func handleLogin() {
         let deviceUid = UIDevice.current.identifierForVendor?.uuidString
         guard let deviceUid = deviceUid else { return }
             
@@ -36,7 +36,7 @@ class ViewController: UIViewController {
         }
     }
     
-    func fetchUserAndCheckInHistroy(id userUid: String) {
+    func fetchUserAndCheckInHistory(id userUid: String) {
         FirebaseManager.shared.fetchUser(id: userUid) { user in
             self.viewModel.user = user
             FirebaseManager.shared.fetchCheckInHistory(userUid: userUid) { checkInHistory in

--- a/BNomad/Application/ViewController.swift
+++ b/BNomad/Application/ViewController.swift
@@ -8,16 +8,41 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
+    lazy var viewModel: CombineViewModel = CombineViewModel.shared
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
         view.backgroundColor = .systemBackground
-
-        // TODO: - userDefaults에 저장된 userUid를 가져와 로그인 유무 판단. 그 후에 MapViewController로 이동
         
-        // TODO: - userUid로 fetchUser()를 통해 user 정보를 가져오기
-
-        // TODO: - fetchPlaceAll()
+        handeLogin()
+        
+        let mapViewController = MapViewController()
+        navigationController?.pushViewController(mapViewController, animated: true)
+        
+    }
+    
+    func handeLogin() {
+        let deviceUid = UIDevice.current.identifierForVendor?.uuidString
+        guard let deviceUid = deviceUid else { return }
+            
+        FirebaseManager.shared.checkUserExist(userUid : deviceUid) { isExist in
+            if isExist {
+                self.fetchUserAndCheckInHistroy(id: deviceUid)
+            } else {
+                print("no user")
+            }
+        }
+    }
+    
+    func fetchUserAndCheckInHistroy(id userUid: String) {
+        FirebaseManager.shared.fetchUser(id: userUid) { user in
+            self.viewModel.user = user
+            FirebaseManager.shared.fetchCheckInHistory(userUid: userUid) { checkInHistory in
+                self.viewModel.user?.checkInHistory = checkInHistory
+                print(user)
+            }
+        }
     }
 }

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -22,6 +22,8 @@ class PlaceInfoModalViewController: UIViewController {
     
     var delegate: ClearSelectedAnnotation?
     
+    lazy var viewModel: CombineViewModel = CombineViewModel.shared
+    
     let collectionView: UICollectionView = {
         let flowlayout = UICollectionViewFlowLayout()
         let cv = UICollectionView(frame: .zero, collectionViewLayout: flowlayout)
@@ -88,8 +90,14 @@ class PlaceInfoModalViewController: UIViewController {
     }
     
     @objc func checkIn() {
-        print("CHECK IN")
-        distanceChecker()
+        print("CHECK IN")        
+        if !viewModel.isLogIn {
+            let signUpViewController = SignUpViewController()
+            signUpViewController.modalPresentationStyle = .fullScreen
+            present(signUpViewController, animated: true)
+        } else {
+            distanceChecker()
+        }
     }
     
     // 맵의 특정 장소가 500미터 반경 이내인지 체크

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -11,6 +11,8 @@ class SignUpViewController: UIViewController {
     
     // MARK: - Properties
     
+    lazy var viewModel: CombineViewModel = CombineViewModel.shared
+
     private let requestItem = ["닉네임", "직업", "상태"]
     private var index = 0
     private let nicknameLimit = 20
@@ -356,6 +358,8 @@ class SignUpViewController: UIViewController {
             if let nickname = nicknameField.text, let occupation = occupationField.text, let intro = statusField.text {
                 if nickname.isEmpty == false && occupation.isEmpty == false && intro.isEmpty == false {
                     setUser(nickname: nickname, occupation: occupation, intro: intro)
+                    viewModel.isLogIn = true
+                    self.dismiss(animated: true)
                 } else {
                     print("빈칸있음, 저장안함")
                 }

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -193,15 +193,13 @@ class SignUpViewController: UIViewController {
     
     // MARK: - Methods
     
-    func setUser(nickname: String, occupation: String, intro: String) {
+    func setUser(nickname: String, occupation: String, intro: String) -> User? {
         let deviceUid = UIDevice.current.identifierForVendor?.uuidString
-        guard let userUid = deviceUid else { return }
-        // userdefaults 추가
-        UserDefaults.standard.set(userUid, forKey: "userUid")
-        print(userUid)
-
+        guard let userUid = deviceUid else { return nil}
+        
         let user = User(userUid: userUid, nickname: nickname, occupation: occupation, introduction: intro)
         FirebaseManager.shared.setUser(user: user)
+        return user
     }
     
     func configUI() {
@@ -357,8 +355,8 @@ class SignUpViewController: UIViewController {
         } else {
             if let nickname = nicknameField.text, let occupation = occupationField.text, let intro = statusField.text {
                 if nickname.isEmpty == false && occupation.isEmpty == false && intro.isEmpty == false {
-                    setUser(nickname: nickname, occupation: occupation, intro: intro)
-                    viewModel.isLogIn = true
+                    let user = setUser(nickname: nickname, occupation: occupation, intro: intro)
+                    viewModel.user = user
                     self.dismiss(animated: true)
                 } else {
                     print("빈칸있음, 저장안함")


### PR DESCRIPTION
## 관련 이슈들
#70 
## 작업 내용
- 유저 로그인 판단 방법을 변경합니다.
  - 기존 방식 : userDefaults에 userUid가 존재하는지 유무
  - 새로운 방식 : firebase에 userUid 데이터가 존재하는지 유무
  - 변경이유 : userDefaults를 초기화하려면 앱을 삭제해야하기 떄문에 번거로워서

- ViewController를 entry point로 변경합니다.
  - ViewController의 기능
    - 로그인 유무 판단
    - 유저 데이터, 유저 체크인 히스토리 데이터 가져오기
 
- viewModel을 생성합니다
  - 여러 viewController에서 가져다 사용할 수 있도록 user, place, login 같은 데이터를 관리
 
- login 유무에 따라 체크인 버튼을 눌렀을 때 보여지는 view 분기 시키기

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
