### PR TITLE
[Feat] Firebase 장소데이터 연결 및 뷰 간 데이터 전달 구현

### DIFF
--- a/BNomad/View/MapView/MapData.swift
+++ b/BNomad/View/MapView/MapData.swift
@@ -15,17 +15,19 @@ enum PlaceType: Int {
     case cafe
 }
 
-class PlaceToMKAnnotation: NSObject, MKAnnotation {
+class MKAnnotationFromPlace: NSObject, MKAnnotation {
     var coordinate: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 0, longitude: 0)
     var title: String?
     var subtitle: String?
+    var placeUid: String?
     var type: PlaceType = .coworking
     
     // 더미 데이터에서 좌표 추출하여 MKAnnotation 형식으로 변환
-    static func placeToAnnotation(_ place: Place) -> PlaceToMKAnnotation {
-        let annotation = PlaceToMKAnnotation()
+    static func convertPlaceToAnnotation(_ place: Place) -> MKAnnotationFromPlace {
+        let annotation = MKAnnotationFromPlace()
         annotation.coordinate = CLLocationCoordinate2D(latitude: place.latitude, longitude: place.longitude)
         annotation.title = place.name
+        annotation.placeUid = place.placeUid
         // TODO: - 랜덤 제거 후 PlaceType이 nil 경우의 annotation 사용. 
         let randomNum = Int.random(in: 0...1)
         let randomType = PlaceType(rawValue: randomNum)
@@ -33,11 +35,4 @@ class PlaceToMKAnnotation: NSObject, MKAnnotation {
         return annotation
     }
 }
-
-let placeAnnotations: [MKAnnotation] = [
-    PlaceToMKAnnotation.placeToAnnotation(DummyData.place1),
-    PlaceToMKAnnotation.placeToAnnotation(DummyData.place2),
-    PlaceToMKAnnotation.placeToAnnotation(DummyData.place3)
-]
-
 

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -169,7 +169,7 @@ class MapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.navigationBar.isHidden = true
-        locationAuthorization()
+        locationFuncs()
         configueMapUI()
         
     }
@@ -190,10 +190,13 @@ class MapViewController: UIViewController {
     // MARK: - Helpers
     
     // 위치 권한 받아서 현재 위치 확인
-    func locationAuthorization() {
+    func locationFuncs() {
         locationManager.requestWhenInUseAuthorization()
         locationManager.startUpdatingLocation()
         locationManager.startMonitoringSignificantLocationChanges()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        
     }
     
     // 맵 UI 그리기
@@ -297,4 +300,15 @@ extension MapViewController: ClearSelectedAnnotation {
 
 extension MapViewController: UISheetPresentationControllerDelegate {
 
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension MapViewController: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        currentLocation = location
+        map.removeOverlay(circleOverlay)
+        map.addOverlay(circleOverlay)
+    }
 }

--- a/BNomad/View/PlaceInfoView/BasicInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/BasicInfoCell.swift
@@ -11,8 +11,14 @@ class BasicInfoCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-    // TODO: - 하드 코딩된 부분 전부 제거
-    var place: Place = DummyData.place1
+    var place: Place? {
+        didSet {
+            guard let place = place else { return }
+            mappingPlaceData(place)
+        }
+    }
+
+//    var place: Place = DummyData.place1
 
     static let cellIdentifier = "BasicInfoCell"
     let basicInfoTitleLabel = UILabel()
@@ -63,6 +69,7 @@ class BasicInfoCell: UICollectionViewCell {
         self.addSubview(divider4)
         self.addSubview(infoSuggestionButton)
         setAttributes()
+        mappingPlaceData(place ?? DummyData.place2)
     }
     
     private func setAttributes() {
@@ -136,6 +143,13 @@ class BasicInfoCell: UICollectionViewCell {
 
         
     }
+    
+    func mappingPlaceData(_ place: Place) {
+        // 영업중 표기 등 추가 수정 필요
+        phoneNumberLabel.text = place.contact
+        addressLabel.text = place.address
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/BNomad/View/PlaceInfoView/BasicInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/BasicInfoCell.swift
@@ -69,7 +69,8 @@ class BasicInfoCell: UICollectionViewCell {
         self.addSubview(divider4)
         self.addSubview(infoSuggestionButton)
         setAttributes()
-        mappingPlaceData(place ?? DummyData.place2)
+        guard let place = place else { return }
+        mappingPlaceData(place)
     }
     
     private func setAttributes() {

--- a/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
@@ -47,7 +47,7 @@ class PlaceInfoCell: UICollectionViewCell {
     
     private var placeNameLabel: UILabel = {
         let placeNameLabel = UILabel()
-        placeNameLabel.text = "dd"
+        placeNameLabel.text = "-"
         placeNameLabel.textColor = CustomColor.nomadBlack
         placeNameLabel.font = .preferredFont(forTextStyle: .title1, weight: .bold)
         return placeNameLabel
@@ -145,7 +145,8 @@ class PlaceInfoCell: UICollectionViewCell {
         self.addSubview(operatingTimeLabel)
         
         setAttributes()
-        mappingPlaceData(place ?? DummyData.place2)
+        guard let place = place else { return }
+        mappingPlaceData(place)
     }
     
     private func setAttributes() {

--- a/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
@@ -12,6 +12,13 @@ class PlaceInfoCell: UICollectionViewCell {
     
     // MARK: - Properties
     
+    var place: Place? {
+        didSet {
+            guard let place = place else { return }
+            mappingPlaceData(place)
+        }
+    }
+    
     var configDetailedCheckinButton: UIButton.Configuration = {
         var configDetailedCheckinButton = UIButton.Configuration.filled()
         
@@ -40,7 +47,7 @@ class PlaceInfoCell: UICollectionViewCell {
     
     private var placeNameLabel: UILabel = {
         let placeNameLabel = UILabel()
-        placeNameLabel.text = "노마딕 제주"
+        placeNameLabel.text = "dd"
         placeNameLabel.textColor = CustomColor.nomadBlack
         placeNameLabel.font = .preferredFont(forTextStyle: .title1, weight: .bold)
         return placeNameLabel
@@ -138,6 +145,7 @@ class PlaceInfoCell: UICollectionViewCell {
         self.addSubview(operatingTimeLabel)
         
         setAttributes()
+        mappingPlaceData(place ?? DummyData.place2)
     }
     
     private func setAttributes() {
@@ -153,6 +161,10 @@ class PlaceInfoCell: UICollectionViewCell {
         operatingStatusLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 235, paddingLeft: 138)
         operatingTimeLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 235, paddingLeft: 197)
 
+    }
+    
+    func mappingPlaceData(_ place: Place) {
+        placeNameLabel.text = place.name
     }
 
 }

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -20,8 +20,7 @@ class PlaceInfoModalViewController: UIViewController {
             collectionView.reloadData()
         }
     }
-//    lazy var selectedAnnotation = MKAnnotationFromPlace.convertPlaceToAnnotation(selectedPlace ?? DummyData.place2)
-    
+        
     let locationManager = CLLocationManager()
     lazy var currentLocation = locationManager.location
     
@@ -70,10 +69,11 @@ class PlaceInfoModalViewController: UIViewController {
         setupSheet()
     }
     
-//    override func viewWillDisappear(_ animated: Bool) {
-//        super.viewWillDisappear(animated)
-//        delegate?.clearAnnotation(view: selectedAnnotation)
-//    }
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        guard let selectedPlace = selectedPlace else { return }
+        delegate?.clearAnnotation(view: MKAnnotationFromPlace.convertPlaceToAnnotation(selectedPlace))
+    }
     
     // MARK: - Actions
     
@@ -100,10 +100,9 @@ class PlaceInfoModalViewController: UIViewController {
     func distanceChecker() {
         let boundary = CLCircularRegion(center: currentLocation?.coordinate ?? CLLocationCoordinate2D(latitude: 0, longitude: 0), radius: 500.0, identifier: "반경 500m")
         
-              // TODO: - 하드 코딩된 부분 변경 -> "노마드 제주에 체크인 하시겠습니까?"
-
-        if boundary.contains(CLLocationCoordinate2D(latitude: selectedPlace?.latitude ?? 0, longitude: selectedPlace?.longitude ?? 0)) {
-            let checkInAlert = UIAlertController(title: "체크인 하시겠습니까?", message: "노마드 제주에 체크인 하시겠습니까?", preferredStyle: .alert)
+        guard let selectedPlace = selectedPlace else { return }
+        if boundary.contains(CLLocationCoordinate2D(latitude: selectedPlace.latitude, longitude: selectedPlace.longitude)) {
+            let checkInAlert = UIAlertController(title: "체크인 하시겠습니까?", message: "\(selectedPlace.name)에 체크인합니다.", preferredStyle: .alert)
             checkInAlert.addAction(UIAlertAction(title: "취소", style: .cancel))
             checkInAlert.addAction(UIAlertAction(title: "확인", style: .default, handler: { action in
                 // TODO: Firebase에 올리는 작업, checkInButton 색 바로 업데이트 해야함

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -15,7 +15,12 @@ protocol ClearSelectedAnnotation {
 class PlaceInfoModalViewController: UIViewController {
     
     // MARK: - Properties
-    var selectedAnnotation: MKAnnotation?
+    var selectedPlace: Place? {
+        didSet {
+            collectionView.reloadData()
+        }
+    }
+//    lazy var selectedAnnotation = MKAnnotationFromPlace.convertPlaceToAnnotation(selectedPlace ?? DummyData.place2)
     
     let locationManager = CLLocationManager()
     lazy var currentLocation = locationManager.location
@@ -31,7 +36,7 @@ class PlaceInfoModalViewController: UIViewController {
     // TODO: user.isChecked로 대체
     var isCheckedIn: Bool = false
 
-    var place: Place = DummyData.place1
+    
 
     // TODO: - checkIn, checkOut 버튼 하나로 통일 후 user.isChecked 기반으로 버튼 상태 변경
     lazy var checkInButton: UIButton = {
@@ -65,11 +70,10 @@ class PlaceInfoModalViewController: UIViewController {
         setupSheet()
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        guard let selectedAnnotation = selectedAnnotation else { return }
-        delegate?.clearAnnotation(view: selectedAnnotation)
-    }
+//    override func viewWillDisappear(_ animated: Bool) {
+//        super.viewWillDisappear(animated)
+//        delegate?.clearAnnotation(view: selectedAnnotation)
+//    }
     
     // MARK: - Actions
     
@@ -98,7 +102,7 @@ class PlaceInfoModalViewController: UIViewController {
         
               // TODO: - 하드 코딩된 부분 변경 -> "노마드 제주에 체크인 하시겠습니까?"
 
-        if boundary.contains(CLLocationCoordinate2D(latitude: selectedAnnotation?.coordinate.latitude ?? 0, longitude: selectedAnnotation?.coordinate.longitude ?? 0)) {
+        if boundary.contains(CLLocationCoordinate2D(latitude: selectedPlace?.latitude ?? 0, longitude: selectedPlace?.longitude ?? 0)) {
             let checkInAlert = UIAlertController(title: "체크인 하시겠습니까?", message: "노마드 제주에 체크인 하시겠습니까?", preferredStyle: .alert)
             checkInAlert.addAction(UIAlertAction(title: "취소", style: .cancel))
             checkInAlert.addAction(UIAlertAction(title: "확인", style: .default, handler: { action in
@@ -179,9 +183,11 @@ extension PlaceInfoModalViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if indexPath.section == 0 {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PlaceInfoCell.cellIdentifier, for: indexPath) as? PlaceInfoCell else { return UICollectionViewCell() }
+            cell.place = selectedPlace
             return cell
         } else if indexPath.section == 1 {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BasicInfoCell.cellIdentifier, for: indexPath) as? BasicInfoCell else { return UICollectionViewCell() }
+            cell.place = selectedPlace
             return cell
         }
         else if indexPath.section == 2 {


### PR DESCRIPTION
## 관련 이슈들
- #66 

## 작업 내용
- Firebase fetch 로 장소 데이터 다운로드 (비동기)
- 장소핀 구현
- 장소핀 데이터 (이름, 전화번호, 주소 등) 장소 데이터로부터 자동 전달 (PlaceUid 비교 후 Place 자체를 다른 뷰로 전달)
- 장소 모달과 모달을 구성하는 PlaceInfoCell, BasicInfoCell에 place 기반으로 정보 업데이트하는 func 구현

## 리뷰 노트
- 자동으로 데이터 들어가는 걸 보니 UI 수정이 또 필요한 게 보이네요 ㅎㅎ
- 특정 annotation을 클릭할 때 span값이 고정상태여서인지 어색하게 줌아웃이 되면서 모달이 뜨는 경우가 있고, 클러스터 상태로 돌아가서 모달만 보일 때도 있습니다. (아래 그림 중 박태준 학술정보관) MVP에서 수정이 필요할지 의견이 궁금합니다.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012800/197777389-ab16f3c6-9668-41b0-bcec-056302ff0af3.png" width="300">
<img src="https://user-images.githubusercontent.com/103012800/197777673-5abba96d-b7a5-44eb-9009-04ce3aa6ea15.png" width="300">
<img src="https://user-images.githubusercontent.com/103012800/197779569-9e8ac3b8-e078-45b8-8e88-58d37c502987.png" width="300">

<img src="https://user-images.githubusercontent.com/103012800/197778009-fd15f6e7-61af-4303-9771-0296db8d6104.gif" width="300">


## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
