### PR TITLE
[Fix] #122 평균 근무 시간이 1시간 이내일 경우 0시간 몇분으로 뜨는 것을 막기 위해 calculateAverageTime 함수 조정

### DIFF
--- a/BNomad/View/PlaceViewBeforeCheckIn/CustomCollectionViewCell.swift
+++ b/BNomad/View/PlaceViewBeforeCheckIn/CustomCollectionViewCell.swift
@@ -150,7 +150,7 @@ class CustomCollectionViewCell: UICollectionViewCell {
             averageTime = abs(totalTime / filterCheckInHistory.count)
             hour = averageTime / 60
             minute = averageTime - hour
-            stringTime = "평균 \(hour)시간 \(minute)분 근무"
+            stringTime = hour > 0 ? "평균 \(hour)시간 \(minute)분 근무" : "평균 \(minute)분 근무"
             print(stringTime)
         } else {
             return "평균 0시간"


### PR DESCRIPTION
## 관련 이슈들
- #122 

## 작업 내용
- hour 변수 값이 0인 경우 "0시간" 이 뜨지 않게 하기 위해 calculateAverageTime 함수 조정.

## 리뷰 노트

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/95157024/198105837-2014eb3b-a3da-46bf-91b8-c81d5c530621.png" width="300">

## Reference

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
