### PR TITLE
[Fix] #126 평균 근무 시간이 이상하게 뜨는 것을 방지하기 위해 calculateAverageTime 함수 조정

### DIFF
--- a/BNomad/View/PlaceViewBeforeCheckIn/CustomCollectionViewCell.swift
+++ b/BNomad/View/PlaceViewBeforeCheckIn/CustomCollectionViewCell.swift
@@ -149,8 +149,14 @@ class CustomCollectionViewCell: UICollectionViewCell {
         if filterCheckInHistory.count != 0 {
             averageTime = abs(totalTime / filterCheckInHistory.count)
             hour = averageTime / 60
-            minute = averageTime - hour
-            stringTime = hour > 0 ? "평균 \(hour)시간 \(minute)분 근무" : "평균 \(minute)분 근무"
+            minute = hour > 0 ? averageTime % hour : averageTime
+            if hour > 0 && minute == 0 {
+                stringTime = "평균 \(hour)시간 근무"
+            } else if hour > 0 {
+                stringTime = "평균 \(hour)시간 \(minute)분 근무"
+            } else {
+                stringTime = "평균 \(minute)분 근무"
+            }
             print(stringTime)
         } else {
             return "평균 0시간"

--- a/BNomad/View/PlaceViewBeforeCheckIn/CustomCollectionViewCell.swift
+++ b/BNomad/View/PlaceViewBeforeCheckIn/CustomCollectionViewCell.swift
@@ -150,7 +150,7 @@ class CustomCollectionViewCell: UICollectionViewCell {
             averageTime = abs(totalTime / filterCheckInHistory.count)
             hour = averageTime / 60
             minute = averageTime - hour
-            stringTime = "평균 \(hour)시간 \(minute)분 근무"
+            stringTime = hour > 0 ? "평균 \(hour)시간 \(minute)분 근무" : "평균 \(minute)분 근무"
             print(stringTime)
         } else {
             return "평균 0시간"


### PR DESCRIPTION
## 관련 이슈들
- #122 

## 작업 내용
- 평균 근무 시간이 1시간 66분, 1시간 0분 등으로 뜨는 현상을 방지하기 위해 modulus 와 if-else 문을 활용하여 calculateAverageTime 함수를 조정했습니다.

## 리뷰 노트

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/95157024/198110419-81aac838-b187-4bff-b198-7095c35515d7.png" width="300">

## Reference

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
