### PR TITLE
[Fix] #120 UILabel 글자수 길어질 때 튀어나가지 않도록 함

### DIFF
--- a/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
@@ -77,6 +77,7 @@ class CheckInCardViewCell: UICollectionViewCell {
         label.text = "김노마"
         label.font = .preferredFont(forTextStyle: .title2, weight: .bold)
         label.textColor = CustomColor.nomadBlack
+        label.numberOfLines = 1
         
         return label
     }()
@@ -237,14 +238,18 @@ class CheckInCardViewCell: UICollectionViewCell {
             top: cardRectangleView.topAnchor,
             left: profileImageView.rightAnchor,
             paddingTop: 28,
-            paddingLeft: 18
+            paddingLeft: 18,
+            width: 150
+            
         )
         
         self.addSubview(userOccupationLabel)
         userOccupationLabel.anchor(
             left: userNameLabel.rightAnchor,
             bottom: userNameLabel.bottomAnchor,
-            paddingLeft: 20
+            right: cardRectangleView.rightAnchor,
+            paddingLeft: 20,
+            paddingRight: 20
         )
         
         self.addSubview(userStatusMessage)

--- a/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
@@ -81,11 +81,11 @@ class CheckedProfileListViewCell: UICollectionViewCell {
         
         // 사용자 이름
         self.addSubview(usernameLabel)
-        usernameLabel.anchor(left: userProfileImg.rightAnchor, bottom: userProfileImg.centerYAnchor, paddingLeft: 24, paddingBottom: 2)
+        usernameLabel.anchor(left: userProfileImg.rightAnchor, bottom: userProfileImg.centerYAnchor, right: self.rightAnchor, paddingLeft: 24, paddingBottom: 2, paddingRight: 100)
         
         // 직업
         self.addSubview(occupationLabel)
-        occupationLabel.anchor(bottom: usernameLabel.bottomAnchor, right: self.rightAnchor, paddingRight: 20)
+        occupationLabel.anchor(left: usernameLabel.rightAnchor, bottom: userProfileImg.centerYAnchor, right: self.rightAnchor, paddingLeft: 10, paddingBottom: 2, paddingRight: 20)
         
         // 상태 메세지
         self.addSubview(noteLabel)


### PR DESCRIPTION
## 관련 이슈들
- #120 

## 작업 내용
- UILabel 글자수 길어질 때 튀어나가지 않도록 함

## 리뷰 노트
- 나중에 다이나믹하게 레이아웃이 조정되도록 해보고 싶습니다..

## 스크린샷(UX의 경우 gif)
<img width="300" alt="Screen Shot 2022-10-27 at 11 41 37 AM" src="https://user-images.githubusercontent.com/103012157/198178179-6b0d3272-c244-46fa-9daa-1c2e68b805f1.png">
<img width="300" alt="Screen Shot 2022-10-27 at 11 41 46 AM" src="https://user-images.githubusercontent.com/103012157/198178199-89192408-0efe-4b1e-873b-6af5129b0746.png">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
