### PR TITLE
[fix] profile 뷰에 장소 이름 viewModel과 연결

### DIFF
--- a/BNomad/View/ProfileView/ProfileGraphCell.swift
+++ b/BNomad/View/ProfileView/ProfileGraphCell.swift
@@ -11,7 +11,8 @@ import UIKit
 class ProfileGraphCell: UICollectionViewCell {
     
     // MARK: - Properties
-    
+    lazy var viewModel = CombineViewModel.shared
+
     var thisCellsDate: String?
     var checkInHistory: [CheckIn]? {
         didSet {
@@ -30,9 +31,12 @@ class ProfileGraphCell: UICollectionViewCell {
     static let identifier = "ProfileGraphCell"
     static var addedWeek: Int = 0
     
-    private let nameLabel: UILabel = {
+    private lazy var nameLabel: UILabel = {
         let label = UILabel()
-        label.text = DummyData.place1.name
+
+        let lastCheckIn = self.viewModel.user?.checkInHistory?.last
+        let place = self.viewModel.places.first {$0.placeUid == lastCheckIn?.placeUid}
+        label.text = place?.name
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label

--- a/BNomad/View/ProfileView/VisitingInfoCell.swift
+++ b/BNomad/View/ProfileView/VisitingInfoCell.swift
@@ -12,6 +12,7 @@ class VisitingInfoCell: UICollectionViewCell {
     // MARK: - Properties
     var thisCellsDate: String?
     var cardDataList: [CheckIn] = []
+    lazy var viewModel = CombineViewModel.shared
     
     var checkInHistoryForCalendar: [CheckIn]? {
         didSet {
@@ -58,9 +59,11 @@ class VisitingInfoCell: UICollectionViewCell {
     }
     static let identifier = "VisitingInfoCell"
     
-    private let nameLabel: UILabel = {
+    private lazy var nameLabel: UILabel = {
         let label = UILabel()
-        label.text = DummyData.place1.name
+        let lastCheckIn = self.viewModel.user?.checkInHistory?.last
+        let place = self.viewModel.places.first {$0.placeUid == lastCheckIn?.placeUid}
+        label.text = place?.name
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label


### PR DESCRIPTION

## 작업 내용
- profile 뷰에 장소 이름 viewModel과 연결했습니다.

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.


## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
