### PR TITLE
[Fix] 프로필뷰 및 프로필수정뷰 사소한 수정

### DIFF
--- a/BNomad/View/ProfileView/ProfileEditView/ProfileEditViewController.swift
+++ b/BNomad/View/ProfileView/ProfileEditView/ProfileEditViewController.swift
@@ -37,7 +37,7 @@ class ProfileEditViewController: UIViewController {
     
     private let nickNameLabel: UILabel = {
         let label = UILabel()
-        label.text = "이름⋆"
+        label.text = "닉네임⋆"
         label.font = .preferredFont(forTextStyle: .title2, weight: .bold)
         label.asColor(targetString: "⋆", color: .systemRed)
         return label
@@ -70,7 +70,7 @@ class ProfileEditViewController: UIViewController {
     
     private let occupationLabel: UILabel = {
         let label = UILabel()
-        label.text = "직책⋆"
+        label.text = "직업⋆"
         label.font = .preferredFont(forTextStyle: .title2, weight: .bold)
         label.asColor(targetString: "⋆", color: .systemRed)
         return label
@@ -128,7 +128,7 @@ class ProfileEditViewController: UIViewController {
         textView.layer.masksToBounds = true
         textView.layer.borderColor = CustomColor.nomadGray2?.cgColor
         textView.layer.borderWidth = 1
-        textView.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
+        textView.font = .preferredFont(forTextStyle: .body, weight: .regular)
         textView.delegate = self
         return textView
     }()
@@ -199,6 +199,7 @@ class ProfileEditViewController: UIViewController {
         configureProfileImage()
         configureStackView()
         configureSaveButton()
+        hideKeyboardWhenTappedAround()
     }
     
     

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -113,6 +113,8 @@ class ProfileViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "calendar"), style: .plain, target: self, action: #selector(moveToCalendar))
+        navigationController?.navigationBar.tintColor = CustomColor.nomadBlue
+        navigationItem.backButtonTitle = "취소"
     }
     
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
## 관련 이슈들
- 

## 작업 내용
- 이름, 직책 -> 닉네임, 직업으로 수정
- 자개소개 내용 입력칸 글자크기 키움
- 빈 화면 터치 시 키보드 내리기
- 네비게이션바 색상 nomadBlue로 수정
- 프로필수정 취소 버튼 문구 "Back" -> "취소"

## 리뷰 노트
- 

## 스크린샷(UX의 경우 gif)
<img width="300" alt="Screen Shot 2022-10-27 at 1 03 18 PM" src="https://user-images.githubusercontent.com/103012157/198188475-e81aaf06-6cda-442d-ad7f-5598301406e7.png">
<img width="300" alt="Screen Shot 2022-10-27 at 1 03 32 PM" src="https://user-images.githubusercontent.com/103012157/198188507-8f97067d-eb63-4646-a3dc-4aaebee23c8f.png">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
