### PR TITLE
[Fix] 프로필뷰, 캘린더뷰 비짓카드셀 분기 설정 / 쉐브론 설정

### DIFF
--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -18,14 +18,6 @@ class CalendarViewController: UIViewController {
     private var selectedCell: Int? = Contents.todayDate()["day"]
     let calendarDateFormatter = CalendarDateFormatter()
     
-    var checkinDateData: [Bool] { //TODO: 파베 데이터로 판단하는 로직 필요
-        var data = Array(repeating: false, count: CalendarDateFormatter().days.count)
-        data[10] = true
-        data[11] = true
-        data[20] = true
-        data[21] = true
-        return data
-    }
     
     private let CalendarCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()

--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -105,7 +105,7 @@ class CalendarViewController: UIViewController {
     
     private let plusMonthButton: UIButton = {
         let button = UIButton()
-        button.setTitle(">", for: .normal)
+        button.setImage(UIImage(systemName: "chevron.right"), for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -114,7 +114,7 @@ class CalendarViewController: UIViewController {
     
     private let minusMonthButton: UIButton = {
         let button = UIButton()
-        button.setTitle("<", for: .normal)
+        button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -35,7 +35,7 @@ class ProfileViewController: UIViewController {
     
     private let plusWeek: UIButton = {
         let button = UIButton()
-        button.setTitle(">", for: .normal)
+        button.setImage(UIImage(systemName: "chevron.right"), for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -44,7 +44,7 @@ class ProfileViewController: UIViewController {
     
     private let minusWeek: UIButton = {
         let button = UIButton()
-        button.setTitle("<", for: .normal)
+        button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/BNomad/View/ProfileView/VisitingInfoCell.swift
+++ b/BNomad/View/ProfileView/VisitingInfoCell.swift
@@ -42,6 +42,7 @@ class VisitingInfoCell: UICollectionViewCell {
                 self.checkinTimeLabel.text = ""
                 self.stayedTimeLabel.text = ""
             }
+            nameLabel.reloadInputViews()
         }
     }
     
@@ -58,6 +59,8 @@ class VisitingInfoCell: UICollectionViewCell {
             
             let stayedTime = Int((lastCheckIn.checkOutTime?.timeIntervalSince(lastCheckIn.checkInTime) ?? 0) / 60)
             self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
+            
+            nameLabel.reloadInputViews()
         }
     }
     static let identifier = "VisitingInfoCell"

--- a/BNomad/View/ProfileView/VisitingInfoCell.swift
+++ b/BNomad/View/ProfileView/VisitingInfoCell.swift
@@ -12,10 +12,12 @@ class VisitingInfoCell: UICollectionViewCell {
     // MARK: - Properties
     var thisCellsDate: String?
     var cardDataList: [CheckIn] = []
+    var viewOption: String = ""
     lazy var viewModel = CombineViewModel.shared
     
     var checkInHistoryForCalendar: [CheckIn]? {
         didSet {
+            viewOption = "calendar"
             cardDataList = []
             guard let checkInHistory = checkInHistoryForCalendar else { return }
             
@@ -45,6 +47,7 @@ class VisitingInfoCell: UICollectionViewCell {
     
     var checkInHistoryForProfile: [CheckIn]? {
         didSet {
+            viewOption = "profile"
             guard let lastCheckIn = checkInHistoryForProfile?.last else {return}
             
             let dateFormatter = DateFormatter()
@@ -61,9 +64,17 @@ class VisitingInfoCell: UICollectionViewCell {
     
     private lazy var nameLabel: UILabel = {
         let label = UILabel()
-        let lastCheckIn = self.viewModel.user?.checkInHistory?.last
-        let place = self.viewModel.places.first {$0.placeUid == lastCheckIn?.placeUid}
-        label.text = place?.name
+        
+        if viewOption == "calendar" {
+            let lastCheckIn = self.viewModel.user?.checkInHistory?.first {$0.date == thisCellsDate ?? ""}
+            let place = self.viewModel.places.first {$0.placeUid == lastCheckIn?.placeUid}
+            label.text = place?.name
+        }else {
+            let lastCheckIn = self.viewModel.user?.checkInHistory?.last
+            let place = self.viewModel.places.first {$0.placeUid == lastCheckIn?.placeUid}
+            label.text = place?.name
+        }
+        
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label


### PR DESCRIPTION
## 관련 이슈들


## 작업 내용
- 비짓인포셀을 공유하는 두 뷰컨에 대해 다른 nameLable을 반환하도록 수정했습니다
- 텍스트에서 쉐브론 이미지로 버튼을 교체했습니다

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img src="https://이미지링크를넣어주세요" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
