### PR TITLE
[Fix] 프로필뷰, 캘린더뷰 오토레이아웃 수정

### DIFF
--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -311,7 +311,7 @@ extension CalendarViewController: UICollectionViewDelegateFlowLayout {
         if collectionView == CalendarCollectionView {
             return CGSize(width: 358/8, height: 358/7)
         } else {
-            return CGSize(width: 358, height: 119)
+            return CGSize(width: VisitInfInfoView.frame.width, height: 119)
         }
         
     }

--- a/BNomad/View/ProfileView/ProfileGraphCell.swift
+++ b/BNomad/View/ProfileView/ProfileGraphCell.swift
@@ -100,7 +100,7 @@ class ProfileGraphCell: UICollectionViewCell {
         
         let dayStack = UIStackView(arrangedSubviews: ProfileGraphCell.dayLabel)
         dayStack.axis = .horizontal
-        dayStack.spacing = 19
+        dayStack.spacing = (CGFloat(contentView.frame.width)-55-24*7)/6
         dayStack.distribution = .fillEqually
         dayStack.translatesAutoresizingMaskIntoConstraints = false
         

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -65,7 +65,7 @@ class ProfileViewController: UIViewController {
         return collectionView
     }()
     
-    private let ProfileGraphCollectionView:  UICollectionView = {
+    private let profileGraphCollectionView:  UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
@@ -91,8 +91,8 @@ class ProfileViewController: UIViewController {
         profileCollectionView.dataSource = self
         profileCollectionView.delegate = self
         
-        ProfileGraphCollectionView.dataSource = self
-        ProfileGraphCollectionView.delegate = self
+        profileGraphCollectionView.dataSource = self
+        profileGraphCollectionView.delegate = self
         
         plusWeek.addTarget(self, action: #selector(plusWeekTapButton), for: .touchUpInside)
         minusWeek.addTarget(self, action: #selector(minusWeekTapButton), for: .touchUpInside)
@@ -160,7 +160,7 @@ class ProfileViewController: UIViewController {
     @objc func plusWeekTapButton() {
         ProfileGraphCell.editWeek(edit: 1)
         profileCollectionView.reloadData()
-        ProfileGraphCollectionView.reloadData()
+        profileGraphCollectionView.reloadData()
         
         ProfileViewController.profileGraphCellHeaderMaker(label: profileGraphCellHeaderLabel, weekAdded: 1)
     }
@@ -168,7 +168,7 @@ class ProfileViewController: UIViewController {
     @objc func minusWeekTapButton() {
         ProfileGraphCell.editWeek(edit: -1)
         profileCollectionView.reloadData()
-        ProfileGraphCollectionView.reloadData()
+        profileGraphCollectionView.reloadData()
         
         ProfileViewController.profileGraphCellHeaderMaker(label: profileGraphCellHeaderLabel, weekAdded: -1)
     }
@@ -202,8 +202,8 @@ class ProfileViewController: UIViewController {
         view.addSubview(plusWeek)
         plusWeek.anchor(top: view.topAnchor, right: view.rightAnchor, paddingTop: 570, paddingRight: 45)
         
-        view.addSubview(ProfileGraphCollectionView)
-        ProfileGraphCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: 615, paddingLeft: 58, width: 345/390*view.frame.width, height: 154)
+        view.addSubview(profileGraphCollectionView)
+        profileGraphCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: 615, paddingLeft: 58, width: 345/390*view.frame.width, height: 154)
     }
     
 }

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -24,15 +24,6 @@ class ProfileViewController: UIViewController {
         return iv
     }()
     
-    private lazy var DummyGraphImage: UIImageView = { //FIXME: 더미 그래프 이미지임 로직 생성 필요
-        let iv = UIImageView()
-        iv.contentMode = .scaleAspectFill
-        iv.clipsToBounds = true
-        iv.isUserInteractionEnabled = true
-        iv.image = UIImage(named: "graph")
-        return iv
-    }()
-    
     private let plusWeek: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "chevron.right"), for: .normal)
@@ -212,7 +203,7 @@ class ProfileViewController: UIViewController {
         plusWeek.anchor(top: view.topAnchor, right: view.rightAnchor, paddingTop: 570, paddingRight: 45)
         
         view.addSubview(ProfileGraphCollectionView)
-        ProfileGraphCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: 615, paddingLeft: 58, width: 286, height: 154)
+        ProfileGraphCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: 615, paddingLeft: 58, width: 345/390*view.frame.width, height: 154)
     }
     
 }
@@ -308,11 +299,11 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize{
         if collectionView == profileCollectionView {
             if indexPath.section == 0 {
-                return CGSize(width: 358, height: 166)
+                return CGSize(width: profileCollectionView.frame.width, height: 166)
             } else if indexPath.section == 1 {
-                return CGSize(width: 358, height: 119)
+                return CGSize(width: profileCollectionView.frame.width, height: 119)
             } else {
-                return CGSize(width: 358, height: 190)
+                return CGSize(width: profileCollectionView.frame.width, height: 190)
             }
         }else {
             return CGSize(width: 27, height: 154)
@@ -332,7 +323,7 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
         if collectionView == profileCollectionView {
             return CGFloat(0)
         }else {
-            return CGFloat(15)
+            return CGFloat(profileCollectionView.frame.width - 55 - 27*7)/6
         }
     }
 }

--- a/BNomad/View/ProfileView/SelfUserInfoCell.swift
+++ b/BNomad/View/ProfileView/SelfUserInfoCell.swift
@@ -86,7 +86,7 @@ class SelfUserInfoCell: UICollectionViewCell {
     func render() {
 
         contentView.addSubview(nameLabel)
-        nameLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 25, paddingLeft: 20, paddingRight: 20)
+        nameLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 25, paddingLeft: 20)
         
         contentView.addSubview(editingButton)
         editingButton.anchor(top: contentView.topAnchor, right: contentView.rightAnchor, paddingTop: 18, paddingRight: 12, width: 55, height: 13)


### PR DESCRIPTION
## 관련 이슈들

## 작업 내용
- 프로필뷰와 캘린더뷰의 각 셀 오토레이아웃을 수정했습니다.
- 뷰는 패딩값으로 설정하여 폭을 일정하게 하고, 기존 하드코딩되어있던 각 셀과 내부 요소들의 레이아웃을 뷰에 맞춰 수정함

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img src="https://이미지링크를넣어주세요" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
