### PR TITLE
[Bug] iOS15 이하 버전 Annotation 노출 + 회원가입 텍스트필드 키보드return 구현

### DIFF
--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -456,4 +456,9 @@ extension SignUpViewController: UITextFieldDelegate {
         
         return true
     }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        didTapInputConfirmButton()
+        return true
+    }
 }


### PR DESCRIPTION
## 관련 이슈들
- #152 

## 작업 내용
- 비 로그인 상태에서도 위치 정보 허용 시 Region 초기화
- extension func MKAnnotationView로 변경 후 데이터 바인딩 수정
- 장소 annotation 이 아닌 클러스터 annotation 클릭 시 자동으로 해당 클러스터 중심으로 확대하여 장소 핀 볼 수 있도록 수정 (thanks to 성수)
- 회원가입 뷰에서 키보드의 return키 입력 시 자동으로 다음칸으로 넘어가게 (확인 버튼과 같은 기능)

## 리뷰 노트
- 위치정보 허용, 비허용, 한 번만 허용 케이스를 시뮬레이터로 시험해보니 생각 못했던 에러 메시지들이 많이 나왔습니다. 추후 테스트할 때 기기별로 나눠서 상세하게 봐야할 것 같아요.
- MKAnnotation 만 클릭하는 걸 iOS16 부터 새로 제공하는 이유를 상세하게 찾아봐야 할 것 같습니다. 아직은 숨은 의도를 모르겠네요.
- Will the Code Master 성수 도움으로 클러스터 핀 클릭할 때의 인터랙션이 굉장히 좋아졌습니다. Yo ma sunshiningsoo
- 회원가입 뷰.. 키보드로 쓰다가 위에 확인 버튼 누르는 것도 귀찮을 때 오른쪽 return 키를 누를 수도 있을 것 같아 한 줄만 추가했습니다. (저는 블투 키보드로 연결해서 앱들 쓸 때 return키 안 먹으면 불편했던 기억이 있어서 고쳤습니다 ㅋㅋ)

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012800/199431912-0fe1563d-120e-428b-8ebf-0839bcc6fd71.gif" width="300">



## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
