### PR TITLE
[Bug] '업무중' 버튼 실시간 반영, 클릭 가능하게 고침

### DIFF
--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import MapKit
 import CoreLocation
+import Combine
 
 class MapViewController: UIViewController {
     
@@ -183,10 +184,14 @@ class MapViewController: UIViewController {
         }
         controller.selectedPlace = tempPlace
         controller.modalPresentationStyle = .fullScreen
-        present(controller, animated: true)
+        self.dismiss(animated: true) {
+            self.present(controller, animated: true)
+        }
     }
     
     private var currentAnnotation: MKAnnotation?
+    
+    var store = Set<AnyCancellable>()
     
     // MARK: - LifeCycle
     
@@ -203,6 +208,7 @@ class MapViewController: UIViewController {
         navigationController?.navigationBar.isHidden = true
         locationFuncs()
         configueMapUI()
+        userSink()
     }
     
     // MARK: - Actions
@@ -291,6 +297,15 @@ class MapViewController: UIViewController {
         view.addSubview(checkInNow)
         checkInNow.anchor(top: view.topAnchor, paddingTop: 60, width: 100, height: 40)
         checkInNow.centerX(inView: view)
+    }
+    
+    func userSink() {
+        viewModel.$user
+            .sink { user in
+                guard let user = user else { return }
+                self.checkInNow.isHidden = user.isChecked ? false : true
+            }
+            .store(in: &store)
     }
 }
 

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -456,4 +456,9 @@ extension SignUpViewController: UITextFieldDelegate {
         
         return true
     }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        didTapInputConfirmButton()
+        return true
+    }
 }


### PR DESCRIPTION
## 관련 이슈들
- #152 
- #153 

## 작업 내용
- '업무중' 모달 클릭 가능
- '업무중' user상태로 실시간 반영

## 리뷰 노트
- '업무중' 모달이 안뜨는 이유가 이미 mapviewcontroller 위에 모달이 떠 있어서 안뜨는 것이었습니다
- '영업중'을 누르게 되면 바로 모달들이 dismiss된 이후에 리스트뷰가 올라오게 됩니다.

## 스크린샷(UX의 경우 gif)
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-03 at 09 39 37](https://user-images.githubusercontent.com/72736657/199627704-1a16fa89-3287-473e-8f2a-02fb2daa6ac1.gif)


## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
