### PR TITLE
[Feat] #161 CheckInListView header UI, 코드정리

### DIFF
--- a/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
@@ -169,7 +169,6 @@ class CheckInCardViewCell: UICollectionViewCell {
         userStack.spacing = 9
         userStack.alignment = .leading
         
-        
         let wholeStack = UIStackView(arrangedSubviews: [profileImageView, userStack])
         wholeStack.alignment = .leading
         wholeStack.axis = .horizontal
@@ -248,6 +247,7 @@ class CheckInCardViewCell: UICollectionViewCell {
     func configUI() {
         let spacer = UIView()
         let stack = UIStackView(arrangedSubviews: [userProfileStack, spendingTimeStack, timeBarStack, checkOutButton, spacer])
+        timeBarStack.anchor(top: spendingTimeStack.bottomAnchor, paddingTop: 15)
         spacer.anchor(height: 15)
         stack.axis = .vertical
         stack.distribution = .equalCentering

--- a/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
@@ -53,18 +53,16 @@ class CheckInCardViewCell: UICollectionViewCell {
         }
     }
     
-//    var delegate: pageDismiss?
+    var selectedPlaceTitle: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .headline, weight: .regular)
+        return label
+    }()
     
     private let cardRectangleView: UIView = {
         let view = UIView()
-        view.backgroundColor = .white
-        view.layer.cornerRadius = 12
-        view.layer.shadowRadius = 4
-        view.layer.shadowOpacity = 0.2
-        view.layer.shadowOffset = CGSize(width: 3, height: 4)
-        view.layer.shadowColor = CustomColor.nomadBlack?.cgColor
+        view.backgroundColor = CustomColor.nomadGray2
         view.layer.masksToBounds = false
-        
         return view
     }()
 
@@ -72,36 +70,30 @@ class CheckInCardViewCell: UICollectionViewCell {
         let view = UIImageView()
         view.image = UIImage(systemName: "person.circle.fill")
         view.tintColor = CustomColor.nomadGray2
-        
+        view.anchor(width: 80, height: 80)
         return view
     }()
     
     private lazy var userNameLabel: UILabel = {
         let label = UILabel()
-        label.text = "김노마"
         label.font = .preferredFont(forTextStyle: .title2, weight: .bold)
         label.textColor = CustomColor.nomadBlack
         label.numberOfLines = 1
-        
         return label
     }()
 
     private lazy var userOccupationLabel: UILabel = {
         let label = UILabel()
-        label.text = "iOS 개발자"
-        label.font = .preferredFont(forTextStyle: .footnote, weight: .semibold)
+        label.font = .preferredFont(forTextStyle: .subheadline, weight: .semibold)
         label.textColor = CustomColor.nomadGray1
-        
         return label
     }()
     
     private lazy var userStatusMessage: UILabel = {
         let label = UILabel()
-        label.text = "디자인을 좋아하는 개발자입니다."
         label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
         label.numberOfLines = 1
         label.textColor = CustomColor.nomadGray1
-        
         return label
     }()
     
@@ -110,7 +102,6 @@ class CheckInCardViewCell: UICollectionViewCell {
         label.text = "체크인"
         label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
         label.textColor = CustomColor.nomadBlack
-        
         return label
     }()
     
@@ -119,7 +110,6 @@ class CheckInCardViewCell: UICollectionViewCell {
         label.text = "이용시간"
         label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
         label.textColor = CustomColor.nomadBlack
-        
         return label
     }()
     
@@ -127,16 +117,13 @@ class CheckInCardViewCell: UICollectionViewCell {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .body, weight: .semibold)
         label.textColor = CustomColor.nomadBlack
-        
         return label
     }()
     
     private let userTimeSpentLabel: UILabel = {
         let label = UILabel()
-        label.text = "3시간 40분"
         label.font = .preferredFont(forTextStyle: .body, weight: .semibold)
         label.textColor = CustomColor.nomadBlack
-        
         return label
     }()
     
@@ -145,7 +132,6 @@ class CheckInCardViewCell: UICollectionViewCell {
         label.text = "9:00"
         label.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
         label.textColor = CustomColor.nomadGray1
-        
         return label
     }()
     
@@ -154,15 +140,13 @@ class CheckInCardViewCell: UICollectionViewCell {
         label.text = "22:00"
         label.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
         label.textColor = CustomColor.nomadGray1
-        
         return label
     }()
     
     private let timeBar: UIView = {
         let view = UIView()
-        view.backgroundColor = CustomColor.nomadGray2
+        view.backgroundColor = CustomColor.nomadGray1
         view.layer.cornerRadius = 4
-        
         return view
     }()
     
@@ -171,19 +155,72 @@ class CheckInCardViewCell: UICollectionViewCell {
         view.backgroundColor = CustomColor.nomadBlue
         view.tintColor = CustomColor.nomadBlue
         view.layer.cornerRadius = 4
-        
         return view
+    }()
+    
+    private lazy var userProfileStack: UIStackView = {
+        let userStatusStack = UIStackView(arrangedSubviews: [userNameLabel, userOccupationLabel])
+        userStatusStack.alignment = .leading
+        userStatusStack.axis = .vertical
+        userStatusStack.spacing = 2
+        
+        let userStack = UIStackView(arrangedSubviews: [UIView(), userStatusStack, userStatusMessage])
+        userStack.axis = .vertical
+        userStack.spacing = 9
+        userStack.alignment = .leading
+        
+        
+        let wholeStack = UIStackView(arrangedSubviews: [profileImageView, userStack])
+        wholeStack.alignment = .leading
+        wholeStack.axis = .horizontal
+        wholeStack.spacing = 12
+        
+        return wholeStack
+    }()
+    
+    private lazy var spendingTimeStack: UIStackView = {
+        let checkInStack = UIStackView(arrangedSubviews: [checkInLabel, checkInTimeLabel])
+        checkInStack.axis = .vertical
+        checkInStack.spacing = 3
+        checkInStack.alignment = .leading
+        
+        let timeSpentStack = UIStackView(arrangedSubviews: [timeSpentLabel, userTimeSpentLabel])
+        timeSpentStack.axis = .vertical
+        timeSpentStack.spacing = 3
+        timeSpentStack.alignment = .trailing
+        
+        let spacer = UIView()
+        let wholeStack = UIStackView(arrangedSubviews: [checkInStack, spacer, timeSpentStack])
+        spacer.anchor(left: checkInTimeLabel.rightAnchor, right: userTimeSpentLabel.leftAnchor)
+        wholeStack.axis = .horizontal
+        wholeStack.distribution = .fill
+        
+        return wholeStack
+    }()
+    
+    private lazy var timeBarStack: UIStackView = {
+        let spacer = UIView()
+        let timeStack = UIStackView(arrangedSubviews: [startTimeLabel, spacer, endTimeLabel])
+        spacer.anchor(left: startTimeLabel.rightAnchor, right: endTimeLabel.leftAnchor)
+        timeStack.axis = .horizontal
+        timeStack.distribution = .fill
+        
+        timeBar.addSubview(checkInTimeBar)
+        checkInTimeBar.anchor(top: timeBar.topAnchor, left: timeBar.leftAnchor, bottom: timeBar.bottomAnchor, right: timeBar.rightAnchor, paddingLeft: 30, paddingRight: 30)
+        timeBar.anchor(height: 10)
+        let wholeStack = UIStackView(arrangedSubviews: [timeStack, timeBar])
+        wholeStack.axis = .vertical
+        
+        return wholeStack
     }()
     
     private lazy var checkOutButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("체크아웃 하기", for: .normal)
         button.titleLabel?.font = .preferredFont(forTextStyle: .body, weight: .bold)
-        button.backgroundColor = .white
-        button.layer.borderColor = CustomColor.nomadBlue?.cgColor
-        button.layer.borderWidth = 1
+        button.backgroundColor = CustomColor.nomadBlue
         button.layer.cornerRadius = 8
-        button.tintColor = CustomColor.nomadBlue
+        button.tintColor = .white
         button.addTarget(self, action: #selector(checkOutTapped), for: .touchUpInside)
         return button
     }()
@@ -209,132 +246,19 @@ class CheckInCardViewCell: UICollectionViewCell {
     // MARK: - Methods
     
     func configUI() {
+        let spacer = UIView()
+        let stack = UIStackView(arrangedSubviews: [userProfileStack, spendingTimeStack, timeBarStack, checkOutButton, spacer])
+        spacer.anchor(height: 15)
+        stack.axis = .vertical
+        stack.distribution = .equalCentering
+        stack.spacing = 17
         
-        self.addSubview(cardRectangleView)
-        cardRectangleView.anchor(
-            top: self.topAnchor,
-            left: self.leftAnchor,
-            bottom: self.bottomAnchor,
-            right: self.rightAnchor,
-            paddingTop: 5,
-            paddingLeft: 20,
-            paddingBottom: 25,
-            paddingRight: 20,
-            height: 266
-        )
+        self.addSubview(stack)
+        stack.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 90, paddingLeft: 20, paddingRight: 20, height: 290)
+        checkOutButton.anchor(height: 50)
         
-        self.addSubview(profileImageView)
-        profileImageView.anchor(
-            top: cardRectangleView.topAnchor,
-            left: cardRectangleView.leftAnchor,
-            paddingTop: 20,
-            paddingLeft: 17,
-            width: 64,
-            height: 64
-        )
-        
-        self.addSubview(userNameLabel)
-        userNameLabel.anchor(
-            top: cardRectangleView.topAnchor,
-            left: profileImageView.rightAnchor,
-            paddingTop: 28,
-            paddingLeft: 18,
-            width: 150
-            
-        )
-        
-        self.addSubview(userOccupationLabel)
-        userOccupationLabel.anchor(
-            left: userNameLabel.rightAnchor,
-            bottom: userNameLabel.bottomAnchor,
-            right: cardRectangleView.rightAnchor,
-            paddingLeft: 20,
-            paddingRight: 20
-        )
-        
-        self.addSubview(userStatusMessage)
-        userStatusMessage.anchor(
-            top: userNameLabel.bottomAnchor,
-            left: userNameLabel.leftAnchor,
-            right: self.rightAnchor,
-            paddingTop: 6,
-            paddingRight: 20
-        )
-        
-        self.addSubview(checkInLabel)
-        checkInLabel.anchor(
-            top: profileImageView.bottomAnchor,
-            left: cardRectangleView.leftAnchor,
-            paddingTop: 18,
-            paddingLeft: 22
-        )
-        
-        self.addSubview(timeSpentLabel)
-        timeSpentLabel.anchor(
-            top: checkInLabel.topAnchor,
-            left: cardRectangleView.leftAnchor,
-            paddingLeft: 197)
-        
-        self.addSubview(checkInTimeLabel)
-        checkInTimeLabel.anchor(
-            top: checkInLabel.bottomAnchor,
-            left: checkInLabel.leftAnchor,
-            paddingTop: 4
-        )
-        
-        self.addSubview(userTimeSpentLabel)
-        userTimeSpentLabel.anchor(
-            top: checkInTimeLabel.topAnchor,
-            left: timeSpentLabel.leftAnchor
-        )
-        
-        self.addSubview(startTimeLabel)
-        startTimeLabel.anchor(
-            top: checkInTimeLabel.bottomAnchor,
-            left: checkInLabel.leftAnchor,
-            paddingTop: 18,
-            width: 100
-        )
-        
-        self.addSubview(endTimeLabel)
-        endTimeLabel.anchor(
-            top: userTimeSpentLabel.bottomAnchor,
-            right: cardRectangleView.rightAnchor,
-            paddingTop: 18,
-            paddingRight: 22
-        )
-        
-        self.addSubview(timeBar)
-        timeBar.anchor(
-            top: startTimeLabel.bottomAnchor,
-            left: cardRectangleView.leftAnchor,
-            right: cardRectangleView.rightAnchor,
-            paddingTop: 4,
-            paddingLeft: 22,
-            paddingRight: 22,
-            height: 8
-        )
-        
-        self.addSubview(checkInTimeBar)
-        checkInTimeBar.anchor(
-            top: timeBar.topAnchor,
-            left: timeBar.leftAnchor,
-            bottom: timeBar.bottomAnchor,
-            right: timeBar.rightAnchor,
-            paddingLeft: 30,
-            paddingRight: 100
-        )
-        
-        self.addSubview(checkOutButton)
-        checkOutButton.anchor(
-            top: timeBar.bottomAnchor,
-            left: cardRectangleView.leftAnchor,
-            bottom: cardRectangleView.bottomAnchor,
-            right: cardRectangleView.rightAnchor,
-            paddingTop: 13,
-            paddingLeft: 22,
-            paddingBottom: 16,
-            paddingRight: 22
-        )
+        self.addSubview(selectedPlaceTitle)
+        selectedPlaceTitle.anchor(bottom: stack.topAnchor, paddingBottom: 7)
+        selectedPlaceTitle.centerX(inView: self)
     }
 }

--- a/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
@@ -11,7 +11,6 @@ class CheckedProfileListViewCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-    // var user: User
     var userUid: String? {
         didSet {
             guard let userUid = userUid else { return }

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -80,10 +80,11 @@ class PlaceCheckInViewController: UIViewController {
     func placeCheckInView() {
 
         view.addSubview(placeTitleLabel)
-        placeTitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-        placeTitleLabel.anchor(top: view.topAnchor, paddingTop: 51)
+        placeTitleLabel.centerX(inView: view)
+        placeTitleLabel.anchor(top: view.topAnchor, paddingTop: 58)
         
         view.addSubview(collectionView)
+        collectionView.contentInsetAdjustmentBehavior = .never
         self.collectionView.dataSource = self
         self.collectionView.delegate = self
         self.collectionView.register(CheckedProfileListViewCell.self, forCellWithReuseIdentifier: CheckedProfileListViewCell.identifier)
@@ -91,7 +92,7 @@ class PlaceCheckInViewController: UIViewController {
         self.collectionView.register(PlaceInfoViewCell.self, forCellWithReuseIdentifier: PlaceInfoViewCell.identifier)
         self.collectionView.register(CheckedProfileListHeader.self, forCellWithReuseIdentifier: CheckedProfileListHeader.identifier)
         
-        collectionView.anchor(top: placeTitleLabel.bottomAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingTop: 15, paddingLeft: 0, paddingBottom: 0, paddingRight: 0)
+        collectionView.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
     }
     
     func configureCancelButton() {
@@ -117,7 +118,7 @@ extension PlaceCheckInViewController: UICollectionViewDataSource {
             checkInCardViewCell.checkOutDelegate = self
             checkInCardViewCell.user = viewModel.user
             checkInCardViewCell.checkIn = viewModel.user?.currentCheckIn
-            
+            checkInCardViewCell.selectedPlaceTitle.text = selectedPlace?.name
             return checkInCardViewCell
         }
         else if indexPath.section == 1 {
@@ -167,8 +168,7 @@ extension PlaceCheckInViewController: UICollectionViewDelegateFlowLayout {
         let sectionZeroHeight = sectionZeroCardHeight + sectionZeroBottomPadding
         
         if indexPath.section == 0 {
-            print(sectionZeroHeight)
-            return CGSize(width: viewWidth, height: sectionZeroHeight)
+            return CGSize(width: viewWidth, height: 390)
         } else if indexPath.section == 1 {
             return CGSize(width: viewWidth, height: 220)
         } else if indexPath.section == 2 {
@@ -181,6 +181,7 @@ extension PlaceCheckInViewController: UICollectionViewDelegateFlowLayout {
             return CGSize(width: viewWidth, height: 0)
         }
     }
+    
 }
 
 // MARK: - pageDismiss


### PR DESCRIPTION
## 관련 이슈들
- #161 

## 작업 내용
- 코드정리와 함께, CheckInListView의 header UI 작업을 했습니다.
- compositional layout으로 변경하지 않고, 기존의 틀을 가져가기로 했습니다. 이유로는 짧은 기간에 방대한 작업량이 우려되었음...

## 리뷰 노트
- 백그라운드의 색상이 아직 적용되지 않았는데, 추후에 CustomColor extension에 값 들어오면 고치려 합니다.
- 상단에서부터, 체크아웃하기 버튼이 있는 곳까지의 UI 작업을 했습니다. 하단은 아직 작업되지 않았습니다.
- 체크인 시간부터 현재 일한 시간만큼의 가로 그래프가 차는데에, 생각해볼 로직이 더 많아 보입니다. (그런데 지금 꼭 해야하는지는 또 미지수,,ㅋㅋ)
   - 체크인 가능시간 체크하는 로직이 추가되어야 함
   - 체크아웃 시간이 지났을때 자동 체크아웃이 되어야하는 로직
   - 장소 데이터에 영업시간이 들어가야함 등등,,,

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/72736657/200443558-270d8b80-ae83-4dc7-bb52-2aeb19adec93.png" width="300">

## Reference
- stackView사용 https://hyunndyblog.tistory.com/148

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
