### PR TITLE
[Feat] #166 NewMeetUpView UI 작업 완료

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		6383330C2900CD6D005AB0C3 /* PlaceInfoModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383330B2900CD6D005AB0C3 /* PlaceInfoModalViewController.swift */; };
 		6383330E2900CDBA005AB0C3 /* PlaceInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383330D2900CDBA005AB0C3 /* PlaceInfoCell.swift */; };
 		7E5CF5D42906886A00641E74 /* CheckInCardViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5CF5D32906886A00641E74 /* CheckInCardViewCell.swift */; };
+		7E97254E2919160800AA9F44 /* NewMeetUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E97254D2919160800AA9F44 /* NewMeetUpViewController.swift */; };
 		7EC6F9EE28FE39CB003D8A95 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6F9ED28FE39CB003D8A95 /* UIFont+Extension.swift */; };
 		7EC6F9F028FE39F4003D8A95 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6F9EF28FE39F4003D8A95 /* UIColor+Extension.swift */; };
 		7EC6F9F228FE3A19003D8A95 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6F9F128FE3A19003D8A95 /* UILabel+Extension.swift */; };
@@ -83,6 +84,7 @@
 		6383330D2900CDBA005AB0C3 /* PlaceInfoCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceInfoCell.swift; sourceTree = "<group>"; };
 		7E5CF5D228FFB73400641E74 /* BNomad.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BNomad.entitlements; sourceTree = "<group>"; };
 		7E5CF5D32906886A00641E74 /* CheckInCardViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInCardViewCell.swift; sourceTree = "<group>"; };
+		7E97254D2919160800AA9F44 /* NewMeetUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMeetUpViewController.swift; sourceTree = "<group>"; };
 		7EC6F9ED28FE39CB003D8A95 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		7EC6F9EF28FE39F4003D8A95 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		7EC6F9F128FE3A19003D8A95 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
@@ -285,6 +287,7 @@
 			isa = PBXGroup;
 			children = (
 				DF561CA42918A0B40099D41D /* MeetUpViewController.swift */,
+				7E97254D2919160800AA9F44 /* NewMeetUpViewController.swift */,
 			);
 			path = MeetUpView;
 			sourceTree = "<group>";
@@ -456,6 +459,7 @@
 				041351A728FFF459005D19CC /* CalendarViewController.swift in Sources */,
 				E2E6B23228FE757D005C0D77 /* Date+Extension.swift in Sources */,
 				E2E6B23428FE75F7005C0D77 /* String+Extension.swift in Sources */,
+				7E97254E2919160800AA9F44 /* NewMeetUpViewController.swift in Sources */,
 				DF9618AE28FCEFC200E21D30 /* SignUpViewController.swift in Sources */,
 				DF288B4F28F7D70F002838A4 /* AppDelegate.swift in Sources */,
 				8C21CC4128FF8018009043AF /* PlaceAnnotation.swift in Sources */,

--- a/BNomad/Application/SceneDelegate.swift
+++ b/BNomad/Application/SceneDelegate.swift
@@ -28,13 +28,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     FirebaseManager.shared.fetchCheckInHistory(userUid: deviceUid) { checkInHistory in
                         self.viewModel.user?.checkInHistory = checkInHistory
                         print("checkIn 유무", self.viewModel.user?.isChecked)
-                        self.window?.rootViewController = UINavigationController(rootViewController: MapViewController())
+                        self.window?.rootViewController = UINavigationController(rootViewController: NewMeetUpViewController())
                         self.window?.makeKeyAndVisible()
                     }
                 }
             } else {
                 print("no user")
-                self.window?.rootViewController = UINavigationController(rootViewController: MapViewController())
+                self.window?.rootViewController = UINavigationController(rootViewController: NewMeetUpViewController())
                 self.window?.makeKeyAndVisible()
             }
         }

--- a/BNomad/Application/SceneDelegate.swift
+++ b/BNomad/Application/SceneDelegate.swift
@@ -28,13 +28,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     FirebaseManager.shared.fetchCheckInHistory(userUid: deviceUid) { checkInHistory in
                         self.viewModel.user?.checkInHistory = checkInHistory
                         print("checkIn 유무", self.viewModel.user?.isChecked)
-                        self.window?.rootViewController = UINavigationController(rootViewController: NewMeetUpViewController())
+                        self.window?.rootViewController = UINavigationController(rootViewController: MapViewController())
                         self.window?.makeKeyAndVisible()
                     }
                 }
             } else {
                 print("no user")
-                self.window?.rootViewController = UINavigationController(rootViewController: NewMeetUpViewController())
+                self.window?.rootViewController = UINavigationController(rootViewController: MapViewController())
                 self.window?.makeKeyAndVisible()
             }
         }

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -14,6 +14,9 @@ class NewMeetUpViewController: UIViewController {
     private let subjectLimit = 15
     private let locationLimit = 15
     
+    private let minimumPeople = 2
+    private var counter = 2
+    
     private let subject: UILabel = {
         let label = UILabel()
         label.text = "제목"
@@ -98,6 +101,13 @@ class NewMeetUpViewController: UIViewController {
         textField.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         textField.borderStyle = .none
         
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        formatter.dateFormat = "HH:mm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        textField.text = formatter.string(from: Date())
+        
         return textField
     }()
     
@@ -154,11 +164,21 @@ class NewMeetUpViewController: UIViewController {
         return view
     }()
     
+    private lazy var peopleCounterLabel: UILabel = {
+        let label = UILabel()
+        label.text = "\(counter)"
+        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        label.textColor = CustomColor.nomadBlack
+        
+        return label
+    }()
+    
     private let plusButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "plus"), for: .normal)
         button.tintColor = CustomColor.nomadBlack
         button.backgroundColor = .white
+        button.addTarget(self, action: #selector(didTapPlusButton), for: .touchUpInside)
         
         return button
     }()
@@ -176,6 +196,7 @@ class NewMeetUpViewController: UIViewController {
         button.setImage(UIImage(systemName: "minus"), for: .normal)
         button.tintColor = CustomColor.nomadBlack
         button.backgroundColor = .white
+        button.addTarget(self, action: #selector(didTapMinusButton), for: .touchUpInside)
         
         return button
     }()
@@ -261,6 +282,18 @@ class NewMeetUpViewController: UIViewController {
     
     @objc func didTapDoneTimePicker() {
         timeField.resignFirstResponder()
+    }
+    
+    @objc func didTapPlusButton() {
+        counter = counter + 1
+        peopleCounterLabel.text = "\(counter)"
+    }
+    
+    @objc func didTapMinusButton() {
+        if counter > minimumPeople {
+            counter = counter - 1
+            peopleCounterLabel.text = "\(counter)"
+        }
     }
     
     @objc func didTapDoneCreatingMeetUp() {
@@ -368,6 +401,9 @@ class NewMeetUpViewController: UIViewController {
             width: halfRectWidth,
             height: 48
         )
+        
+        peopleRectangle.addSubview(peopleCounterLabel)
+        peopleCounterLabel.center(inView: peopleRectangle)
         
         view.addSubview(peopleCounterView)
         peopleCounterView.anchor(

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -28,6 +28,16 @@ class NewMeetUpViewController: UIViewController {
         return view
     }()
     
+    private let subjectField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "모임 제목을 입력하세요."
+        textField.font = .preferredFont(forTextStyle: .body)
+        textField.borderStyle = .none
+        textField.clearButtonMode = .whileEditing
+        
+        return textField
+    }()
+    
     private let time: UILabel = {
         let label = UILabel()
         label.text = "모임 시간"
@@ -45,6 +55,39 @@ class NewMeetUpViewController: UIViewController {
         return view
     }()
     
+    private let timePicker: UIDatePicker = {
+        let picker = UIDatePicker()
+        picker.datePickerMode = .time
+        picker.preferredDatePickerStyle = .wheels
+        picker.frame.size = CGSize(width: 0, height: 250)
+        picker.locale = Locale(identifier: "ko_KR")
+        picker.addTarget(self, action: #selector(didTimePickerValueChange), for: .valueChanged)
+        
+        return picker
+    }()
+    
+    private let timePickerToolBar: UIToolbar = {
+        let toolBar = UIToolbar()
+        let cancelButton = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(didTapCancelTimePicker))
+        let doneButton = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(didTapDoneTimePicker))
+        let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        cancelButton.tintColor = CustomColor.nomadBlue
+        doneButton.tintColor = CustomColor.nomadBlue
+        
+        toolBar.sizeToFit()
+        toolBar.setItems([cancelButton, space, doneButton], animated: false)
+        
+        return toolBar
+    }()
+    
+    private let timeField: UITextField = {
+        let textField = UITextField()
+        textField.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        textField.borderStyle = .none
+        
+        return textField
+    }()
+    
     private let location: UILabel = {
         let label = UILabel()
         label.text = "모임 장소"
@@ -60,6 +103,16 @@ class NewMeetUpViewController: UIViewController {
         view.layer.cornerRadius = 12
         
         return view
+    }()
+    
+    private let locationField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "모임 장소를 입력하세요."
+        textField.font = .preferredFont(forTextStyle: .body)
+        textField.borderStyle = .none
+        textField.clearButtonMode = .whileEditing
+        
+        return textField
     }()
     
     private let people: UILabel = {
@@ -155,6 +208,23 @@ class NewMeetUpViewController: UIViewController {
     
     // MARK: - Actions
     
+    @objc func didTimePickerValueChange() {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        formatter.dateFormat = "HH:mm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        self.timeField.text = formatter.string(from: timePicker.date)
+    }
+    
+    @objc func didTapCancelTimePicker() {
+        timeField.resignFirstResponder()
+    }
+    
+    @objc func didTapDoneTimePicker() {
+        timeField.resignFirstResponder()
+    }
+    
     @objc func didTapDoneCreatingMeetUp() {
         // TODO: 내용 저장
     }
@@ -178,17 +248,30 @@ class NewMeetUpViewController: UIViewController {
         view.addSubview(subjectRectangle)
         subjectRectangle.anchor(top: subject.bottomAnchor, left: subject.leftAnchor, right: view.rightAnchor, paddingTop: 8, paddingRight: 20, height: 48)
         
+        subjectRectangle.addSubview(subjectField)
+        subjectField.centerY(inView: subjectRectangle)
+        subjectField.anchor(left: subjectRectangle.leftAnchor, right: subjectRectangle.rightAnchor, paddingLeft: 20, paddingRight: 10)
+        
         view.addSubview(time)
         time.anchor(top: subjectRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
         
         view.addSubview(timeRectangle)
         timeRectangle.anchor(top: time.bottomAnchor, left: subject.leftAnchor, right: subjectRectangle.rightAnchor, paddingTop: 8, height: 48)
         
+        timeRectangle.addSubview(timeField)
+        timeField.center(inView: timeRectangle)
+        timeField.inputView = timePicker
+        timeField.inputAccessoryView = timePickerToolBar
+        
         view.addSubview(location)
         location.anchor(top: timeRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
         
         view.addSubview(locationRectangle)
         locationRectangle.anchor(top: location.bottomAnchor, left: subject.leftAnchor, right: subjectRectangle.rightAnchor, paddingTop: 8, height: 48)
+        
+        locationRectangle.addSubview(locationField)
+        locationField.centerY(inView: locationRectangle)
+        locationField.anchor(left: subjectRectangle.leftAnchor, right: subjectRectangle.rightAnchor, paddingLeft: 20, paddingRight: 10)
         
         view.addSubview(people)
         people.anchor(top: locationRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -193,6 +193,17 @@ class NewMeetUpViewController: UIViewController {
         return view
     }()
     
+    private lazy var contentField: UITextView = {
+        let textView = UITextView()
+        textView.text = "내용을 입력하세요."
+        textView.textColor = .tertiaryLabel
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.backgroundColor = .clear
+        textView.delegate = self
+        
+        return textView
+    }()
+    
     // MARK: - LifeCycle
 
     override func viewDidLoad() {
@@ -291,5 +302,26 @@ class NewMeetUpViewController: UIViewController {
         view.addSubview(contentRectangle)
         contentRectangle.anchor(top: content.bottomAnchor, left: subject.leftAnchor, right: subjectRectangle.rightAnchor, paddingTop: 8, height: 120)
         
+        contentRectangle.addSubview(contentField)
+        contentField.anchor(top: contentRectangle.topAnchor, left: contentRectangle.leftAnchor, bottom: contentRectangle.bottomAnchor, right: contentRectangle.rightAnchor, paddingTop: 13, paddingLeft: 20, paddingBottom: 15, paddingRight: 20)
+
+    }
+}
+
+// MARK: - UITextViewDelegate
+
+extension NewMeetUpViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .tertiaryLabel {
+            textView.text = nil
+            textView.textColor = CustomColor.nomadBlack
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = "내용을 입력하세요."
+            textView.textColor = .tertiaryLabel
+        }
     }
 }

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -11,6 +11,11 @@ class NewMeetUpViewController: UIViewController {
 
     // MARK: - Properties
     
+    private enum Value {
+        static let cornerRadius: CGFloat = 12.0
+        static let paddingLeftRight: CGFloat = 20.0
+    }
+    
     private let subjectLimit = 15
     private let locationLimit = 15
     
@@ -29,7 +34,7 @@ class NewMeetUpViewController: UIViewController {
     private let subjectRectangle: UIView = {
         let view = UIView()
         view.backgroundColor = CustomColor.nomadGray3
-        view.layer.cornerRadius = 12
+        view.layer.cornerRadius = Value.cornerRadius
         
         return view
     }()
@@ -65,7 +70,7 @@ class NewMeetUpViewController: UIViewController {
     private let timeRectangle: UIView = {
         let view = UIView()
         view.backgroundColor = CustomColor.nomadGray3
-        view.layer.cornerRadius = 12
+        view.layer.cornerRadius = Value.cornerRadius
         
         return view
     }()
@@ -124,7 +129,7 @@ class NewMeetUpViewController: UIViewController {
     private let locationRectangle: UIView = {
         let view = UIView()
         view.backgroundColor = CustomColor.nomadGray3
-        view.layer.cornerRadius = 12
+        view.layer.cornerRadius = Value.cornerRadius
         
         return view
     }()
@@ -160,7 +165,7 @@ class NewMeetUpViewController: UIViewController {
     private let peopleRectangle: UIView = {
         let view = UIView()
         view.backgroundColor = CustomColor.nomadGray3
-        view.layer.cornerRadius = 12
+        view.layer.cornerRadius = Value.cornerRadius
         
         return view
     }()
@@ -202,14 +207,14 @@ class NewMeetUpViewController: UIViewController {
         return button
     }()
     
-    lazy var peopleCounterView: UIStackView = {
+    private lazy var peopleCounterView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [plusButton, divider, minusButton])
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = 1
         stackView.distribution = .fillProportionally
         stackView.backgroundColor = .white
-        stackView.layer.cornerRadius = 12
+        stackView.layer.cornerRadius = Value.cornerRadius
         stackView.layer.borderWidth = 1
         stackView.layer.borderColor = CustomColor.nomadGray2?.cgColor
         stackView.layer.shadowRadius = 5
@@ -232,7 +237,7 @@ class NewMeetUpViewController: UIViewController {
     private let contentRectangle: UIView = {
         let view = UIView()
         view.backgroundColor = CustomColor.nomadGray3
-        view.layer.cornerRadius = 12
+        view.layer.cornerRadius = Value.cornerRadius
         
         return view
     }()
@@ -315,7 +320,7 @@ class NewMeetUpViewController: UIViewController {
         let paddingTop = viewHeight * 100/844
         
         view.addSubview(subject)
-        subject.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: paddingTop, paddingLeft: 20)
+        subject.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: paddingTop, paddingLeft: Value.paddingLeftRight)
         
         view.addSubview(subjectRectangle)
         subjectRectangle.anchor(
@@ -323,7 +328,7 @@ class NewMeetUpViewController: UIViewController {
             left: subject.leftAnchor,
             right: view.rightAnchor,
             paddingTop: 8,
-            paddingRight: 20,
+            paddingRight: Value.paddingLeftRight,
             height: 48
         )
         
@@ -332,7 +337,7 @@ class NewMeetUpViewController: UIViewController {
         subjectField.anchor(
             left: subjectRectangle.leftAnchor,
             right: subjectRectangle.rightAnchor,
-            paddingLeft: 20,
+            paddingLeft: Value.paddingLeftRight,
             paddingRight: 10
         )
         
@@ -377,7 +382,7 @@ class NewMeetUpViewController: UIViewController {
         locationField.anchor(
             left: subjectRectangle.leftAnchor,
             right: subjectRectangle.rightAnchor,
-            paddingLeft: 20,
+            paddingLeft: Value.paddingLeftRight,
             paddingRight: 10
         )
         
@@ -392,7 +397,7 @@ class NewMeetUpViewController: UIViewController {
         people.anchor(top: locationRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
         
         let viewWidth = view.bounds.width
-        let halfRectWidth = (viewWidth - 20*2 - 10*2)/2
+        let halfRectWidth = (viewWidth - Value.paddingLeftRight*2 - 10*2)/2
         
         view.addSubview(peopleRectangle)
         peopleRectangle.anchor(
@@ -410,7 +415,7 @@ class NewMeetUpViewController: UIViewController {
         peopleCounterView.anchor(
             top: peopleRectangle.topAnchor,
             right: view.rightAnchor,
-            paddingRight: 20,
+            paddingRight: Value.paddingLeftRight,
             width: halfRectWidth,
             height: 48
         )
@@ -434,9 +439,9 @@ class NewMeetUpViewController: UIViewController {
             bottom: contentRectangle.bottomAnchor,
             right: contentRectangle.rightAnchor,
             paddingTop: 13,
-            paddingLeft: 20,
+            paddingLeft: Value.paddingLeftRight,
             paddingBottom: 15,
-            paddingRight: 20
+            paddingRight: Value.paddingLeftRight
         )
 
     }

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -11,6 +11,9 @@ class NewMeetUpViewController: UIViewController {
 
     // MARK: - Properties
     
+    private let subjectLimit = 15
+    private let locationLimit = 15
+    
     private let subject: UILabel = {
         let label = UILabel()
         label.text = "제목"
@@ -28,7 +31,7 @@ class NewMeetUpViewController: UIViewController {
         return view
     }()
     
-    private let subjectField: UITextField = {
+    private var subjectField: UITextField = {
         let textField = UITextField()
         textField.placeholder = "모임 제목을 입력하세요."
         textField.font = .preferredFont(forTextStyle: .body)
@@ -36,6 +39,15 @@ class NewMeetUpViewController: UIViewController {
         textField.clearButtonMode = .whileEditing
         
         return textField
+    }()
+    
+    private lazy var subjectCounterLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .caption2)
+        label.text = "0 / \(subjectLimit)"
+        label.textColor = CustomColor.nomadGray1
+        
+        return label
     }()
     
     private let time: UILabel = {
@@ -59,6 +71,7 @@ class NewMeetUpViewController: UIViewController {
         let picker = UIDatePicker()
         picker.datePickerMode = .time
         picker.preferredDatePickerStyle = .wheels
+        picker.minuteInterval = 10
         picker.frame.size = CGSize(width: 0, height: 250)
         picker.locale = Locale(identifier: "ko_KR")
         picker.addTarget(self, action: #selector(didTimePickerValueChange), for: .valueChanged)
@@ -80,7 +93,7 @@ class NewMeetUpViewController: UIViewController {
         return toolBar
     }()
     
-    private let timeField: UITextField = {
+    private var timeField: UITextField = {
         let textField = UITextField()
         textField.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         textField.borderStyle = .none
@@ -105,7 +118,7 @@ class NewMeetUpViewController: UIViewController {
         return view
     }()
     
-    private let locationField: UITextField = {
+    private var locationField: UITextField = {
         let textField = UITextField()
         textField.placeholder = "모임 장소를 입력하세요."
         textField.font = .preferredFont(forTextStyle: .body)
@@ -113,6 +126,15 @@ class NewMeetUpViewController: UIViewController {
         textField.clearButtonMode = .whileEditing
         
         return textField
+    }()
+    
+    private lazy var locationCounterLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .caption2)
+        label.text = "0 / \(locationLimit)"
+        label.textColor = CustomColor.nomadGray1
+        
+        return label
     }()
     
     private let people: UILabel = {
@@ -215,6 +237,11 @@ class NewMeetUpViewController: UIViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(didTapDoneCreatingMeetUp))
                  navigationController?.navigationBar.tintColor = CustomColor.nomadBlue
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(didTapCancelCreatingMeetUp))
+        
+        subjectField.delegate = self
+        locationField.delegate = self
+        
+        hideKeyboardWhenTappedAround()
     }
     
     // MARK: - Actions
@@ -257,17 +284,42 @@ class NewMeetUpViewController: UIViewController {
         subject.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: paddingTop, paddingLeft: 20)
         
         view.addSubview(subjectRectangle)
-        subjectRectangle.anchor(top: subject.bottomAnchor, left: subject.leftAnchor, right: view.rightAnchor, paddingTop: 8, paddingRight: 20, height: 48)
+        subjectRectangle.anchor(
+            top: subject.bottomAnchor,
+            left: subject.leftAnchor,
+            right: view.rightAnchor,
+            paddingTop: 8,
+            paddingRight: 20,
+            height: 48
+        )
         
         subjectRectangle.addSubview(subjectField)
         subjectField.centerY(inView: subjectRectangle)
-        subjectField.anchor(left: subjectRectangle.leftAnchor, right: subjectRectangle.rightAnchor, paddingLeft: 20, paddingRight: 10)
+        subjectField.anchor(
+            left: subjectRectangle.leftAnchor,
+            right: subjectRectangle.rightAnchor,
+            paddingLeft: 20,
+            paddingRight: 10
+        )
+        
+        view.addSubview(subjectCounterLabel)
+        subjectCounterLabel.anchor(
+            top: subjectRectangle.bottomAnchor,
+            right: subjectRectangle.rightAnchor,
+            paddingTop: 4
+        )
         
         view.addSubview(time)
         time.anchor(top: subjectRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
         
         view.addSubview(timeRectangle)
-        timeRectangle.anchor(top: time.bottomAnchor, left: subject.leftAnchor, right: subjectRectangle.rightAnchor, paddingTop: 8, height: 48)
+        timeRectangle.anchor(
+            top: time.bottomAnchor,
+            left: subject.leftAnchor,
+            right: subjectRectangle.rightAnchor,
+            paddingTop: 8,
+            height: 48
+        )
         
         timeRectangle.addSubview(timeField)
         timeField.center(inView: timeRectangle)
@@ -278,11 +330,29 @@ class NewMeetUpViewController: UIViewController {
         location.anchor(top: timeRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
         
         view.addSubview(locationRectangle)
-        locationRectangle.anchor(top: location.bottomAnchor, left: subject.leftAnchor, right: subjectRectangle.rightAnchor, paddingTop: 8, height: 48)
+        locationRectangle.anchor(
+            top: location.bottomAnchor,
+            left: subject.leftAnchor,
+            right: subjectRectangle.rightAnchor,
+            paddingTop: 8,
+            height: 48
+        )
         
         locationRectangle.addSubview(locationField)
         locationField.centerY(inView: locationRectangle)
-        locationField.anchor(left: subjectRectangle.leftAnchor, right: subjectRectangle.rightAnchor, paddingLeft: 20, paddingRight: 10)
+        locationField.anchor(
+            left: subjectRectangle.leftAnchor,
+            right: subjectRectangle.rightAnchor,
+            paddingLeft: 20,
+            paddingRight: 10
+        )
+        
+        view.addSubview(locationCounterLabel)
+        locationCounterLabel.anchor(
+            top: locationRectangle.bottomAnchor,
+            right: locationRectangle.rightAnchor,
+            paddingTop: 4
+        )
         
         view.addSubview(people)
         people.anchor(top: locationRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
@@ -291,21 +361,69 @@ class NewMeetUpViewController: UIViewController {
         let halfRectWidth = (viewWidth - 20*2 - 10*2)/2
         
         view.addSubview(peopleRectangle)
-        peopleRectangle.anchor(top: people.bottomAnchor, left: subject.leftAnchor, paddingTop: 8, width: halfRectWidth, height: 48)
+        peopleRectangle.anchor(
+            top: people.bottomAnchor,
+            left: subject.leftAnchor,
+            paddingTop: 8,
+            width: halfRectWidth,
+            height: 48
+        )
         
         view.addSubview(peopleCounterView)
-        peopleCounterView.anchor(top: peopleRectangle.topAnchor, right: view.rightAnchor, paddingRight: 20, width: halfRectWidth, height: 48)
+        peopleCounterView.anchor(
+            top: peopleRectangle.topAnchor,
+            right: view.rightAnchor,
+            paddingRight: 20,
+            width: halfRectWidth,
+            height: 48
+        )
         
         view.addSubview(content)
         content.anchor(top: peopleRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
         
         view.addSubview(contentRectangle)
-        contentRectangle.anchor(top: content.bottomAnchor, left: subject.leftAnchor, right: subjectRectangle.rightAnchor, paddingTop: 8, height: 120)
+        contentRectangle.anchor(
+            top: content.bottomAnchor,
+            left: subject.leftAnchor,
+            right: subjectRectangle.rightAnchor,
+            paddingTop: 8,
+            height: 120
+        )
         
         contentRectangle.addSubview(contentField)
-        contentField.anchor(top: contentRectangle.topAnchor, left: contentRectangle.leftAnchor, bottom: contentRectangle.bottomAnchor, right: contentRectangle.rightAnchor, paddingTop: 13, paddingLeft: 20, paddingBottom: 15, paddingRight: 20)
+        contentField.anchor(
+            top: contentRectangle.topAnchor,
+            left: contentRectangle.leftAnchor,
+            bottom: contentRectangle.bottomAnchor,
+            right: contentRectangle.rightAnchor,
+            paddingTop: 13,
+            paddingLeft: 20,
+            paddingBottom: 15,
+            paddingRight: 20
+        )
 
     }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension NewMeetUpViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let currentText = textField.text ?? ""
+        guard let stringRange = Range(range, in: currentText) else { return false }
+        let updateText = currentText.replacingCharacters(in: stringRange, with: string)
+        if textField == subjectField {
+            subjectCounterLabel.text = "\(updateText.count) / \(subjectLimit)"
+            return updateText.count < subjectLimit
+        } else if textField == locationField {
+            locationCounterLabel.text = "\(updateText.count) / \(locationLimit)"
+            return updateText.count < locationLimit
+        }
+        
+        return true
+    }
+    
+    
 }
 
 // MARK: - UITextViewDelegate

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -1,0 +1,212 @@
+//
+//  NewMeetUpViewController.swift
+//  BNomad
+//
+//  Created by Eunbee Kang on 2022/11/07.
+//
+
+import UIKit
+
+class NewMeetUpViewController: UIViewController {
+
+    // MARK: - Properties
+    
+    private let subject: UILabel = {
+        let label = UILabel()
+        label.text = "제목"
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = CustomColor.nomadBlack
+        
+        return label
+    }()
+    
+    private let subjectRectangle: UIView = {
+        let view = UIView()
+        view.backgroundColor = CustomColor.nomadGray3
+        view.layer.cornerRadius = 12
+        
+        return view
+    }()
+    
+    private let time: UILabel = {
+        let label = UILabel()
+        label.text = "모임 시간"
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = CustomColor.nomadBlack
+        
+        return label
+    }()
+    
+    private let timeRectangle: UIView = {
+        let view = UIView()
+        view.backgroundColor = CustomColor.nomadGray3
+        view.layer.cornerRadius = 12
+        
+        return view
+    }()
+    
+    private let location: UILabel = {
+        let label = UILabel()
+        label.text = "모임 장소"
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = CustomColor.nomadBlack
+        
+        return label
+    }()
+    
+    private let locationRectangle: UIView = {
+        let view = UIView()
+        view.backgroundColor = CustomColor.nomadGray3
+        view.layer.cornerRadius = 12
+        
+        return view
+    }()
+    
+    private let people: UILabel = {
+        let label = UILabel()
+        label.text = "모집 인원(나 포함)"
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = CustomColor.nomadBlack
+        
+        return label
+    }()
+    
+    private let peopleRectangle: UIView = {
+        let view = UIView()
+        view.backgroundColor = CustomColor.nomadGray3
+        view.layer.cornerRadius = 12
+        
+        return view
+    }()
+    
+    private let plusButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "plus"), for: .normal)
+        button.tintColor = CustomColor.nomadBlack
+        button.backgroundColor = .white
+        
+        return button
+    }()
+    
+    private let divider: UIView = {
+        let view = UIView()
+        view.backgroundColor = CustomColor.nomadGray2
+        view.anchor(width: 1, height: 36)
+        
+        return view
+    }()
+    
+    private let minusButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "minus"), for: .normal)
+        button.tintColor = CustomColor.nomadBlack
+        button.backgroundColor = .white
+        
+        return button
+    }()
+    
+    lazy var peopleCounterView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [plusButton, divider, minusButton])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 1
+        stackView.distribution = .fillProportionally
+        stackView.backgroundColor = .white
+        stackView.layer.cornerRadius = 12
+        stackView.layer.borderWidth = 1
+        stackView.layer.borderColor = CustomColor.nomadGray2?.cgColor
+        stackView.layer.shadowRadius = 5
+        stackView.layer.shadowOpacity = 0.05
+        stackView.layer.shadowColor = CustomColor.nomadBlack?.cgColor
+        stackView.layer.shadowOffset = CGSize(width: 3, height: 4)
+        
+        return stackView
+    }()
+    
+    private let content: UILabel = {
+        let label = UILabel()
+        label.text = "내용"
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = CustomColor.nomadBlack
+        
+        return label
+    }()
+    
+    private let contentRectangle: UIView = {
+        let view = UIView()
+        view.backgroundColor = CustomColor.nomadGray3
+        view.layer.cornerRadius = 12
+        
+        return view
+    }()
+    
+    // MARK: - LifeCycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configUI()
+        
+        navigationItem.title = "새로운 모임 생성"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(didTapDoneCreatingMeetUp))
+                 navigationController?.navigationBar.tintColor = CustomColor.nomadBlue
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(didTapCancelCreatingMeetUp))
+    }
+    
+    // MARK: - Actions
+    
+    @objc func didTapDoneCreatingMeetUp() {
+        // TODO: 내용 저장
+    }
+    
+    @objc func didTapCancelCreatingMeetUp() {
+        // TODO: dismiss 동작
+    }
+    
+    // MARK: - Helpers
+    
+    func configUI() {
+        
+        view.backgroundColor = .white
+        
+        let viewHeight = view.bounds.height
+        let paddingTop = viewHeight * 100/844
+        
+        view.addSubview(subject)
+        subject.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: paddingTop, paddingLeft: 20)
+        
+        view.addSubview(subjectRectangle)
+        subjectRectangle.anchor(top: subject.bottomAnchor, left: subject.leftAnchor, right: view.rightAnchor, paddingTop: 8, paddingRight: 20, height: 48)
+        
+        view.addSubview(time)
+        time.anchor(top: subjectRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
+        
+        view.addSubview(timeRectangle)
+        timeRectangle.anchor(top: time.bottomAnchor, left: subject.leftAnchor, right: subjectRectangle.rightAnchor, paddingTop: 8, height: 48)
+        
+        view.addSubview(location)
+        location.anchor(top: timeRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
+        
+        view.addSubview(locationRectangle)
+        locationRectangle.anchor(top: location.bottomAnchor, left: subject.leftAnchor, right: subjectRectangle.rightAnchor, paddingTop: 8, height: 48)
+        
+        view.addSubview(people)
+        people.anchor(top: locationRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
+        
+        let viewWidth = view.bounds.width
+        let halfRectWidth = (viewWidth - 20*2 - 10*2)/2
+        
+        view.addSubview(peopleRectangle)
+        peopleRectangle.anchor(top: people.bottomAnchor, left: subject.leftAnchor, paddingTop: 8, width: halfRectWidth, height: 48)
+        
+        view.addSubview(peopleCounterView)
+        peopleCounterView.anchor(top: peopleRectangle.topAnchor, right: view.rightAnchor, paddingRight: 20, width: halfRectWidth, height: 48)
+        
+        view.addSubview(content)
+        content.anchor(top: peopleRectangle.bottomAnchor, left: subject.leftAnchor, paddingTop: 30)
+        
+        view.addSubview(contentRectangle)
+        contentRectangle.anchor(top: content.bottomAnchor, left: subject.leftAnchor, right: subjectRectangle.rightAnchor, paddingTop: 8, height: 120)
+        
+    }
+}

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -99,6 +99,7 @@ class NewMeetUpViewController: UIViewController {
     private var timeField: UITextField = {
         let textField = UITextField()
         textField.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        textField.tintColor = .clear
         textField.borderStyle = .none
         
         let formatter = DateFormatter()

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -208,7 +208,7 @@ class NewMeetUpViewController: UIViewController {
     }()
     
     private lazy var peopleCounterView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [plusButton, divider, minusButton])
+        let stackView = UIStackView(arrangedSubviews: [minusButton, divider, plusButton])
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = 1


### PR DESCRIPTION
## 관련 이슈들
- #166 

## 작업 내용
- 새로운 퀘스트를 생성하는 뷰의 UI 작업입니다.
- 제목, 장소는 15자까지로 제한했습니다.
- 모임 시간은 datePicker로 10분 단위로 선택하도록 했습니다. 처음에는 현재 시간과 가까운 시간이 표시됩니다.
- 모집인원 + - 누르면 숫자가 바뀌도록 했습니다. 2명 이하로는 내려가지 않도록 했습니다.

## 리뷰 노트
- 모집인원 + - 버튼을 스택뷰로 만들었는데 가운데 divider가 완전히 한가운데가 안되네요..

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012157/200470345-595e2751-f34b-485c-a3f1-b184a82e8cd5.gif" width="300">

## Reference
- DatePicker (https://formestory.tistory.com/6, https://zeddios.tistory.com/291)
- textView placeholder (https://hyongdoc.tistory.com/280)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
