### PR TITLE
[Feat] PlaceCheckInView의 퀘스트 가로스크롤 UI 작업

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		DF561CA52918A0B40099D41D /* MeetUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF561CA42918A0B40099D41D /* MeetUpViewController.swift */; };
 		DF561CA82918A0C40099D41D /* ReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF561CA72918A0C40099D41D /* ReviewViewController.swift */; };
 		DF561CAB2918A0DA0099D41D /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF561CAA2918A0DA0099D41D /* SettingViewController.swift */; };
+		DF561CAD291A02840099D41D /* QuestCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF561CAC291A02840099D41D /* QuestCollectionViewCell.swift */; };
 		DF9618A628FCEF6A00E21D30 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9618A528FCEF6A00E21D30 /* MapViewController.swift */; };
 		DF9618AC28FCEFB600E21D30 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9618AB28FCEFB600E21D30 /* LoginViewController.swift */; };
 		DF9618AE28FCEFC200E21D30 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9618AD28FCEFC200E21D30 /* SignUpViewController.swift */; };
@@ -99,6 +100,7 @@
 		DF561CA42918A0B40099D41D /* MeetUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetUpViewController.swift; sourceTree = "<group>"; };
 		DF561CA72918A0C40099D41D /* ReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewController.swift; sourceTree = "<group>"; };
 		DF561CAA2918A0DA0099D41D /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
+		DF561CAC291A02840099D41D /* QuestCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestCollectionViewCell.swift; sourceTree = "<group>"; };
 		DF9618A528FCEF6A00E21D30 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		DF9618AB28FCEFB600E21D30 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		DF9618AD28FCEFC200E21D30 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 				159F831728FF79B700DBF98B /* CheckedProfileListViewCell.swift */,
 				15B621FC2901469D00E31125 /* PlaceInfoViewCell.swift */,
 				7E5CF5D32906886A00641E74 /* CheckInCardViewCell.swift */,
+				DF561CAC291A02840099D41D /* QuestCollectionViewCell.swift */,
 			);
 			path = PlaceCheckInView;
 			sourceTree = "<group>";
@@ -459,6 +462,7 @@
 				041351A728FFF459005D19CC /* CalendarViewController.swift in Sources */,
 				E2E6B23228FE757D005C0D77 /* Date+Extension.swift in Sources */,
 				E2E6B23428FE75F7005C0D77 /* String+Extension.swift in Sources */,
+				DF561CAD291A02840099D41D /* QuestCollectionViewCell.swift in Sources */,
 				DF9618AE28FCEFC200E21D30 /* SignUpViewController.swift in Sources */,
 				DF288B4F28F7D70F002838A4 /* AppDelegate.swift in Sources */,
 				8C21CC4128FF8018009043AF /* PlaceAnnotation.swift in Sources */,
@@ -468,7 +472,7 @@
 				8C21CC4528FF89BA009043AF /* MapData.swift in Sources */,
 				DF288B5128F7D70F002838A4 /* SceneDelegate.swift in Sources */,
 				7E5CF5DA2918BE2E00641E74 /* ParticipantCell.swift in Sources */,
-				631AD82B2906316B00EEED02 /* BasicInfoCell.swift in Sources */,
+				631AD82B2906316B00EEED02 /* ReviewInfoCell.swift in Sources */,
 				631AD82B2906316B00EEED02 /* ReviewInfoCell.swift in Sources */,
 				E25A675428F7E2C6004614B0 /* Place.swift in Sources */,
 				041351AD29081D16005D19CC /* ProfileGraphCollectionCell.swift in Sources */,

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -62,7 +62,6 @@ class PlaceCheckInViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         placeCheckInView()
         configureCancelButton()
         view.backgroundColor = .white
@@ -124,6 +123,7 @@ extension PlaceCheckInViewController: UICollectionViewDataSource {
         else if indexPath.section == 1 {
             guard let placeInfoViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: PlaceInfoViewCell.identifier, for: indexPath) as? PlaceInfoViewCell else { return UICollectionViewCell() }
             placeInfoViewCell.place = selectedPlace
+            
             return placeInfoViewCell
         }
         else if indexPath.section == 2 {

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -74,7 +74,7 @@ class PlaceInfoViewCell: UICollectionViewCell {
         collectionView.delegate = self
         collectionView.dataSource = self
         self.addSubview(collectionView)
-        collectionView.backgroundColor = .systemBlue
+        collectionView.backgroundColor = .systemBackground
         collectionView.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor)
         collectionView.register(QuestCollectionViewCell.self, forCellWithReuseIdentifier: QuestCollectionViewCell.identifier)
         

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -13,128 +13,104 @@ class PlaceInfoViewCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-//    var place: Place = DummyData.place1
     var place: Place? {
         didSet {
-            placeNameLable.text = place?.name
+//            placeNameLable.text = place?.name
             // MARK: 공지사항 data가 없어서 address으로 대체
-            placeNoteLabel.text = place?.address
+//            placeNoteLabel.text = place?.address
             FirebaseManager.shared.fetchCheckInHistoryAll(placeUid: place?.placeUid ?? "") { checkInHistory in
-                self.visitorsLabel.text = String(checkInHistory.count) + "명"
+//                self.visitorsLabel.text = String(checkInHistory.count) + "명"
             }
         }
     }
     
-    private let placeNameLable: UILabel = {
-        let label = UILabel()
-        label.text = "노마딕 제주"
-        label.font = .preferredFont(forTextStyle: .subheadline, weight: .semibold)
-        label.textColor = CustomColor.nomadBlue
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
+    let collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        let collectionview = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionview.showsHorizontalScrollIndicator = false
+        collectionview.contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 0)
+        return collectionview
     }()
-
-    private let locationLabel: UILabel = {
+    
+    let questLabel: UILabel = {
         let label = UILabel()
-        label.text = "제주시"
-        label.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
-        label.textColor = CustomColor.nomadGray1
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    private let locationIcon: UIImageView = {
-        let icon = UIImageView()
-        icon.image = UIImage(named: "locationIcon")
-        icon.translatesAutoresizingMaskIntoConstraints = false
-        return icon
-    }()
-
-    private let placeNoteLabel: UILabel = {
-        let label = UILabel()
-        label.text = "인포데스크는 오전 10시 - 오후 4시 사이에만 운영됩니다. (점심시간포함)"
-        label.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
-        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "퀘스트 5"
+        label.asFont(targetString: "퀘스트", font: .preferredFont(forTextStyle: .title3, weight: .semibold))
+        label.asFont(targetString: "5", font: .preferredFont(forTextStyle: .title3, weight: .semibold))
+        label.asColor(targetString: "5", color: CustomColor.nomadBlue ?? .red)
         return label
     }()
     
-    private let visitorTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "누적 노마더"
-        label.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
-        label.tintColor = CustomColor.nomadGray1
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private let visitorsLabel: UILabel = {
-        let label = UILabel()
-        label.text = "142명"
-        label.font = .preferredFont(forTextStyle: .title2, weight: .semibold)
-        label.tintColor = CustomColor.nomadGray1
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private let workHoursTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "누적 근무시간"
-        label.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
-        label.tintColor = CustomColor.nomadBlack
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private let workHoursLabel: UILabel = {
-        let label = UILabel()
-        label.text = "2173시간"
-        label.font = .preferredFont(forTextStyle: .title2, weight: .semibold)
-        label.tintColor = CustomColor.nomadGray1
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
+    lazy var plusButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "plus"), for: .normal)
+        button.tintColor = .black
+        button.addTarget(self, action: #selector(questAdd), for: .touchUpInside)
+        return button
     }()
     
     // MARK: - LifeCycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        renderInfo()
-        renderAnalysis()
+        
+        configureCollectionView()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(corder:) has not been implemented")
     }
     
+    // MARK: - Actions
+    
+    @objc func questAdd() {
+        print("QUEST ADD!!")
+    }
+    
     // MARK: - Helpers
     
-    func renderInfo() {
-        // 공간 이름
-        self.addSubview(placeNameLable)
-        placeNameLable.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 15, paddingLeft: 17)
-        // 픽토그램
-        self.addSubview(locationIcon)
-        locationIcon.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 40, paddingLeft: 18)
-        // 소재지
-        self.addSubview(locationLabel)
-        locationLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 39, paddingLeft: 28)
-        // 공지사항
-        self.addSubview(placeNoteLabel)
-        placeNoteLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 60, paddingLeft: 18)
+    func configureCollectionView() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        self.addSubview(collectionView)
+        collectionView.backgroundColor = .systemBlue
+        collectionView.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor)
+        collectionView.register(QuestCollectionViewCell.self, forCellWithReuseIdentifier: QuestCollectionViewCell.identifier)
+        
+        self.addSubview(questLabel)
+        questLabel.anchor(top: collectionView.topAnchor, left: collectionView.leftAnchor, paddingTop: 10, paddingLeft: 20)
+        
+        self.addSubview(plusButton)
+        plusButton.anchor(top: collectionView.topAnchor, right: collectionView.rightAnchor, paddingTop: 10, paddingRight: 20, width: 24, height: 24)
     }
     
-    func renderAnalysis() {
-        // 누적 노마더 통계
-        self.addSubview(visitorTitleLabel)
-        self.addSubview(visitorsLabel)
-        visitorTitleLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 115, paddingLeft: 75)
-        visitorsLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 135, paddingLeft: 71)
-        
-        // 누적 근무시간 통계
-        self.addSubview(workHoursTitleLabel)
-        self.addSubview(workHoursLabel)
-        workHoursTitleLabel.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 115, paddingRight: 75)
-        workHoursLabel.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 135, paddingRight: 62)
-    }
 }
 
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension PlaceInfoViewCell: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 312, height: 124)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print(indexPath)
+    }
+    
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension PlaceInfoViewCell: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 10
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: QuestCollectionViewCell.identifier, for: indexPath) as? QuestCollectionViewCell else { return UICollectionViewCell() }
+        
+        return cell
+    }
+    
+}

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -1,0 +1,154 @@
+//
+//  QuestCollectionViewCell.swift
+//  BNomad
+//
+//  Created by 박성수 on 2022/11/08.
+//
+
+import UIKit
+
+class QuestCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: - Properties
+    
+    static let identifier: String = String(describing: QuestCollectionViewCell.self)
+    
+    let title: UILabel = {
+        let title = UILabel()
+        title.font = .preferredFont(forTextStyle: .headline, weight: .regular)
+        title.text = "맛찬들 같이 가실 분!"
+        title.numberOfLines = 1
+        return title
+    }()
+    
+    let participateButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "checkmark.circle.fill"), for: .normal)
+        button.tintColor = CustomColor.nomadBlue
+        return button
+    }()
+    
+    let timeImage: UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "timer")
+        image.tintColor = CustomColor.nomadGray1
+        return image
+    }()
+    
+    let time: UILabel = {
+        let time = UILabel()
+        time.text = "12:00"
+        time.textColor = CustomColor.nomadGray1
+        return time
+    }()
+    
+    let locationImage: UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "signpost.right")
+        image.tintColor = CustomColor.nomadGray1
+        return image
+    }()
+    
+    let location: UILabel = {
+        let location = UILabel()
+        location.text = "입구 앞"
+        location.textColor = CustomColor.nomadGray1
+        return location
+    }()
+    
+    let currentCheckedPeople: String = "1"
+    
+    lazy var checkedPeople: UILabel = {
+        let label = UILabel()
+        label.text = "\(currentCheckedPeople) / 4"
+        label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
+        label.textColor = CustomColor.nomadGray1
+        return label
+    }()
+    
+    let checkedImage1: UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "person.crop.circle.fill")
+        image.anchor(width: 32, height: 32)
+        image.tintColor = CustomColor.nomadGray1
+        return image
+    }()
+    let checkedImage2: UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "person.crop.circle.fill")
+        image.anchor(width: 32, height: 32)
+        return image
+    }()
+    let checkedImage3: UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "person.crop.circle.fill")
+        image.anchor(width: 32, height: 32)
+        return image
+    }()
+    let checkedImage4: UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "person.crop.circle.fill")
+        image.anchor(width: 32, height: 32)
+        return image
+    }()
+    
+    lazy var checkedInPeople: [UIImageView] = [checkedImage1, checkedImage2, checkedImage3, checkedImage4]
+    
+    // MARK: - LifeCycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureUI()
+        
+        for person in 1...Int(currentCheckedPeople)! + 1 {
+            checkedInPeople.append(checkedInPeople[person])
+        }
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Actions
+    
+    
+    // MARK: - Helpers
+    
+    func configureUI() {
+        backgroundColor = .systemBackground
+        self.layer.cornerRadius = 12
+        
+        self.addSubview(participateButton)
+        participateButton.anchor(top: self.topAnchor, right: self.rightAnchor, width: 32, height: 32)
+        
+        self.addSubview(title)
+        title.anchor(top: self.topAnchor, left: self.leftAnchor, right: participateButton.leftAnchor, paddingTop: 16, paddingLeft: 12, paddingRight: 10)
+        
+        let upperStack = UIStackView(arrangedSubviews: [timeImage, time])
+        upperStack.axis = .horizontal
+        upperStack.spacing = 12
+        upperStack.alignment = .leading
+        let downStack = UIStackView(arrangedSubviews: [locationImage, location])
+        downStack.axis = .horizontal
+        downStack.spacing = 12
+        downStack.alignment = .leading
+        
+        self.addSubview(upperStack)
+        upperStack.anchor(top: title.bottomAnchor, left: self.leftAnchor, paddingTop: 25, paddingLeft: 14)
+        self.addSubview(downStack)
+        downStack.anchor(top: upperStack.bottomAnchor, left: self.leftAnchor, paddingTop: 7, paddingLeft: 14)
+        
+        let peopleStack = UIStackView(arrangedSubviews: checkedInPeople)
+        peopleStack.axis = .horizontal
+        peopleStack.spacing = -10
+        
+        self.addSubview(peopleStack)
+        peopleStack.anchor(bottom: self.bottomAnchor, right: self.rightAnchor, paddingBottom: 13, paddingRight: 14)
+        
+        self.addSubview(checkedPeople)
+        checkedPeople.anchor(bottom: self.bottomAnchor, right: peopleStack.leftAnchor, paddingBottom: 15, paddingRight: 11)
+    }
+    
+}

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -23,7 +23,8 @@ class QuestCollectionViewCell: UICollectionViewCell {
     
     let participateButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(systemName: "checkmark.circle.fill"), for: .normal)
+        let config = UIImage.SymbolConfiguration(pointSize: 32)
+        button.setImage(UIImage(systemName: "checkmark.circle.fill", withConfiguration: config), for: .normal)
         button.tintColor = CustomColor.nomadBlue
         return button
     }()
@@ -99,12 +100,8 @@ class QuestCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        shadowSetting()
         configureUI()
-        
-        for person in 1...Int(currentCheckedPeople)! + 1 {
-            checkedInPeople.append(checkedInPeople[person])
-        }
-        
     }
     
     required init?(coder: NSCoder) {
@@ -116,29 +113,37 @@ class QuestCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Helpers
     
-    func configureUI() {
+    func shadowSetting() {
         backgroundColor = .systemBackground
         self.layer.cornerRadius = 12
+        self.clipsToBounds = true
         
+        self.layer.masksToBounds = false
+        self.layer.shadowRadius = 15
+        self.layer.shadowOffset = CGSize(width: 3, height: 4)
+        self.layer.shadowOpacity = 0.1
+    }
+    
+    func configureUI() {
         self.addSubview(participateButton)
-        participateButton.anchor(top: self.topAnchor, right: self.rightAnchor, width: 32, height: 32)
+        participateButton.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 10, paddingRight: 10)
         
         self.addSubview(title)
-        title.anchor(top: self.topAnchor, left: self.leftAnchor, right: participateButton.leftAnchor, paddingTop: 16, paddingLeft: 12, paddingRight: 10)
+        title.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 16, paddingLeft: 12)
         
-        let upperStack = UIStackView(arrangedSubviews: [timeImage, time])
-        upperStack.axis = .horizontal
-        upperStack.spacing = 12
-        upperStack.alignment = .leading
-        let downStack = UIStackView(arrangedSubviews: [locationImage, location])
-        downStack.axis = .horizontal
-        downStack.spacing = 12
-        downStack.alignment = .leading
+        let timeStack = UIStackView(arrangedSubviews: [timeImage, time])
+        timeStack.axis = .horizontal
+        timeStack.spacing = 12
+        timeStack.alignment = .leading
+        let locationStack = UIStackView(arrangedSubviews: [locationImage, location])
+        locationStack.axis = .horizontal
+        locationStack.spacing = 12
+        locationStack.alignment = .leading
         
-        self.addSubview(upperStack)
-        upperStack.anchor(top: title.bottomAnchor, left: self.leftAnchor, paddingTop: 25, paddingLeft: 14)
-        self.addSubview(downStack)
-        downStack.anchor(top: upperStack.bottomAnchor, left: self.leftAnchor, paddingTop: 7, paddingLeft: 14)
+        self.addSubview(timeStack)
+        timeStack.anchor(top: title.bottomAnchor, left: self.leftAnchor, paddingTop: 25, paddingLeft: 14)
+        self.addSubview(locationStack)
+        locationStack.anchor(top: timeStack.bottomAnchor, left: self.leftAnchor, paddingTop: 7, paddingLeft: 14)
         
         let peopleStack = UIStackView(arrangedSubviews: checkedInPeople)
         peopleStack.axis = .horizontal


### PR DESCRIPTION
## 관련 이슈들
- #175 

## 작업 내용
- 가로스크롤을 PlaceCheckInView의 cell안에 collectionview를 넣는 방식으로 구현했습니다.
- 퀘스트 추가 액션은 아직 넣지 않았습니다.

## 리뷰 노트
- 사람 수만큼의 프로필이미지가 보이게 되는데, 이 작업 아직 완료되지 않았습니다. (4명 전부 나오게 설정함)
- 지금 QuestCell이 `PlaceChekInViewCell 안에 CollectionView 안의 cell`로 깊이가 있는 것 같아 `최하단cell(QuestCell)`에서 액션이 일어나면 상위뷰들로 액션 전달이 힘들 것 같아, 현재는 하단의 이미지가 모두 하나의 section에 있지만, '퀘스트 5개 ~~~ +버튼' 까지를 다른 섹션으로 분리할까 생각중입니다. **도움주세요!**
<img width="300" alt="스크린샷 2022-11-09 11 12 02" src="https://user-images.githubusercontent.com/72736657/200720133-ef2dc19f-de67-497e-a31a-de5f15a41099.png">


## 스크린샷(UX의 경우 gif)
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-09 at 11 08 50](https://user-images.githubusercontent.com/72736657/200719733-ca592dd8-8902-46f6-9462-158b263763a2.gif)

## Reference
- UIButton configuration: https://velog.io/@wannabe_eung/iOS-UIButton-Configuration-사용해보기-in-iOS-15

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
