### PR TITLE
[Feat] 지역 선택 기능 구현 및 신규 UI 변경

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		7EC6F9F228FE3A19003D8A95 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6F9F128FE3A19003D8A95 /* UILabel+Extension.swift */; };
 		8C21CC4128FF8018009043AF /* PlaceAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C21CC4028FF8018009043AF /* PlaceAnnotation.swift */; };
 		8C21CC4528FF89BA009043AF /* MapData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C21CC4428FF89BA009043AF /* MapData.swift */; };
+		8CC750912919F330009F9C91 /* RegionSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC750902919F330009F9C91 /* RegionSelectViewController.swift */; };
+		8CC750932919F3BE009F9C91 /* RegionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC750922919F3BE009F9C91 /* RegionCollectionViewCell.swift */; };
 		DF288B4F28F7D70F002838A4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF288B4E28F7D70F002838A4 /* AppDelegate.swift */; };
 		DF288B5128F7D70F002838A4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF288B5028F7D70F002838A4 /* SceneDelegate.swift */; };
 		DF288B5828F7D710002838A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DF288B5728F7D710002838A4 /* Assets.xcassets */; };
@@ -88,6 +90,8 @@
 		7EC6F9F128FE3A19003D8A95 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		8C21CC4028FF8018009043AF /* PlaceAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceAnnotation.swift; sourceTree = "<group>"; };
 		8C21CC4428FF89BA009043AF /* MapData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapData.swift; sourceTree = "<group>"; };
+		8CC750902919F330009F9C91 /* RegionSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionSelectViewController.swift; sourceTree = "<group>"; };
+		8CC750922919F3BE009F9C91 /* RegionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCollectionViewCell.swift; sourceTree = "<group>"; };
 		DF288B4B28F7D70F002838A4 /* BNomad.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BNomad.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF288B4E28F7D70F002838A4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DF288B5028F7D70F002838A4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -221,6 +225,8 @@
 			isa = PBXGroup;
 			children = (
 				DF9618A528FCEF6A00E21D30 /* MapViewController.swift */,
+				8CC750902919F330009F9C91 /* RegionSelectViewController.swift */,
+				8CC750922919F3BE009F9C91 /* RegionCollectionViewCell.swift */,
 				8C21CC4028FF8018009043AF /* PlaceAnnotation.swift */,
 				8C21CC4428FF89BA009043AF /* MapData.swift */,
 			);
@@ -457,6 +463,7 @@
 				E2E6B23228FE757D005C0D77 /* Date+Extension.swift in Sources */,
 				E2E6B23428FE75F7005C0D77 /* String+Extension.swift in Sources */,
 				DF9618AE28FCEFC200E21D30 /* SignUpViewController.swift in Sources */,
+				8CC750912919F330009F9C91 /* RegionSelectViewController.swift in Sources */,
 				DF288B4F28F7D70F002838A4 /* AppDelegate.swift in Sources */,
 				8C21CC4128FF8018009043AF /* PlaceAnnotation.swift in Sources */,
 				041351A328FF7E98005D19CC /* ProfileGraphCell.swift in Sources */,
@@ -486,6 +493,7 @@
 				6383330E2900CDBA005AB0C3 /* PlaceInfoCell.swift in Sources */,
 				6383330E2900CDBA005AB0C3 /* PlaceInfoCell.swift in Sources */,
 				041351A528FF8EBE005D19CC /* LiteralContents.swift in Sources */,
+				8CC750932919F3BE009F9C91 /* RegionCollectionViewCell.swift in Sources */,
 				DF561CAB2918A0DA0099D41D /* SettingViewController.swift in Sources */,
 				E2ADB25A2906D44200082596 /* FirebaseTestVC.swift in Sources */,
 			);

--- a/BNomad/Model/Place.swift
+++ b/BNomad/Model/Place.swift
@@ -22,3 +22,9 @@ struct Place {
     var currentCheckIn: [CheckIn]? { todayCheckInHistory?.filter { $0.checkOutTime == nil } }
     
 }
+
+enum PlaceType: Int {
+    case coworking
+    case library
+    case cafe
+}

--- a/BNomad/View/MapView/MapData.swift
+++ b/BNomad/View/MapView/MapData.swift
@@ -8,12 +8,6 @@
 import Foundation
 import MapKit
 
-// TODO: - 해당 파일 제거 후 Place의 extension으로 편입시키기
-enum PlaceType: Int {
-    case coworking
-    case library
-    case cafe
-}
 
 class MKAnnotationFromPlace: NSObject, MKAnnotation {
     var coordinate: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 0, longitude: 0)
@@ -86,11 +80,16 @@ struct Region {
     }
 }
 
-struct RegionData {
-    static var jeju1: Region = Region(name: "\(RegionName.jeju1.rawValue)", lat: 33.4974, long: 126.5164, span: 0.9)
-    static var jeju2: Region = Region(name: "\(RegionName.jeju2.rawValue)", lat: 33.2327, long: 126.3003, span: 0.5)
 
-    static var seoul: Region = Region(name: "\(RegionName.seoul.rawValue)", lat: 37.5542, long: 126.9733, span: 0.5)
+// RegionData와 하단의 RegionArray는 갯수, 순서 일치시켜서 관리
+
+struct RegionData {
+    static let jeju1: Region = Region(name: "\(RegionName.jeju1.rawValue)", lat: 33.4974, long: 126.5164, span: 0.9)
+    static let jeju2: Region = Region(name: "\(RegionName.jeju2.rawValue)", lat: 33.2327, long: 126.3003, span: 0.5)
+    static let seoul: Region = Region(name: "\(RegionName.seoul.rawValue)", lat: 37.5542, long: 126.9733, span: 0.5)
+    static let pohang: Region = Region(name: "\(RegionName.pohang.rawValue)", lat: 36.0137, long: 129.3257, span: 0.5)
+    
+    // 추후 지역 추가를 위해 남김
 //    static var gangwon: Region = Region(name: "\(RegionName.gangwon.rawValue)", lat: 0, long: 0, span: 0.1)
 //    static var jeolla: Region = Region(name: "\(RegionName.jeolla.rawValue)", lat: 0, long: 0, span: 0.1)
 //    static var gyeongsang: Region = Region(name: "\(RegionName.gyeongsang.rawValue)", lat: 0, long: 0, span: 0.1)
@@ -103,9 +102,8 @@ struct RegionData {
 //    static var incheon: Region = Region(name: "\(RegionName.incheon.rawValue)", lat: 0, long: 0, span: 0.1)
 //    static var daejeon: Region = Region(name: "\(RegionName.daejeon.rawValue)", lat: 0, long: 0, span: 0.1)
 //    static var sejong: Region = Region(name: "\(RegionName.sejong.rawValue)", lat: 0, long: 0, span: 0.1)
-    static var pohang: Region = Region(name: "\(RegionName.pohang.rawValue)", lat: 36.0137, long: 129.3257, span: 0.5)
 
+    
+    static let regionArray: [Region] = [RegionData.jeju1, RegionData.jeju2, RegionData.seoul, RegionData.pohang]
 }
 
-
-//var regions: [Region] = [RegionData.jeju, RegionData.seoul]

--- a/BNomad/View/MapView/MapData.swift
+++ b/BNomad/View/MapView/MapData.swift
@@ -36,3 +36,76 @@ class MKAnnotationFromPlace: NSObject, MKAnnotation {
     }
 }
 
+
+enum RegionName: String {
+    case jeju1 = "제주 제주시"
+    case jeju2 = "제주 서귀포시"
+    case seoul = "서울"
+    case gangwon = "강원"
+    case jeolla = "전라"
+    case gyeongsang = "경상"
+    case gyeonggi = "경기"
+    case chungcheong = "충청"
+    case daegu = "대구"
+    case busan = "부산"
+    case ulsan = "울산"
+    case gwangju = "광주"
+    case incheon = "인천"
+    case daejeon = "대전"
+    case sejong = "세종"
+    case pohang = "포항"
+}
+
+struct Region {
+    let name: String
+    let lat: Double
+    let long: Double
+    
+    var coordiante: CLLocationCoordinate2D {
+        let coordinate = CLLocationCoordinate2D(latitude: lat, longitude: long)
+        return coordinate
+    }
+    
+    let span: Double
+    
+    var convertedSpan: MKCoordinateSpan {
+        let span = MKCoordinateSpan(latitudeDelta: span, longitudeDelta: span)
+        return span
+    }
+    
+    var region: MKCoordinateRegion {
+        let region = MKCoordinateRegion(center: coordiante, span: convertedSpan)
+        return region
+    }
+    
+    init(name: String, lat: Double, long: Double, span: Double) {
+        self.name = name
+        self.lat = lat
+        self.long = long
+        self.span = span
+    }
+}
+
+struct RegionData {
+    static var jeju1: Region = Region(name: "\(RegionName.jeju1.rawValue)", lat: 33.4974, long: 126.5164, span: 0.9)
+    static var jeju2: Region = Region(name: "\(RegionName.jeju2.rawValue)", lat: 33.2327, long: 126.3003, span: 0.5)
+
+    static var seoul: Region = Region(name: "\(RegionName.seoul.rawValue)", lat: 37.5542, long: 126.9733, span: 0.5)
+//    static var gangwon: Region = Region(name: "\(RegionName.gangwon.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var jeolla: Region = Region(name: "\(RegionName.jeolla.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var gyeongsang: Region = Region(name: "\(RegionName.gyeongsang.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var gyeonggi: Region = Region(name: "\(RegionName.gyeonggi.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var chungcheong: Region = Region(name: "\(RegionName.chungcheong.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var daegu: Region = Region(name: "\(RegionName.daegu.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var busan: Region = Region(name: "\(RegionName.busan.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var ulsan: Region = Region(name: "\(RegionName.ulsan.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var gwangju: Region = Region(name: "\(RegionName.gwangju.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var incheon: Region = Region(name: "\(RegionName.incheon.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var daejeon: Region = Region(name: "\(RegionName.daejeon.rawValue)", lat: 0, long: 0, span: 0.1)
+//    static var sejong: Region = Region(name: "\(RegionName.sejong.rawValue)", lat: 0, long: 0, span: 0.1)
+    static var pohang: Region = Region(name: "\(RegionName.pohang.rawValue)", lat: 36.0137, long: 129.3257, span: 0.5)
+
+}
+
+
+//var regions: [Region] = [RegionData.jeju, RegionData.seoul]

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -10,6 +10,18 @@ import MapKit
 import CoreLocation
 import Combine
 
+protocol ClearSelectedAnnotation {
+    func clearAnnotation(view: MKAnnotation)
+}
+
+protocol UpdateFloating {
+    func checkInFloating()
+}
+
+protocol setMap {
+    func setMapRegion(_ latitude: Double, _ longitude: Double, spanDelta: Double)
+}
+
 class MapViewController: UIViewController {
     
     // MARK: - Properties
@@ -19,7 +31,8 @@ class MapViewController: UIViewController {
     let customStartLocation: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 33.37, longitude: 126.53) // 디바이스 현재 위치 못 받을 경우 커스텀 시작 위치 정해야 함 (c5로? 제주로? 서울로? 전국 지도?) -> 우선은 제주도. 디바이스 위치 허용하면 제주도 볼 일 없음 ㅋㅋ
     
     lazy var viewModel: CombineViewModel = CombineViewModel.shared
-
+    
+    var selectedRegion: Region?
     
     // 맵 띄우기
     private lazy var map: MKMapView = {
@@ -45,9 +58,8 @@ class MapViewController: UIViewController {
     lazy var profileBtn: UIButton = {
         var btn = UIButton()
         btn.setImage(UIImage(systemName: "person"), for: .normal)
-        btn.tintColor = .systemGray
-        btn.backgroundColor = .white
-        btn.layer.cornerRadius = 10
+//        btn.tintColor = CustomColor.nomadBlue
+//        btn.backgroundColor = .white
         btn.translatesAutoresizingMaskIntoConstraints = false
         btn.addTarget(self, action: #selector(moveToProfile), for: .touchUpInside)
         return btn
@@ -71,58 +83,100 @@ class MapViewController: UIViewController {
     
     private let divider: UIView = {
         let divider = UIView()
-        divider.backgroundColor = .systemGray
+//        divider.tintColor = CustomColor.nomadBlue
+        divider.backgroundColor = CustomColor.nomadBlue
         divider.translatesAutoresizingMaskIntoConstraints = false
-        divider.heightAnchor.constraint(equalToConstant: 1).isActive = true
-        divider.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        divider.heightAnchor.constraint(equalToConstant: 20).isActive = true
+        divider.widthAnchor.constraint(equalToConstant: 1).isActive = true
         return divider
     }()
     
     private let settingBtn: UIButton = {
         let btn = UIButton()
         btn.setImage(UIImage(systemName: "gearshape"), for: .normal)
-        btn.tintColor = .systemGray
-        btn.backgroundColor = .white
-        btn.layer.cornerRadius = 10
+//        btn.tintColor = CustomColor.nomadBlue
+//        btn.backgroundColor = .white
         btn.translatesAutoresizingMaskIntoConstraints = false
         return btn
     }()
     
-    lazy var profileAndSetting: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [profileBtn, divider, settingBtn])
-        stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.spacing = 1
-        stackView.distribution = .fillProportionally
-        stackView.backgroundColor = .white
-        stackView.layer.cornerRadius = 10
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
+
+    
+    // 지역명 표기 및 지역 변경
+    lazy var regionTitle: UILabel = {
+        let title = UILabel()
+        title.text = selectedRegion?.name ?? "지역 선택"
+        title.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
+        return title
+    }()
+    
+    var regionChangeBtn: UIButton = {
+        let btn = UIButton()
+        btn.setImage(UIImage(systemName: "chevron.down"), for: .normal)
+        btn.changesSelectionAsPrimaryAction = true
+        btn.addTarget(self, action: #selector(presentRegionSelector), for: .touchUpInside)
+        return btn
+    }()
+    
+    @objc private func presentRegionSelector() {
+        let sheet = RegionSelectViewController()
+        sheet.modalPresentationStyle = .pageSheet
+        if let sheet = sheet.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.delegate = self
+            sheet.prefersGrabberVisible = false
+//            sheet.largestUndimmedDetentIdentifier = .medium
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+            sheet.preferredCornerRadius = 12
+        }
+        sheet.regionChangeDelegate = self
+        present(sheet, animated: true, completion: nil)
+    }
+    
+    lazy var upperStack: UIStackView = {
+        let topLeftTitle = UIStackView(arrangedSubviews: [regionTitle, regionChangeBtn])
+        topLeftTitle.axis = .horizontal
+        topLeftTitle.alignment = .center
+        topLeftTitle.spacing = 10
+        topLeftTitle.distribution = .fillProportionally
+        topLeftTitle.anchor(width: 100)
+        topLeftTitle.translatesAutoresizingMaskIntoConstraints = false
+
+        let topRightBtn = UIStackView(arrangedSubviews: [profileBtn, divider, settingBtn])
+        topRightBtn.axis = .horizontal
+        topRightBtn.alignment = .center
+        topRightBtn.spacing = 5
+        topRightBtn.tintColor = CustomColor.nomadBlue
+        topRightBtn.distribution = .fillProportionally
+        topRightBtn.anchor(width: 60)
+        topRightBtn.translatesAutoresizingMaskIntoConstraints = false
+        
+        let upperStack = UIStackView(arrangedSubviews: [topLeftTitle, topRightBtn])
+        upperStack.axis = .horizontal
+        upperStack.alignment = .fill
+        upperStack.distribution = .equalSpacing
+        upperStack.translatesAutoresizingMaskIntoConstraints = false
+        return upperStack
+    }()
+    
+    // 화면 상단 스택 백그라운드
+    private let blurBackground: UIVisualEffectView = {
+        let blur = UIBlurEffect(style: .light)
+        let background = UIVisualEffectView(effect: blur)
+        background.translatesAutoresizingMaskIntoConstraints = false
+        return background
     }()
     
     // TODO: - 장소 모달 뷰 보다가 현재 위치로 이동 시 보던 장소 모달 dismiss 필요
     lazy var userTrackingBtn: MKUserTrackingButton = {
         let btn = MKUserTrackingButton(mapView: map)
         btn.backgroundColor = .white
-        btn.tintColor = .systemGray
-        btn.layer.cornerRadius = 10
+        btn.tintColor = CustomColor.nomadBlue
+        btn.layer.cornerRadius = 20
+        btn.layer.borderColor = CustomColor.nomadBlue?.cgColor
+        btn.layer.borderWidth = 1
         btn.translatesAutoresizingMaskIntoConstraints = false
         return btn
-    }()
-    
-    lazy var mapButtons: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [profileAndSetting, userTrackingBtn])
-        stackView.sizeToFit()
-        stackView.axis = .vertical
-        stackView.alignment = .fill
-        stackView.spacing = 2
-        stackView.distribution = .equalCentering
-        stackView.backgroundColor = .clear
-        stackView.layer.cornerRadius = 10
-        profileAndSetting.widthAnchor.constraint(equalToConstant: 40).isActive = true
-        profileAndSetting.heightAnchor.constraint(equalToConstant: 90).isActive = true
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
     }()
     
     // 유저 위치 중심으로 circle overlay (radius distance 미터 단위)
@@ -136,8 +190,7 @@ class MapViewController: UIViewController {
     lazy var listViewButton: UIButton = {
         let button = UIButton()
         button.backgroundColor = .white
-        button.setTitle("리스트 보기", for:.normal)
-        button.titleLabel!.font = .preferredFont(forTextStyle: .subheadline, weight: .bold)
+        button.setImage(UIImage(systemName: "list.bullet"), for: .normal)
         button.setTitleColor(CustomColor.nomadBlue, for: .normal)
         button.layer.cornerRadius = 20
         button.layer.borderColor = CustomColor.nomadBlue?.cgColor
@@ -225,10 +278,6 @@ class MapViewController: UIViewController {
         
     }
     
-    func setMapRegion(_ latitude: Double, _ longitude: Double, spanDelta: Double) {
-        map.setRegion(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: latitude, longitude: longitude), span: MKCoordinateSpan(latitudeDelta: spanDelta, longitudeDelta: spanDelta)), animated: true)
-    }
-    
     func checkInBinding() {
         print("체크인 바인딩 -> 위치 전달")
         if let user = viewModel.user {
@@ -239,12 +288,12 @@ class MapViewController: UIViewController {
                     self.setMapRegion(place.latitude - 0.004, place.longitude, spanDelta: 0.01)
                     let annotation = MKAnnotationFromPlace.convertPlaceToAnnotation(place)
                     self.map.selectAnnotation(annotation, animated: true)
-                    let controller = PlaceInfoModalViewController()
-                    controller.selectedPlace = place
-                    controller.delegateForClearAnnotation = self
-                    controller.delegateForFloating = self
-                    controller.presentationController?.delegate = self
-                    present(controller, animated: true)
+//                    let controller = PlaceInfoModalViewController()
+//                    controller.selectedPlace = place
+//                    controller.delegateForClearAnnotation = self
+//                    controller.delegateForFloating = self
+//                    controller.presentationController?.delegate = self
+//                    present(controller, animated: true)
                 }
                 
                 print("체크인 상태로 맵 세팅 끝")
@@ -279,9 +328,12 @@ class MapViewController: UIViewController {
         map.delegate = self
         view.addSubview(map)
         map.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
+        
+        map.addSubview(blurBackground)
+        blurBackground.anchor(top: map.topAnchor, left: map.leftAnchor, right: map.rightAnchor, paddingTop: 0, paddingLeft: 0, paddingRight: 0, height: 100)
 
-        map.addSubview(mapButtons)
-        mapButtons.anchor(top: map.topAnchor, right: map.rightAnchor, paddingTop: 50, paddingRight: 20, width: 40, height: 140)
+        map.addSubview(upperStack)
+        upperStack.anchor(top: map.topAnchor, left: map.leftAnchor, right: map.rightAnchor, paddingTop: 30, paddingLeft: 20, paddingRight: 20, height: 80)
         
         map.addSubview(compass)
         compass.anchor(top: map.topAnchor, left: map.leftAnchor, paddingTop: 50, paddingLeft: 20, width: 40, height: 40)
@@ -295,15 +347,18 @@ class MapViewController: UIViewController {
         }
         
         map.addSubview(listViewButton)
-        listViewButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, paddingLeft: 15, paddingBottom: 70, width: 88, height: 43.73)
+        listViewButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, paddingLeft: 15, paddingBottom: 70, width: 40, height: 40)
+        
+        map.addSubview(userTrackingBtn)
+        userTrackingBtn.anchor(bottom: view.bottomAnchor, right: view.rightAnchor, paddingBottom: 70, paddingRight: 15, width: 40, height: 40)
     }
 
     
-    func configureFloating() {
-        view.addSubview(checkInNow)
-        checkInNow.anchor(top: view.topAnchor, paddingTop: 60, width: 100, height: 40)
-        checkInNow.centerX(inView: view)
-    }
+//    func configureFloating() {
+//        view.addSubview(checkInNow)
+//        checkInNow.anchor(top: upperStack.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 200, paddingLeft: 0, paddingRight: 0, width: 100, height: 40)
+//        checkInNow.centerX(inView: view)
+//    }
     
     func userCombine() {
         viewModel.$user
@@ -409,9 +464,8 @@ extension MapViewController: ClearSelectedAnnotation {
 extension MapViewController: UpdateFloating {
     func checkInFloating() {
         map.addSubview(checkInNow)
-        checkInNow.anchor(top: view.topAnchor, paddingTop: 60, width: 100, height: 40)
+        checkInNow.anchor(top: view.topAnchor, paddingTop: 110, width: 100, height: 40)
         checkInNow.centerX(inView: view)
-        
     }
 }
 
@@ -435,5 +489,12 @@ extension MapViewController: CLLocationManagerDelegate {
         currentLocation = location
         map.removeOverlay(circleOverlay)
         map.addOverlay(circleOverlay)
+    }
+}
+
+// MARK: - MapRegionChange
+extension MapViewController: setMap {
+    func setMapRegion(_ latitude: Double, _ longitude: Double, spanDelta: Double) {
+        map.setRegion(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: latitude, longitude: longitude), span: MKCoordinateSpan(latitudeDelta: spanDelta, longitudeDelta: spanDelta)), animated: true)
     }
 }

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -58,9 +58,7 @@ class MapViewController: UIViewController {
     lazy var profileBtn: UIButton = {
         var btn = UIButton()
         btn.setImage(UIImage(systemName: "person"), for: .normal)
-//        btn.tintColor = CustomColor.nomadBlue
-//        btn.backgroundColor = .white
-        btn.translatesAutoresizingMaskIntoConstraints = false
+        btn.anchor(width: 22, height: 22)
         btn.addTarget(self, action: #selector(moveToProfile), for: .touchUpInside)
         return btn
     }()
@@ -74,6 +72,9 @@ class MapViewController: UIViewController {
         if viewModel.isLogIn {
             navigationController?.pushViewController(ProfileViewController(), animated: true)
         } else {
+            
+            // TODO: - 회원가입 창 띄우기 전에 모달 띄우기
+            
             let controller = SignUpViewController()
             controller.modalPresentationStyle = .fullScreen
             present(controller, animated: true)
@@ -81,22 +82,18 @@ class MapViewController: UIViewController {
         map.selectedAnnotations = []
     }
     
-    private let divider: UIView = {
-        let divider = UIView()
-//        divider.tintColor = CustomColor.nomadBlue
-        divider.backgroundColor = CustomColor.nomadBlue
-        divider.translatesAutoresizingMaskIntoConstraints = false
-        divider.heightAnchor.constraint(equalToConstant: 20).isActive = true
-        divider.widthAnchor.constraint(equalToConstant: 1).isActive = true
+    private let divider: UIButton = {
+        let divider = UIButton()
+        divider.setImage(UIImage(systemName: "squareshape.fill"), for: .normal)
+        divider.isUserInteractionEnabled = false
+        divider.anchor(width: 1.5, height: 24)
         return divider
     }()
     
     private let settingBtn: UIButton = {
         let btn = UIButton()
-        btn.setImage(UIImage(systemName: "gearshape"), for: .normal)
-//        btn.tintColor = CustomColor.nomadBlue
-//        btn.backgroundColor = .white
-        btn.translatesAutoresizingMaskIntoConstraints = false
+        btn.setImage(UIImage(systemName: "gearshape")?.withRenderingMode(.automatic), for: .normal)
+        btn.anchor(width: 22, height: 22)
         return btn
     }()
     
@@ -114,6 +111,7 @@ class MapViewController: UIViewController {
         let btn = UIButton()
         btn.setImage(UIImage(systemName: "chevron.down"), for: .normal)
         btn.changesSelectionAsPrimaryAction = true
+        btn.tintColor = CustomColor.nomadBlue
         btn.addTarget(self, action: #selector(presentRegionSelector), for: .touchUpInside)
         return btn
     }()

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -28,7 +28,7 @@ class MapViewController: UIViewController {
 
     private let locationManager = CLLocationManager()
     lazy var currentLocation: CLLocation? = locationManager.location
-    let customStartLocation: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 33.37, longitude: 126.53) // 디바이스 현재 위치 못 받을 경우 커스텀 시작 위치 정해야 함 (c5로? 제주로? 서울로? 전국 지도?) -> 우선은 제주도. 디바이스 위치 허용하면 제주도 볼 일 없음 ㅋㅋ
+    let customStartLocation: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 33.37, longitude: 126.53) // 디바이스 현재 위치 못 받을 경우 커스텀 시작 위치 정해야 함 (c5로? 제주로? 서울로? 전국 지도?)
     
     lazy var viewModel: CombineViewModel = CombineViewModel.shared
     
@@ -173,7 +173,6 @@ class MapViewController: UIViewController {
         btn.layer.cornerRadius = 20
         btn.layer.borderColor = CustomColor.nomadBlue?.cgColor
         btn.layer.borderWidth = 1
-        btn.translatesAutoresizingMaskIntoConstraints = false
         return btn
     }()
     
@@ -189,11 +188,10 @@ class MapViewController: UIViewController {
         let button = UIButton()
         button.backgroundColor = .white
         button.setImage(UIImage(systemName: "list.bullet"), for: .normal)
-        button.setTitleColor(CustomColor.nomadBlue, for: .normal)
+        button.tintColor = CustomColor.nomadBlue
         button.layer.cornerRadius = 20
         button.layer.borderColor = CustomColor.nomadBlue?.cgColor
         button.layer.borderWidth = 1
-        button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(presentPlaceViewModal), for: .touchUpInside)
         return button
     }()
@@ -286,12 +284,12 @@ class MapViewController: UIViewController {
                     self.setMapRegion(place.latitude - 0.004, place.longitude, spanDelta: 0.01)
                     let annotation = MKAnnotationFromPlace.convertPlaceToAnnotation(place)
                     self.map.selectAnnotation(annotation, animated: true)
-//                    let controller = PlaceInfoModalViewController()
-//                    controller.selectedPlace = place
-//                    controller.delegateForClearAnnotation = self
-//                    controller.delegateForFloating = self
-//                    controller.presentationController?.delegate = self
-//                    present(controller, animated: true)
+                    let controller = PlaceInfoModalViewController()
+                    controller.selectedPlace = place
+                    controller.delegateForClearAnnotation = self
+                    controller.delegateForFloating = self
+                    controller.presentationController?.delegate = self
+                    present(controller, animated: true)
                 }
                 
                 print("체크인 상태로 맵 세팅 끝")
@@ -350,13 +348,6 @@ class MapViewController: UIViewController {
         map.addSubview(userTrackingBtn)
         userTrackingBtn.anchor(bottom: view.bottomAnchor, right: view.rightAnchor, paddingBottom: 70, paddingRight: 15, width: 40, height: 40)
     }
-
-    
-//    func configureFloating() {
-//        view.addSubview(checkInNow)
-//        checkInNow.anchor(top: upperStack.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 200, paddingLeft: 0, paddingRight: 0, width: 100, height: 40)
-//        checkInNow.centerX(inView: view)
-//    }
     
     func userCombine() {
         viewModel.$user
@@ -393,25 +384,6 @@ extension MapViewController: MKMapViewDelegate {
             return LibraryAnnotationView(annotation: annotation, reuseIdentifier: LibraryAnnotationView.ReuseID)
         }
     }
-    
-//    func mapView(_ mapView: MKMapView, didSelect annotation: MKAnnotation) {
-//        if let annotation = annotation as? MKAnnotationFromPlace {
-//            self.currentAnnotation = annotation
-//            map.setRegion(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: annotation.coordinate.latitude - 0.004, longitude: annotation.coordinate.longitude ), span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)), animated: true)
-//            let controller = PlaceInfoModalViewController()
-//            let tempPlace = self.viewModel.places.first { place in
-//                annotation.placeUid == place.placeUid
-//            }
-//            controller.selectedPlace = tempPlace
-//            controller.delegateForClearAnnotation = self
-//            controller.delegateForFloating = self
-//            controller.presentationController?.delegate = self
-//            present(controller, animated: true)
-//            
-//        } else {
-//            print("THIS is CLUSTER")
-//        }
-//    }
     
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
         if let view = view as? PlaceAnnotationView  {

--- a/BNomad/View/MapView/RegionCollectionViewCell.swift
+++ b/BNomad/View/MapView/RegionCollectionViewCell.swift
@@ -1,0 +1,70 @@
+//
+//  RegionCollectionViewCell.swift
+//  BNomad
+//
+//  Created by Youngwoong Choi on 2022/11/08.
+//
+
+import UIKit
+
+class RegionCollectionViewCell: UICollectionViewCell {
+    
+    static let identifier = "RegionCollectionViewCell"
+
+    // MARK: - Properties
+    
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                regionBtn.textColor = CustomColor.nomadBlue
+                regionBtn.layer.borderColor = CustomColor.nomadBlue?.cgColor
+            } else {
+                regionBtn.textColor = .black
+                regionBtn.layer.borderColor = UIColor.black.cgColor
+
+            }
+        }
+    }
+    
+    lazy var regionBtn: UILabel = {
+        let btn = UILabel()
+        btn.text = "지역명"
+        btn.clipsToBounds = true
+        btn.layer.cornerRadius = 20
+        btn.backgroundColor = .white
+        btn.layer.borderWidth = 0.5
+        btn.layer.borderColor = UIColor.black.cgColor
+        btn.textAlignment = .center
+        return btn
+    }()
+        
+//    lazy var cell: UIView = {
+//        let view = UIView()
+//        view.clipsToBounds = true
+//        view.layer.cornerRadius = 20
+//        view.backgroundColor = .white
+//        view.addSubview(name)
+//        name.center(inView: view)
+//        return view
+//    }()
+    
+    
+    // MARK: - LifeCycle
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUpCell()
+    }
+
+    // MARK: - Helpers
+    
+    func setUpCell() {
+        contentView.addSubview(regionBtn)
+        regionBtn.anchor(top: self.topAnchor, width: 150, height: 40)
+        regionBtn.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
+    }
+}

--- a/BNomad/View/MapView/RegionSelectViewController.swift
+++ b/BNomad/View/MapView/RegionSelectViewController.swift
@@ -12,7 +12,7 @@ class RegionSelectViewController: UIViewController {
     // MARK: - Properties
 
     var selectedRegion: Region?
-    var regions: [Region]? = [RegionData.jeju1, RegionData.jeju2, RegionData.seoul, RegionData.pohang] // RegionData 안에 있는 요소를 한 번에 단축해서 배열에 넣는 방법은?
+    var regions: [Region]? = RegionData.regionArray
     var regionChangeDelegate: setMap?
     
     var rectangle: UIView = {
@@ -53,10 +53,6 @@ class RegionSelectViewController: UIViewController {
         btn.layer.cornerRadius = 12
         btn.clipsToBounds = true
         btn.addTarget(self, action: #selector(regionChange), for: .touchUpInside)
-//        btn.addTarget(MapViewController(), action: )
-        
-
-        btn.translatesAutoresizingMaskIntoConstraints = false
         return btn
     }()
     

--- a/BNomad/View/MapView/RegionSelectViewController.swift
+++ b/BNomad/View/MapView/RegionSelectViewController.swift
@@ -1,0 +1,134 @@
+//
+//  RegionSelectViewController.swift
+//  BNomad
+//
+//  Created by Youngwoong Choi on 2022/11/08.
+//
+
+import UIKit
+
+class RegionSelectViewController: UIViewController {
+    
+    // MARK: - Properties
+
+    var selectedRegion: Region?
+    var regions: [Region]? = [RegionData.jeju1, RegionData.jeju2, RegionData.seoul, RegionData.pohang] // RegionData 안에 있는 요소를 한 번에 단축해서 배열에 넣는 방법은?
+    var regionChangeDelegate: setMap?
+    
+    var rectangle: UIView = {
+        let rectangle = UIView()
+        rectangle.frame = CGRect(x: 0, y: 0, width: 80, height: 5)
+        rectangle.layer.cornerRadius = 3
+        rectangle.translatesAutoresizingMaskIntoConstraints = false
+        rectangle.backgroundColor = .systemGray2
+        return rectangle
+    }()
+    
+    private let layout: UICollectionViewFlowLayout = {
+        let guideline = UICollectionViewFlowLayout()
+        guideline.scrollDirection = .vertical
+        guideline.minimumLineSpacing = 10
+        guideline.minimumInteritemSpacing = 0
+        return guideline
+    }()
+    
+    private lazy var collectionView: UICollectionView = {
+        let view = UICollectionView(frame: .zero, collectionViewLayout: self.layout)
+        view.isScrollEnabled = true
+        view.showsHorizontalScrollIndicator = false
+        view.showsVerticalScrollIndicator = true
+        view.scrollIndicatorInsets = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
+        view.contentInset = .zero
+        view.layer.backgroundColor = CustomColor.nomadGray3?.cgColor
+        view.clipsToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let confirmBtn: UIButton = {
+        let btn = UIButton()
+        btn.setTitle("확인", for: .normal)
+        btn.backgroundColor = CustomColor.nomadBlue
+        btn.setTitleColor(.white, for: .normal)
+        btn.layer.cornerRadius = 12
+        btn.clipsToBounds = true
+        btn.addTarget(self, action: #selector(regionChange), for: .touchUpInside)
+//        btn.addTarget(MapViewController(), action: )
+        
+
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
+    }()
+    
+
+    // MARK: - LifeCycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.view.layer.backgroundColor = CustomColor.nomadGray3?.cgColor
+        self.view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        self.view.layer.shadowColor = UIColor.black.cgColor
+        self.view.layer.shadowOffset = .init(width: 0, height: -2)
+        self.view.layer.shadowRadius = 20
+        self.view.layer.shadowOpacity = 0.5
+        
+        self.view.addSubview(rectangle)
+        self.view.addSubview(collectionView)
+        self.view.addSubview(confirmBtn)
+
+        rectangle.anchor(top: view.topAnchor, paddingTop: 15, width: 80, height: 5)
+        rectangle.centerX(inView: view)
+//        rectangle.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        collectionView.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingTop: 50, paddingLeft: 10, paddingRight: 10)
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.register(RegionCollectionViewCell.self, forCellWithReuseIdentifier: RegionCollectionViewCell.identifier)
+        confirmBtn.anchor(bottom: view.bottomAnchor, paddingBottom: 30, width: 280, height: 50)
+        confirmBtn.centerX(inView: view)
+    }
+    
+    
+    // MARK: - Action
+
+    @objc func regionChange() {
+        guard let selectedRegion = selectedRegion else { return }
+        regionChangeDelegate?.setMapRegion(selectedRegion.lat, selectedRegion.long, spanDelta: selectedRegion.span)
+        dismiss(animated: true)
+    }
+
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension RegionSelectViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        guard let regions = regions else { return 14 }
+        return regions.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RegionCollectionViewCell.identifier, for: indexPath) as? RegionCollectionViewCell else { return UICollectionViewCell() }
+        guard var regions = regions else { return UICollectionViewCell() }
+        cell.regionBtn.text = regions[indexPath.item].name
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension RegionSelectViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let regions = regions else { return }
+        selectedRegion = regions[indexPath.item]
+    }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension RegionSelectViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: view.bounds.width/2 - 10, height: 40)
+
+    }
+}

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -8,13 +8,7 @@
 import UIKit
 import MapKit
 
-protocol ClearSelectedAnnotation {
-    func clearAnnotation(view: MKAnnotation)
-}
 
-protocol UpdateFloating {
-    func checkInFloating()
-}
 
 class PlaceInfoModalViewController: UIViewController {
     

--- a/BNomad/View/PlaceViewBeforeCheckIn/CustomCollectionViewCell.swift
+++ b/BNomad/View/PlaceViewBeforeCheckIn/CustomCollectionViewCell.swift
@@ -77,7 +77,7 @@ class CustomCollectionViewCell: UICollectionViewCell {
         title.backgroundColor = .clear
         title.textColor = .black
         title.font = .preferredFont(forTextStyle: .title2, weight: .bold)
-        title.text = "스타스타"
+        title.text = "스타스타" // ???
         title.textAlignment = .center
         title.translatesAutoresizingMaskIntoConstraints = false
         return title

--- a/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
+++ b/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
@@ -74,6 +74,7 @@ class CustomModalViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // 맵 뷰에서 한 번 다 불러오는데 모달에서 또 따로 불러와야 하는지 고민 필요! (데이터를 아끼기 위해...)
         FirebaseManager.shared.fetchPlaceAll { place in
             self.places?.append(place)
         }

--- a/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
+++ b/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
@@ -17,6 +17,8 @@ class CustomModalViewController: UIViewController {
     var delegateForFloating: UpdateFloating?
     
     var position: CLLocation?
+    
+    lazy var viewModel: CombineViewModel = CombineViewModel.shared
 
     var places: [Place]? = [] {
         didSet {
@@ -25,7 +27,7 @@ class CustomModalViewController: UIViewController {
             self.numberOfPlaces.text = "업무 공간 " + String(places.count) + "개"
         }
     }
-
+    
     var rectangle: UIView = {
         let rectangle = UIView()
         rectangle.frame = CGRect(x: 0, y: 0, width: 80, height: 5)
@@ -74,10 +76,7 @@ class CustomModalViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // 맵 뷰에서 한 번 다 불러오는데 모달에서 또 따로 불러와야 하는지 고민 필요! (데이터를 아끼기 위해...)
-        FirebaseManager.shared.fetchPlaceAll { place in
-            self.places?.append(place)
-        }
+        places = viewModel.places
         
 //        self.view.layer.backgroundColor = UIColor(red: 0.967, green: 0.967, blue: 0.967, alpha: 1).cgColor
         self.view.layer.backgroundColor = CustomColor.nomadGray3?.cgColor


### PR DESCRIPTION
## 관련 이슈들
- #165 

## 작업 내용
- 임시로 4개 지역 선정하여 맵 이동 (선택 후 확인 버튼)
- 지역 선정 모달 구현 (컬렉션뷰, 셀)
- 맵 신규 UI에 맞춰 버튼 위치 이동, 스택뷰 수정
- 지역 정보 커스텀 모델, 데이터 구축

## 리뷰 노트
- 체크인 상태에서 자신이 체크인한 장소를 기준으로 맵을 원복시키는 기능을 기존에 넣어놨는데, 지역 이동하고 여러 코워킹스페이스를 구경하다보니 계속 체크인 장소로 돌아가는게 불편하게 느껴져서 규칙을 수정해야 할 것 같기도 합니다.
  - 예: 다른 지역을 보다가 업무중 버튼을 눌러서 모달을 보고 나오면 타 지역 그대로 유지가 안되고 코워킹스페이스 중심으로 맵 원복
- 전국 단위에서 핀 클러스터가 보이다보니 클러스터를 눌러도 충분하게 확대가 안되네요. 이전에 얘기했던대로 일정 축척 이상으로 지도를 넓게 보면 핀 annotation 대신 지역명을 눌러서 지역 단위로 먼저 확대를 시켜줘야 할 것 같기도 합니다. 그 뒤에 핀을 띄우는 방식으로...
- 마찬가지로 전국을 보다가 쉽게 남한이 아닌 북한, 일본, 중국으로 넘어갈 수 있는 걸 막아야 할 것 같습니다.
- 현재 핀 정보를 firebase에 정리해 넣듯이 지역 정보도 신규등록, 저장, 관리하기 좋은 방식이 있을 것 같은데 조언 부탁드립니다. 다만 지역은 코워킹 스페이스만큼 종류가 많지 않고 한 번 세팅하면 수정도 많지는 않을 것 같아서 현재는 RegionData 로 써넣었습니다.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012800/200759382-eb9ac5b3-02b4-445b-bf00-9e1fb1c8c225.gif" width="300">


## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
