### PR TITLE
[Feat] #178 SignUpView 수정

### DIFF
--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -35,7 +35,10 @@ class SignUpViewController: UIViewController {
     private let occupationLimit = 40
     private let statusLimit = 150
     private let introPlaceholder = "자기소개를 작성해주세요!"
-        
+    
+    private var keyboardHeight: CGFloat = 0
+    private var moveValue: CGFloat = 0
+
     lazy var requestLabel: UILabel = {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .title1, weight: .bold)
@@ -266,6 +269,8 @@ class SignUpViewController: UIViewController {
         
         hideKeyboardWhenTappedAround()
         configCancelButton()
+        
+        setKeyboardObserver()
     }
     
     // MARK: - Methods
@@ -476,7 +481,18 @@ class SignUpViewController: UIViewController {
         inputConfirmButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingLeft: 20, paddingBottom: 33, paddingRight: 20, height: 48)
     }
     
+    func setKeyboardObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+    }
+    
     // MARK: - Actions
+    
+    @objc func keyboardWillShow(notification: NSNotification)  {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            keyboardHeight = keyboardRectangle.height
+        }
+    }
     
     @objc func dismissPage() {
         self.dismiss(animated: true)
@@ -616,6 +632,20 @@ extension SignUpViewController: UITextViewDelegate {
         }
         introRectangle.layer.borderColor = CustomColor.nomadBlue?.cgColor
         showKeyboardAcc()
+        
+        let screenHeight = UIScreen.main.bounds.height
+        let keyboardAndAccHeight = keyboardHeight + self.keyboardAccView.frame.height
+        let keyboardAndAccY = screenHeight - keyboardAndAccHeight
+        let introY = statusCounterLabel.frame.minY + statusCounterLabel.frame.height
+        
+        if introY > keyboardAndAccY {
+            moveValue = introY - keyboardAndAccY
+            UIView.animate(withDuration: 0.2) {
+                self.view.window?.frame.origin.y -= self.moveValue
+            }
+        } else {
+            moveValue = 0
+        }
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
@@ -625,6 +655,10 @@ extension SignUpViewController: UITextViewDelegate {
         }
         introRectangle.layer.borderColor = CustomColor.nomadGray1?.cgColor
         showInputConfirmButton()
+        
+        UIView.animate(withDuration: 0.2) {
+            self.view.window?.frame.origin.y += self.moveValue
+        }
     }
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -458,6 +458,24 @@ class SignUpViewController: UIViewController {
         )
     }
     
+    func showKeyboardAcc() {
+        keyboardAccView.addSubview(inputConfirmButton)
+        guard let inputConfirmButtonSuperview = inputConfirmButton.superview else { return }
+        inputConfirmButton.anchor(
+            top: inputConfirmButtonSuperview.topAnchor,
+            left: inputConfirmButtonSuperview.leftAnchor,
+            right: inputConfirmButtonSuperview.rightAnchor,
+            paddingLeft: 20,
+            paddingRight: 20,
+            height: 48
+        )
+    }
+    
+    func showInputConfirmButton() {
+        view.addSubview(inputConfirmButton)
+        inputConfirmButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingLeft: 20, paddingBottom: 33, paddingRight: 20, height: 48)
+    }
+    
     // MARK: - Actions
     
     @objc func dismissPage() {
@@ -526,7 +544,7 @@ class SignUpViewController: UIViewController {
                     isIntroDone = true
                 }
                 
-                if nickname.isEmpty == false && occupation.isEmpty == false && isIntroDone == true {
+                if !nickname.isEmpty && !occupation.isEmpty && isIntroDone == true {
                     print("입력완료")
                     let user = setUser(nickname: nickname, occupation: occupation, intro: intro)
                     viewModel.user = user
@@ -553,16 +571,7 @@ extension SignUpViewController: UITextFieldDelegate {
             statusLineView.backgroundColor = CustomColor.nomadBlue
         }
         
-        keyboardAccView.addSubview(inputConfirmButton)
-        guard let inputConfirmButtonSuperview = inputConfirmButton.superview else { return }
-        inputConfirmButton.anchor(
-            top: inputConfirmButtonSuperview.topAnchor,
-            left: inputConfirmButtonSuperview.leftAnchor,
-            right: inputConfirmButtonSuperview.rightAnchor,
-            paddingLeft: 20,
-            paddingRight: 20,
-            height: 48
-        )
+        showKeyboardAcc()
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
@@ -573,9 +582,7 @@ extension SignUpViewController: UITextFieldDelegate {
         } else {
             statusLineView.backgroundColor = CustomColor.nomadGray1
         }
-        
-        view.addSubview(inputConfirmButton)
-        inputConfirmButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingLeft: 20, paddingBottom: 33, paddingRight: 20, height: 48)
+        showInputConfirmButton()
     }
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
@@ -608,6 +615,7 @@ extension SignUpViewController: UITextViewDelegate {
             textView.textColor = CustomColor.nomadBlack
         }
         introRectangle.layer.borderColor = CustomColor.nomadBlue?.cgColor
+        showKeyboardAcc()
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
@@ -616,6 +624,7 @@ extension SignUpViewController: UITextViewDelegate {
             textView.textColor = .tertiaryLabel
         }
         introRectangle.layer.borderColor = CustomColor.nomadGray1?.cgColor
+        showInputConfirmButton()
     }
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -71,8 +71,17 @@ class SignUpViewController: UIViewController {
         return view
     }()
     
+    lazy var dot4View: UIView = {
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
+        view.backgroundColor = CustomColor.nomadGray2
+        view.layer.cornerRadius = 2.5
+        view.contentMode = .scaleAspectFit
+
+        return view
+    }()
+    
     lazy var dotsStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [dot1View, dot2View, dot3View])
+        let stackView = UIStackView(arrangedSubviews: [dot1View, dot2View, dot3View, dot4View])
         stackView.axis = .horizontal
         stackView.spacing = 8.0
         stackView.alignment = .fill
@@ -82,6 +91,7 @@ class SignUpViewController: UIViewController {
         dot1View.anchor(width: 5, height: 5)
         dot2View.anchor(width: 5, height: 5)
         dot3View.anchor(width: 5, height: 5)
+        dot4View.anchor(width: 5, height: 5)
 
         return stackView
     }()
@@ -183,6 +193,22 @@ class SignUpViewController: UIViewController {
         return label
     }()
     
+    private lazy var profileImageButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "person.circle.fill"), for: .normal)
+        button.tintColor = CustomColor.nomadGray2
+        
+        return button
+    }()
+    
+    private let plusView: UIImageView = {
+        let view = UIImageView()
+        view.image = UIImage(systemName: "plus.circle.fill")
+        view.tintColor = CustomColor.nomadBlue
+        
+        return view
+    }()
+    
     private var inputConfirmButton: UIButton = {
         let button = UIButton()
         button.setTitle("다음", for: .normal)
@@ -197,8 +223,6 @@ class SignUpViewController: UIViewController {
         let view = UIView(frame: CGRect(x: 0.0, y: 0.0, width: UIScreen.main.bounds.width, height: 58))
         
 //        view.addSubview(inputConfirmButton)
-        
-        
         return view
     }()
     
@@ -234,6 +258,8 @@ class SignUpViewController: UIViewController {
         statusCounterLabel.isHidden = true
         introRectangle.isHidden = true
         introductionField.isHidden = true
+        profileImageButton.isHidden = true
+        plusView.isHidden = true
         
         inputConfirmButton.addTarget(self, action: #selector(didTapInputConfirmButton), for: .touchUpInside)
         
@@ -250,6 +276,11 @@ class SignUpViewController: UIViewController {
         let user = User(userUid: userUid, nickname: nickname, occupation: occupation, introduction: intro)
         FirebaseManager.shared.setUser(user: user)
         return user
+    }
+    
+    func configHiddenUI() {
+        
+        
     }
     
     func configUI() {
@@ -370,21 +401,27 @@ class SignUpViewController: UIViewController {
             paddingTop: 8
         )
         
-//        keyboardAccView.addSubview(inputConfirmButton)
+        let profileImageSize = viewWidth * 127/390
+        let plusImageSize = profileImageSize * 30/127
         
-//        guard let inputConfirmButtonSuperview = inputConfirmButton.superview
-//        else {
-//            return
-//        }
-//
-//        inputConfirmButton.anchor(
-//            top: inputConfirmButtonSuperview.topAnchor,
-//            left: inputConfirmButtonSuperview.leftAnchor,
-//            right: inputConfirmButtonSuperview.rightAnchor,
-//            paddingLeft: 20,
-//            paddingRight: 20,
-//            height: 48
-//        )
+        view.addSubview(profileImageButton)
+
+        profileImageButton.setPreferredSymbolConfiguration(.init(pointSize: profileImageSize, weight: .regular, scale: .default), forImageIn: .normal)
+        profileImageButton.centerX(inView: view)
+        profileImageButton.anchor(
+            top: requestLabel.bottomAnchor,
+            paddingTop: 35
+        )
+        
+        view.addSubview(plusView)
+        plusView.anchor(
+            bottom: profileImageButton.bottomAnchor,
+            right: profileImageButton.rightAnchor,
+            paddingBottom: 15,
+            paddingRight: 10,
+            width: plusImageSize,
+            height: plusImageSize
+        )
 
     }
     
@@ -468,6 +505,19 @@ class SignUpViewController: UIViewController {
                 requestLabel.asColor(targetString: requestItem[index], color: CustomColor.nomadBlue ?? .label)
             }
             
+        } else if introductionField.isHidden == false && profileImageButton.isHidden == true {
+            if introductionField.text.isEmpty == true {
+                print("자기소개를 입력하세요.")
+            } else {
+                profileImageButton.isHidden = false
+                plusView.isHidden = false
+                dot3View.backgroundColor = CustomColor.nomadGray2
+                dot4View.backgroundColor = CustomColor.nomadBlue
+                
+                index = 3
+                updateRequestLabel(index: index)
+                requestLabel.asColor(targetString: requestItem[index], color: CustomColor.nomadBlue ?? .label)
+            }
         } else {
             if let nickname = nicknameField.text, let occupation = occupationField.text, let intro = introductionField.text {
                 var isIntroDone = false

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -28,11 +28,13 @@ class SignUpViewController: UIViewController {
         return button
     }()
 
-    private let requestItem = ["닉네임", "직업", "상태"]
+    private let requestItem = ["닉네임", "직업", "상태", "멋진 사진"]
+    private let requestSentence = ["닉네임을 알려주세요!", "직업을 알려주세요!", "상태를 알려주세요!", "멋진 사진을 올려주세요!"]
     private var index = 0
     private let nicknameLimit = 20
     private let occupationLimit = 40
-    private let statusLimit = 50
+    private let statusLimit = 150
+    private let introPlaceholder = "자기소개를 작성해주세요!"
         
     lazy var requestLabel: UILabel = {
         let label = UILabel()
@@ -153,6 +155,25 @@ class SignUpViewController: UIViewController {
         return view
     }()
     
+    private lazy var introductionField: UITextView = {
+        let textView = UITextView()
+        textView.text = introPlaceholder
+        textView.textColor = .tertiaryLabel
+        textView.font = .preferredFont(forTextStyle: .footnote)
+        textView.backgroundColor = .clear
+        
+        return textView
+    }()
+    
+    private var introRectangle: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.layer.borderWidth = 2
+        view.layer.borderColor = CustomColor.nomadBlue?.cgColor
+        
+        return view
+    }()
+    
     private lazy var statusCounterLabel: UILabel = {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
@@ -162,9 +183,9 @@ class SignUpViewController: UIViewController {
         return label
     }()
     
-    private let inputConfirmButton: UIButton = {
+    private var inputConfirmButton: UIButton = {
         let button = UIButton()
-        button.setTitle("확인", for: .normal)
+        button.setTitle("다음", for: .normal)
         button.titleLabel?.font = .preferredFont(forTextStyle: .body, weight: .semibold)
         button.backgroundColor = CustomColor.nomadBlue
         button.layer.cornerRadius = 8
@@ -173,7 +194,7 @@ class SignUpViewController: UIViewController {
     }()
     
     private lazy var keyboardAccView: UIView = {
-        let view = UIView(frame: CGRect(x: 0.0, y: 0.0, width: UIScreen.main.bounds.width, height: 80.0))
+        let view = UIView(frame: CGRect(x: 0.0, y: 0.0, width: UIScreen.main.bounds.width, height: 58))
         
 //        view.addSubview(inputConfirmButton)
         
@@ -203,6 +224,7 @@ class SignUpViewController: UIViewController {
         nicknameField.delegate = self
         occupationField.delegate = self
         statusField.delegate = self
+        introductionField.delegate = self
         
         occupationField.isHidden = true
         occupationLineView.isHidden = true
@@ -210,6 +232,8 @@ class SignUpViewController: UIViewController {
         statusField.isHidden = true
         statusLineView.isHidden = true
         statusCounterLabel.isHidden = true
+        introRectangle.isHidden = true
+        introductionField.isHidden = true
         
         inputConfirmButton.addTarget(self, action: #selector(didTapInputConfirmButton), for: .touchUpInside)
         
@@ -317,10 +341,32 @@ class SignUpViewController: UIViewController {
             height: lineHeight
         )
         
+        view.addSubview(introRectangle)
+        introRectangle.anchor(
+            top: occupationField.bottomAnchor,
+            left: requestLabel.leftAnchor,
+            paddingTop: textFieldTopSpacing,
+            width: textFieldWidth,
+            height: 106
+        )
+        
+        view.addSubview(introductionField)
+        introductionField.inputAccessoryView = keyboardAccView
+        introductionField.anchor(
+            top: introRectangle.topAnchor,
+            left: introRectangle.leftAnchor,
+            bottom: introRectangle.bottomAnchor,
+            right: introRectangle.rightAnchor,
+            paddingTop: 4,
+            paddingLeft: 8,
+            paddingBottom: 4,
+            paddingRight: 8
+        )
+        
         view.addSubview(statusCounterLabel)
         statusCounterLabel.anchor(
-            top: statusLineView.bottomAnchor,
-            right: statusLineView.rightAnchor,
+            top: introRectangle.bottomAnchor,
+            right: introRectangle.rightAnchor,
             paddingTop: 8
         )
         
@@ -343,7 +389,7 @@ class SignUpViewController: UIViewController {
     }
     
     func updateRequestLabel(index: Int) {
-        requestLabel.text = "노마드가 되기 위해\n\(requestItem[index])을 알려주세요!"
+        requestLabel.text = "노마드가 되기 위해\n\(requestSentence[index])"
     }
     
     func showAlert() {
@@ -354,9 +400,9 @@ class SignUpViewController: UIViewController {
         alertLabel.alpha = 1.0
         self.view.addSubview(alertLabel)
         alertLabel.anchor(
-            top: statusLineView.bottomAnchor,
-            left: statusLineView.leftAnchor,
-            paddingTop: 21
+            top: introRectangle.bottomAnchor,
+            left: introRectangle.leftAnchor,
+            paddingTop: 8
         )
 
         UIView.animate(withDuration: 1.0, delay: 1, options: .curveEaseOut, animations: {
@@ -403,14 +449,17 @@ class SignUpViewController: UIViewController {
                 requestLabel.asColor(targetString: requestItem[index], color: CustomColor.nomadBlue ?? .label)
             }
             
-        } else if occupationField.isHidden == false && statusField.isHidden == true {
+        } else if occupationField.isHidden == false && introductionField.isHidden == true {
             if occupationField.text?.isEmpty == true {
                 print("직업을 입력하세요.")
             } else {
-                statusField.isHidden = false
-                statusLineView.isHidden = false
+//                statusField.isHidden = false
+//                statusLineView.isHidden = false
                 statusCounterLabel.isHidden = false
-                statusField.becomeFirstResponder()
+//                statusField.becomeFirstResponder()
+                introRectangle.isHidden = false
+                introductionField.isHidden = false
+                introductionField.becomeFirstResponder()
                 dot2View.backgroundColor = CustomColor.nomadGray2
                 dot3View.backgroundColor = CustomColor.nomadBlue
                 
@@ -420,8 +469,14 @@ class SignUpViewController: UIViewController {
             }
             
         } else {
-            if let nickname = nicknameField.text, let occupation = occupationField.text, let intro = statusField.text {
-                if nickname.isEmpty == false && occupation.isEmpty == false && intro.isEmpty == false {
+            if let nickname = nicknameField.text, let occupation = occupationField.text, let intro = introductionField.text {
+                var isIntroDone = false
+                if intro != introPlaceholder && intro.isEmpty == false {
+                    isIntroDone = true
+                }
+                
+                if nickname.isEmpty == false && occupation.isEmpty == false && isIntroDone == true {
+                    print("입력완료")
                     let user = setUser(nickname: nickname, occupation: occupation, intro: intro)
                     viewModel.user = user
                     Analytics.logEvent("signUpCompleted", parameters: nil)
@@ -482,10 +537,11 @@ extension SignUpViewController: UITextFieldDelegate {
         } else if textField == occupationField {
             occupationCounterLabel.text = "\(updateText.count) / \(occupationLimit)"
             return updateText.count < occupationLimit
-        } else if textField == statusField {
-            statusCounterLabel.text = "\(updateText.count) / \(statusLimit)"
-            return updateText.count < statusLimit
         }
+//        else if textField == statusField {
+//            statusCounterLabel.text = "\(updateText.count) / \(statusLimit)"
+//            return updateText.count < statusLimit
+//        }
         
         return true
     }
@@ -494,4 +550,34 @@ extension SignUpViewController: UITextFieldDelegate {
         didTapInputConfirmButton()
         return true
     }
+}
+
+// MARK: - UITextViewDelegate
+
+extension SignUpViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .tertiaryLabel {
+            textView.text = nil
+            textView.textColor = CustomColor.nomadBlack
+        }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = introPlaceholder
+            textView.textColor = .tertiaryLabel
+        }
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let currentText = textView.text ?? ""
+        guard let stringRange = Range(range, in: currentText) else { return false }
+        let updateText = currentText.replacingCharacters(in: stringRange, with: text)
+        if textView == introductionField {
+            statusCounterLabel.text = "\(updateText.count) / \(statusLimit)"
+            return updateText.count < statusLimit
+        }
+        return true
+    }
+    
 }

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -167,12 +167,18 @@ class SignUpViewController: UIViewController {
         button.setTitle("확인", for: .normal)
         button.titleLabel?.font = .preferredFont(forTextStyle: .body, weight: .semibold)
         button.backgroundColor = CustomColor.nomadBlue
+        button.layer.cornerRadius = 8
         
         return button
     }()
     
-    private var keyboardAccView: UIView = {
-        return UIView(frame: CGRect(x: 0.0, y: 0.0, width: UIScreen.main.bounds.width, height: 56.0))
+    private lazy var keyboardAccView: UIView = {
+        let view = UIView(frame: CGRect(x: 0.0, y: 0.0, width: UIScreen.main.bounds.width, height: 80.0))
+        
+//        view.addSubview(inputConfirmButton)
+        
+        
+        return view
     }()
     
     // MARK: - LifeCycle
@@ -318,18 +324,22 @@ class SignUpViewController: UIViewController {
             paddingTop: 8
         )
         
-        keyboardAccView.addSubview(inputConfirmButton)
+//        keyboardAccView.addSubview(inputConfirmButton)
         
-        guard let inputConfirmButtonSuperview = inputConfirmButton.superview
-        else {
-            return
-        }
-        
-        inputConfirmButton.anchor(
-            left: inputConfirmButtonSuperview.leftAnchor,
-            right: inputConfirmButtonSuperview.rightAnchor,
-            height: inputConfirmButtonSuperview.bounds.height
-        )
+//        guard let inputConfirmButtonSuperview = inputConfirmButton.superview
+//        else {
+//            return
+//        }
+//
+//        inputConfirmButton.anchor(
+//            top: inputConfirmButtonSuperview.topAnchor,
+//            left: inputConfirmButtonSuperview.leftAnchor,
+//            right: inputConfirmButtonSuperview.rightAnchor,
+//            paddingLeft: 20,
+//            paddingRight: 20,
+//            height: 48
+//        )
+
     }
     
     func updateRequestLabel(index: Int) {
@@ -436,6 +446,17 @@ extension SignUpViewController: UITextFieldDelegate {
         } else {
             statusLineView.backgroundColor = CustomColor.nomadBlue
         }
+        
+        keyboardAccView.addSubview(inputConfirmButton)
+        guard let inputConfirmButtonSuperview = inputConfirmButton.superview else { return }
+        inputConfirmButton.anchor(
+            top: inputConfirmButtonSuperview.topAnchor,
+            left: inputConfirmButtonSuperview.leftAnchor,
+            right: inputConfirmButtonSuperview.rightAnchor,
+            paddingLeft: 20,
+            paddingRight: 20,
+            height: 48
+        )
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
@@ -446,6 +467,9 @@ extension SignUpViewController: UITextFieldDelegate {
         } else {
             statusLineView.backgroundColor = CustomColor.nomadGray1
         }
+        
+        view.addSubview(inputConfirmButton)
+        inputConfirmButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingLeft: 20, paddingBottom: 33, paddingRight: 20, height: 48)
     }
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {


### PR DESCRIPTION
## 관련 이슈들
- #178 

## 작업 내용
- 단계 이동시 누르는 버튼 디자인을 수정했습니다. 단계 이동시 "다음", 전체 완료 시 "확인"으로 타이틀이 바뀝니다.
- 상태 입력칸을 자기소개(textView)로 수정하고 150자 제한을 반영했습니다.
- 4번째 입력 단계(프로필 사진 등록)를 추가했습니다.
- 4번째 단계 추가에 따라 상단 문구 수정, 우측상단 점 등 수정했습니다.

## 리뷰 노트
- 자기소개(textView) 입력 시에도 키보드 악세서리로 다음 버튼이 나오게 하고 싶은데 안나오네요.. 근데 일단 키보드와 다음 버튼이 자기소개 칸을 
가릴까봐 그냥 이대로 두었습니다. 
- 피그마 디자인과 프로필 사진 선택 버튼 위치가 다른데, 윌로우가 디자인 변경해도 된다고 했기도 하고 아래와 같은 사유로 지금처럼 작업했습니다.
    - 1) 다음 누를때마다 아래에 칸이 추가되다가 갑자기 위에서 나타나면 이상할 것 같음
    - 2) textField들이 화면 하단으로 내려가는 경우 스크롤이 안되는 현재 상황에서 키보드가 입력칸들을 가리게 됨

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012157/200764076-5a460fd3-3699-4d74-b14b-bd04a4a9577a.gif" width="300">

*자기소개 입력 시 키보드 올라오면 가려지므로 뷰 올라가도록 수정(11/10 오전)
<img src="https://user-images.githubusercontent.com/103012157/200987454-95fea1bc-6a77-4448-9056-24ca71d13fdc.gif" width="300">


## Reference
- [키보드가 textView를 가릴 때 뷰 올리기](https://medium.com/swiftcommmunity/swift-keyboard-control-of-textfields-and-textviews-c20112528392)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
