### PR TITLE
[Bug] 지역선택 버튼 버그 수정

### DIFF
--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -102,12 +102,10 @@ class MapViewController: UIViewController {
     // 지역명 표기 및 지역 변경 버튼
     
     private let regionChangeBtn: UIButton = {
-        var configuration = UIButton.Configuration.plain()
-        configuration.titleAlignment = .leading
-        configuration.imagePlacement = .trailing
-
-        var btn = UIButton(configuration: configuration)
+        var btn = UIButton()
         btn.setTitle("지역 선택 ", for: .normal)
+        btn.semanticContentAttribute = .forceRightToLeft
+        btn.titleLabel?.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
         btn.setTitleColor(.black, for: .normal)
         btn.setImage(UIImage(systemName: "chevron.down"), for: .normal)
         btn.tintColor = CustomColor.nomadBlue
@@ -133,13 +131,6 @@ class MapViewController: UIViewController {
     }
     
     lazy var upperStack: UIStackView = {
-        let topLeftTitle = UIStackView(arrangedSubviews: [regionChangeBtn])
-        topLeftTitle.axis = .horizontal
-        topLeftTitle.alignment = .center
-        topLeftTitle.spacing = 10
-        topLeftTitle.distribution = .fillProportionally
-        topLeftTitle.anchor(width: 120)
-        topLeftTitle.translatesAutoresizingMaskIntoConstraints = false
 
         let topRightBtn = UIStackView(arrangedSubviews: [profileBtn, divider, settingBtn])
         topRightBtn.axis = .horizontal
@@ -150,7 +141,7 @@ class MapViewController: UIViewController {
         topRightBtn.anchor(width: 60)
         topRightBtn.translatesAutoresizingMaskIntoConstraints = false
         
-        let upperStack = UIStackView(arrangedSubviews: [topLeftTitle, topRightBtn])
+        let upperStack = UIStackView(arrangedSubviews: [regionChangeBtn, topRightBtn])
         upperStack.axis = .horizontal
         upperStack.alignment = .fill
         upperStack.distribution = .equalSpacing

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -99,24 +99,25 @@ class MapViewController: UIViewController {
     
 
     
-    // 지역명 표기 및 지역 변경
-    lazy var regionTitle: UILabel = {
-        let title = UILabel()
-        title.text = selectedRegion?.name ?? "지역 선택"
-        title.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
-        return title
-    }()
+    // 지역명 표기 및 지역 변경 버튼
     
-    var regionChangeBtn: UIButton = {
-        let btn = UIButton()
+    private let regionChangeBtn: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.titleAlignment = .leading
+        configuration.imagePlacement = .trailing
+
+        var btn = UIButton(configuration: configuration)
+        btn.setTitle("지역 선택 ", for: .normal)
+        btn.setTitleColor(.black, for: .normal)
         btn.setImage(UIImage(systemName: "chevron.down"), for: .normal)
-        btn.changesSelectionAsPrimaryAction = true
         btn.tintColor = CustomColor.nomadBlue
         btn.addTarget(self, action: #selector(presentRegionSelector), for: .touchUpInside)
         return btn
     }()
     
     @objc private func presentRegionSelector() {
+        self.dismiss(animated: false)
+
         let sheet = RegionSelectViewController()
         sheet.modalPresentationStyle = .pageSheet
         if let sheet = sheet.sheetPresentationController {
@@ -132,12 +133,12 @@ class MapViewController: UIViewController {
     }
     
     lazy var upperStack: UIStackView = {
-        let topLeftTitle = UIStackView(arrangedSubviews: [regionTitle, regionChangeBtn])
+        let topLeftTitle = UIStackView(arrangedSubviews: [regionChangeBtn])
         topLeftTitle.axis = .horizontal
         topLeftTitle.alignment = .center
         topLeftTitle.spacing = 10
         topLeftTitle.distribution = .fillProportionally
-        topLeftTitle.anchor(width: 100)
+        topLeftTitle.anchor(width: 120)
         topLeftTitle.translatesAutoresizingMaskIntoConstraints = false
 
         let topRightBtn = UIStackView(arrangedSubviews: [profileBtn, divider, settingBtn])

--- a/BNomad/View/MapView/RegionCollectionViewCell.swift
+++ b/BNomad/View/MapView/RegionCollectionViewCell.swift
@@ -29,6 +29,7 @@ class RegionCollectionViewCell: UICollectionViewCell {
     lazy var regionBtn: UILabel = {
         let btn = UILabel()
         btn.text = "지역명"
+        btn.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
         btn.clipsToBounds = true
         btn.layer.cornerRadius = 20
         btn.backgroundColor = .white

--- a/BNomad/View/MapView/RegionSelectViewController.swift
+++ b/BNomad/View/MapView/RegionSelectViewController.swift
@@ -48,6 +48,7 @@ class RegionSelectViewController: UIViewController {
     private let confirmBtn: UIButton = {
         let btn = UIButton()
         btn.setTitle("확인", for: .normal)
+        btn.titleLabel?.asFont(targetString: "확인", font: .preferredFont(forTextStyle: .body, weight: .bold))
         btn.backgroundColor = CustomColor.nomadBlue
         btn.setTitleColor(.white, for: .normal)
         btn.layer.cornerRadius = 12

--- a/BNomad/View/MapView/RegionSelectViewController.swift
+++ b/BNomad/View/MapView/RegionSelectViewController.swift
@@ -48,7 +48,7 @@ class RegionSelectViewController: UIViewController {
     private let confirmBtn: UIButton = {
         let btn = UIButton()
         btn.setTitle("확인", for: .normal)
-        btn.titleLabel?.asFont(targetString: "확인", font: .preferredFont(forTextStyle: .body, weight: .bold))
+        btn.titleLabel?.font = .preferredFont(forTextStyle: .body, weight: .bold)
         btn.backgroundColor = CustomColor.nomadBlue
         btn.setTitleColor(.white, for: .normal)
         btn.layer.cornerRadius = 12


### PR DESCRIPTION
## 관련 이슈들
- #165 

## 작업 내용
- 텍스트까지 버튼으로 묶음
- 다른 모달 뜬 상태에서 지역버튼 클릭 가능
- 텍스트 스타일 수정

## 리뷰 노트
- '지역 선택' 텍스트를 chevron.down 과 함께 묶어 버튼 처리를 했더니 폰트 스타일 적용이 제대로 안되는 것 같습니다. asFont func도 안되고... 좀 더 알아보겠습니다.

## 스크린샷(UX의 경우 gif)
<img src='https://user-images.githubusercontent.com/103012800/201006831-ed51c93d-96d1-4399-ad76-420096fcc8d5.png' width='300'>



## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
