### PR TITLE
[Feat] 비로그인 상태에서 로그인 뷰로 넘어가는 alert 구현

### DIFF
--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -171,6 +171,7 @@ class MapViewController: UIViewController {
     private let blurBackground: UIVisualEffectView = {
         let blur = UIBlurEffect(style: .light)
         let background = UIVisualEffectView(effect: blur)
+        background.alpha = 0.7 // 기본 blur alpha 값 1.0 -> 0.7로 변경
         background.translatesAutoresizingMaskIntoConstraints = false
         return background
     }()

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -74,12 +74,22 @@ class MapViewController: UIViewController {
         } else {
             
             // TODO: - 회원가입 창 띄우기 전에 모달 띄우기
-            
-            let controller = SignUpViewController()
-            controller.modalPresentationStyle = .fullScreen
-            present(controller, animated: true)
+            loginCheck()
         }
         map.selectedAnnotations = []
+    }
+    
+    func loginCheck() {
+        print("loginCheck")
+        let checkOutAlert = UIAlertController(title: "로그인하시겠습니까?", message: "로그인하시면 프로필을 보실 수 있습니다.", preferredStyle: .alert)
+        checkOutAlert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        checkOutAlert.addAction(UIAlertAction(title: "로그인", style: .default, handler: { action in
+            
+            let controller = SignUpViewController() // 추후 로그인뷰로 변경
+            controller.modalPresentationStyle = .fullScreen
+            self.present(controller, animated: true)
+        }))
+        present(checkOutAlert, animated: true)
     }
     
     private let divider: UIButton = {

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -132,12 +132,23 @@ class PlaceInfoModalViewController: UIViewController {
     @objc func checkIn() {
         print("CHECK IN")        
         if !viewModel.isLogIn {
-            let signUpViewController = SignUpViewController()
-            signUpViewController.modalPresentationStyle = .fullScreen
-            present(signUpViewController, animated: true)
+            loginCheck()
         } else {
             distanceChecker()
         }
+    }
+    
+    // 로그인 체크
+    func loginCheck() {
+        print("loginCheck")
+        let checkOutAlert = UIAlertController(title: "로그인하시겠습니까?", message: "로그인하시면 체크인하실 수 있습니다.", preferredStyle: .alert)
+        checkOutAlert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        checkOutAlert.addAction(UIAlertAction(title: "로그인", style: .default, handler: { action in
+            let controller = SignUpViewController() // 추후 로그인뷰로 변경
+            controller.modalPresentationStyle = .fullScreen
+            self.present(controller, animated: true)
+        }))
+        present(checkOutAlert, animated: true)
     }
     
     // 맵의 특정 장소가 500미터 반경 이내인지 체크


### PR DESCRIPTION
## 관련 이슈들
- #188 

## 작업 내용
- 비로그인 상태에서 1) 프로필 버튼, 2) 체크인 버튼 누를 때 로그인 하시겠냐는 alert 을 만들어 띄웁니다.
- 로그인 하겠다고 누르면 로그인뷰로 이동시킵니다. (현재는 회원가입 뷰로 이동)

## 리뷰 노트
- 프로필 보기, 체크인 하기 외에도 로그인이 필요한 action이 있을지 더 고민해봐야 합니다. (예: 설정 뷰 안에서 회원 관련 메뉴들...?)

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012800/201012996-a4b76f8c-360c-483b-ad64-157b26e30580.png" width="300">

<img src="https://user-images.githubusercontent.com/103012800/201013029-37d2a1e0-1f5c-4e83-9670-9176218baf9b.png" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
