### PR TITLE
[Feat]캘린더 비짓카드뷰 구현 및 네비게이션 루트 변경

### DIFF
--- a/BNomad/View/ProfileView/ProfileGraphCell.swift
+++ b/BNomad/View/ProfileView/ProfileGraphCell.swift
@@ -62,7 +62,6 @@ class ProfileGraphCell: UICollectionViewCell {
         for index in 0..<7 {
             let day = UILabel()
             day.text = Contents.dateLabelMaker()[index][3]
-            day.textColor = .black
             
             let formatter = DateFormatter()
             formatter.dateFormat = "d"

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -51,6 +51,14 @@ class ProfileViewController: UIViewController {
         return label
     }()
     
+    private let visitCardCellHeaderLabel: UILabel = {
+        let label = UILabel()
+        label.text = "체크인 기록"
+        label.font = .preferredFont(forTextStyle: .headline, weight: .regular)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
     private let profileCollectionView:  UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
@@ -70,7 +78,7 @@ class ProfileViewController: UIViewController {
         layout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.isScrollEnabled = false
-        collectionView.backgroundColor = .white
+//        collectionView.backgroundColor = .white
         collectionView.register(ProfileGraphCollectionCell.self, forCellWithReuseIdentifier: ProfileGraphCollectionCell.identifier)
 
         collectionView.translatesAutoresizingMaskIntoConstraints = false
@@ -81,7 +89,7 @@ class ProfileViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        navigationItem.backButtonTitle = ""
         
         ProfileViewController.profileGraphCellHeaderMaker(label: profileGraphCellHeaderLabel, weekAdded: -ProfileViewController.weekAddedMemory)
         ProfileGraphCell.addedWeek = 0
@@ -103,9 +111,8 @@ class ProfileViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "calendar"), style: .plain, target: self, action: #selector(moveToCalendar))
+//        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "calendar"), style: .plain, target: self, action: #selector(moveToCalendar))
         navigationController?.navigationBar.tintColor = CustomColor.nomadBlue
-        navigationItem.backButtonTitle = "취소"
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -193,6 +200,9 @@ class ProfileViewController: UIViewController {
                                      paddingTop: 220, paddingLeft: 16, paddingRight: 16,
                                      height: 600)
         
+        view.addSubview(visitCardCellHeaderLabel)
+        visitCardCellHeaderLabel.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: 405, paddingLeft: 29)
+        
         
         view.addSubview(profileGraphCellHeaderLabel)
         profileGraphCellHeaderLabel.anchor(top: view.topAnchor, paddingTop: 570)
@@ -205,7 +215,7 @@ class ProfileViewController: UIViewController {
         plusWeek.anchor(top: view.topAnchor, right: view.rightAnchor, paddingTop: 570, paddingRight: 45)
         
         view.addSubview(profileGraphCollectionView)
-        profileGraphCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: 615, paddingLeft: 58, width: 345/390*view.frame.width, height: 154)
+        profileGraphCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: 615, paddingLeft: 58, width: 345/390*view.frame.width-35, height: 154)
     }
     
 }
@@ -243,7 +253,7 @@ extension ProfileViewController: UICollectionViewDelegate {
                 return UICollectionViewCell()
             }
                 cell.user = viewModel.user
-                cell.backgroundColor = .white
+                cell.backgroundColor = .systemBackground
                 cell.layer.cornerRadius = 20
                 cell.delegate = self
                 return cell
@@ -253,7 +263,7 @@ extension ProfileViewController: UICollectionViewDelegate {
                 }
                 
                 cell.checkInHistoryForProfile = viewModel.user?.checkInHistory
-                cell.backgroundColor = .white
+                cell.backgroundColor = .systemBackground
                 cell.layer.cornerRadius = 20
                 return cell
             } else {
@@ -269,7 +279,7 @@ extension ProfileViewController: UICollectionViewDelegate {
                 cell.thisCellsDate = dateString
                 cell.checkInHistory = viewModel.user?.checkInHistory
                 
-                cell.backgroundColor = .white
+                cell.backgroundColor = .systemBackground
                 cell.layer.cornerRadius = 20
                 return cell
             }
@@ -287,8 +297,14 @@ extension ProfileViewController: UICollectionViewDelegate {
             
             cell.cellDate = cellDate
             cell.checkInHistory = viewModel.user?.checkInHistory
-            cell.backgroundColor = .white
+            cell.backgroundColor = .systemBackground
             return cell
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if indexPath.section == 1 {
+            moveToCalendar()
         }
     }
   

--- a/BNomad/View/ProfileView/SelfUserInfoCell.swift
+++ b/BNomad/View/ProfileView/SelfUserInfoCell.swift
@@ -54,6 +54,14 @@ class SelfUserInfoCell: UICollectionViewCell {
         return label
     }()
     
+    private let dividerLine: UIView = {
+        let view = UIView()
+        view.backgroundColor = CustomColor.nomadGray1
+        view.layer.masksToBounds = false
+
+        return view
+    }()
+    
     private let statusLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0 //TODO: 행간 늘이기
@@ -67,6 +75,7 @@ class SelfUserInfoCell: UICollectionViewCell {
     // MARK: - LifeCycle
     
     override init(frame: CGRect) {
+        
         super.init(frame: frame)
         render()
     }
@@ -93,6 +102,9 @@ class SelfUserInfoCell: UICollectionViewCell {
         
         contentView.addSubview(jobLabel)
         jobLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 60, paddingLeft: 20, paddingRight: 20)
+        
+        contentView.addSubview(dividerLine)
+        dividerLine.anchor(top: jobLabel.bottomAnchor, left: contentView.leftAnchor, bottom: jobLabel.bottomAnchor, right: contentView.rightAnchor, paddingTop: 17, paddingLeft: 10, paddingBottom: -18, paddingRight: 10, width: 340, height: 1)
         
         contentView.addSubview(statusLabel)
         statusLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 110, paddingLeft: 20, paddingRight: 20)

--- a/BNomad/View/ProfileView/VisitingInfoCell.swift
+++ b/BNomad/View/ProfileView/VisitingInfoCell.swift
@@ -15,6 +15,24 @@ class VisitingInfoCell: UICollectionViewCell {
     var viewOption: String = ""
     lazy var viewModel = CombineViewModel.shared
     
+    var checkinHistoryForList: CheckIn? {
+        didSet {
+            guard let checkInHistory = checkinHistoryForList else { return }
+            let place = self.viewModel.places.first {$0.placeUid == checkInHistory.placeUid}
+            nameLabel.text = place?.name
+            
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "HH:mm"
+
+            let checkinTime = dateFormatter.string(from: checkInHistory.checkInTime)
+            self.checkinTimeLabel.text = checkinTime
+            
+            let stayedTime = Int((checkInHistory.checkOutTime?.timeIntervalSince(checkInHistory.checkInTime) ?? 0) / 60)
+            self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
+
+        }
+    }
+    
     var checkInHistoryForCalendar: [CheckIn]? {
         didSet {
             viewOption = "calendar"


### PR DESCRIPTION
## 관련 이슈들
- #197 

## 작업 내용
- 캘린더뷰로 넘어가는 버튼을 상단 네비게이션 아이콘에서 뷰 안의 카드로 전환하였습니다
- 비짓카드 리스트 뷰를 구현했습니다
: 현재 헤더와 섹션 없이 모든 카드가 일렬로 있는 상태입니다, 수정 필요함
- 캘린더뷰에서 빨간 사각 버튼을 누르면 전환됩니다

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/70618615/201021895-421dbcf3-13c0-4dfb-aae6-f29a0a65949e.png" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
