### PR TITLE
[Feat] #192 SettingView UI 작업

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -23,8 +23,8 @@
 		6383330C2900CD6D005AB0C3 /* PlaceInfoModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383330B2900CD6D005AB0C3 /* PlaceInfoModalViewController.swift */; };
 		6383330E2900CDBA005AB0C3 /* PlaceInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383330D2900CDBA005AB0C3 /* PlaceInfoCell.swift */; };
 		7E5CF5D42906886A00641E74 /* CheckInCardViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5CF5D32906886A00641E74 /* CheckInCardViewCell.swift */; };
-		7E97254E2919160800AA9F44 /* NewMeetUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E97254D2919160800AA9F44 /* NewMeetUpViewController.swift */; };
 		7E5CF5DA2918BE2E00641E74 /* ParticipantCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5CF5D92918BE2E00641E74 /* ParticipantCell.swift */; };
+		7E97254E2919160800AA9F44 /* NewMeetUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E97254D2919160800AA9F44 /* NewMeetUpViewController.swift */; };
 		7EC6F9EE28FE39CB003D8A95 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6F9ED28FE39CB003D8A95 /* UIFont+Extension.swift */; };
 		7EC6F9F028FE39F4003D8A95 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6F9EF28FE39F4003D8A95 /* UIColor+Extension.swift */; };
 		7EC6F9F228FE3A19003D8A95 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6F9F128FE3A19003D8A95 /* UILabel+Extension.swift */; };
@@ -45,6 +45,9 @@
 		DF9618AE28FCEFC200E21D30 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9618AD28FCEFC200E21D30 /* SignUpViewController.swift */; };
 		DF9618B028FCEFCB00E21D30 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9618AF28FCEFCB00E21D30 /* ProfileViewController.swift */; };
 		DF9618B228FCEFEA00E21D30 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9618B128FCEFEA00E21D30 /* FirebaseManager.swift */; };
+		DFD8E94D291CD3FE006BC8BB /* PlaceRequestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD8E94C291CD3FE006BC8BB /* PlaceRequestViewController.swift */; };
+		DFD8E94F291CEA3C006BC8BB /* WithdrawViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD8E94E291CEA3C006BC8BB /* WithdrawViewController.swift */; };
+		DFD8E951291D1C48006BC8BB /* RequestTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD8E950291D1C48006BC8BB /* RequestTextField.swift */; };
 		DFE747B928FD75980048E70A /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE747B828FD75980048E70A /* UIView+Extension.swift */; };
 		DFE747CA29000FC80048E70A /* ProfileEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE747C929000FC80048E70A /* ProfileEditViewController.swift */; };
 		E226DA6E29120A540071E289 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = E226DA6D29120A540071E289 /* FirebasePerformance */; };
@@ -89,8 +92,8 @@
 		6383330D2900CDBA005AB0C3 /* PlaceInfoCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceInfoCell.swift; sourceTree = "<group>"; };
 		7E5CF5D228FFB73400641E74 /* BNomad.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BNomad.entitlements; sourceTree = "<group>"; };
 		7E5CF5D32906886A00641E74 /* CheckInCardViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInCardViewCell.swift; sourceTree = "<group>"; };
-		7E97254D2919160800AA9F44 /* NewMeetUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMeetUpViewController.swift; sourceTree = "<group>"; };
 		7E5CF5D92918BE2E00641E74 /* ParticipantCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantCell.swift; sourceTree = "<group>"; };
+		7E97254D2919160800AA9F44 /* NewMeetUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMeetUpViewController.swift; sourceTree = "<group>"; };
 		7EC6F9ED28FE39CB003D8A95 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		7EC6F9EF28FE39F4003D8A95 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		7EC6F9F128FE3A19003D8A95 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
@@ -113,6 +116,9 @@
 		DF9618AD28FCEFC200E21D30 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		DF9618AF28FCEFCB00E21D30 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		DF9618B128FCEFEA00E21D30 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
+		DFD8E94C291CD3FE006BC8BB /* PlaceRequestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceRequestViewController.swift; sourceTree = "<group>"; };
+		DFD8E94E291CEA3C006BC8BB /* WithdrawViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawViewController.swift; sourceTree = "<group>"; };
+		DFD8E950291D1C48006BC8BB /* RequestTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTextField.swift; sourceTree = "<group>"; };
 		DFE747B828FD75980048E70A /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		DFE747C929000FC80048E70A /* ProfileEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewController.swift; sourceTree = "<group>"; };
 		E251E6D92907E49600638C15 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
@@ -192,6 +198,9 @@
 			isa = PBXGroup;
 			children = (
 				DF561CAA2918A0DA0099D41D /* SettingViewController.swift */,
+				DFD8E94C291CD3FE006BC8BB /* PlaceRequestViewController.swift */,
+				DFD8E94E291CEA3C006BC8BB /* WithdrawViewController.swift */,
+				DFD8E950291D1C48006BC8BB /* RequestTextField.swift */,
 			);
 			path = SettingView;
 			sourceTree = "<group>";
@@ -457,11 +466,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DFD8E94D291CD3FE006BC8BB /* PlaceRequestViewController.swift in Sources */,
 				E27CEED12919118C00369A6E /* MeetUp.swift in Sources */,
 				E25A675228F7E1CE004614B0 /* User.swift in Sources */,
 				E2E6B23028FE7542005C0D77 /* CheckIn.swift in Sources */,
 				DFE747B928FD75980048E70A /* UIView+Extension.swift in Sources */,
 				F6183CC328FFABEC00185A1F /* CustomCollectionViewCell.swift in Sources */,
+				DFD8E94F291CEA3C006BC8BB /* WithdrawViewController.swift in Sources */,
+				DFD8E951291D1C48006BC8BB /* RequestTextField.swift in Sources */,
 				7EC6F9F028FE39F4003D8A95 /* UIColor+Extension.swift in Sources */,
 				041351A928FFF4FB005D19CC /* CalendarCell.swift in Sources */,
 				0413519F28FE534D005D19CC /* SelfUserInfoCell.swift in Sources */,

--- a/BNomad/View/SettingView/PlaceRequestViewController.swift
+++ b/BNomad/View/SettingView/PlaceRequestViewController.swift
@@ -1,0 +1,156 @@
+//
+//  PlaceRequestViewController.swift
+//  BNomad
+//
+//  Created by 박성수 on 2022/11/10.
+//
+
+import UIKit
+
+class PlaceRequestViewController: UIViewController {
+
+    // MARK: - Properties
+    
+    enum Size {
+        static let paddingNormal: CGFloat = 20
+        static let stackInnerSpacing: CGFloat = 7
+    }
+    
+    let placeName: UILabel = {
+        let label = UILabel()
+        label.text = "상호명*"
+        label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
+        label.asColor(targetString: "*", color: .red)
+        return label
+    }()
+    
+    let placeTextField = RequestTextField(placehold: "장소 이름을 입력하세요.")
+    
+    let placeAddress: UILabel = {
+        let label = UILabel()
+        label.text = "주소*"
+        label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
+        label.asColor(targetString: "*", color: .red)
+        return label
+    }()
+    
+    let placeAddressTextField = RequestTextField(placehold: "주소를 입력하세요.")
+    
+    let recommendReason: UILabel = {
+        let label = UILabel()
+        label.text = "추천사유"
+        label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
+        return label
+    }()
+    
+    lazy var recommendTextView: UITextView = {
+        let textView = UITextView()
+        textView.backgroundColor = CustomColor.nomadGray3
+        textView.layer.cornerRadius = 12
+        textView.textContainerInset = UIEdgeInsets(top: 13, left: 13, bottom: 13, right: 20)
+        textView.font = .preferredFont(forTextStyle: .body, weight: .regular)
+        textView.setHeight(150)
+        textView.textColor = .tertiaryLabel
+        textView.text = "추천 사유를 입력하세요."
+        textView.delegate = self
+        return textView
+    }()
+    
+    let recommenderContactNumber: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
+        label.text = "추천자 연락처"
+        return label
+    }()
+    
+    let recommendContactTextField = RequestTextField(placehold: "연락처를 남겨주세요.")
+    
+    lazy var submit: UIButton = {
+        let button = UIButton()
+        button.setTitle("제출하기", for: .normal)
+        button.tintColor = .white
+        button.backgroundColor = CustomColor.nomadBlue
+        button.layer.cornerRadius = 8
+        button.addTarget(self, action: #selector(sendRequest), for: .touchUpInside)
+        return button
+    }()
+    
+    // MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configUI()
+        navigationController?.navigationBar.prefersLargeTitles = false
+        title = "장소 제보"
+    }
+    
+    // MARK: - Actions
+    
+    @objc func sendRequest() {
+        // TODO: 장소 제안 보내는 로직, 상호명과 주소가 nil값이 아님을 체크해주어야 한다.
+        navigationController?.popViewController(animated: true)
+    }
+    
+    // MARK: - Helpers
+    
+    private func configUI() {
+        view.backgroundColor = .systemBackground
+        
+        let placeStack = UIStackView(arrangedSubviews: [placeName, placeTextField])
+        placeStack.axis = .vertical
+        placeStack.spacing = Size.stackInnerSpacing
+        placeStack.alignment = .leading
+        placeStack.distribution = .fill
+        
+        let addressStack = UIStackView(arrangedSubviews: [placeAddress, placeAddressTextField])
+        addressStack.axis = .vertical
+        addressStack.spacing = Size.stackInnerSpacing
+        addressStack.alignment = .leading
+        addressStack.distribution = .fill
+        
+        let recommendStack = UIStackView(arrangedSubviews: [recommendReason, recommendTextView])
+        recommendStack.axis = .vertical
+        recommendStack.spacing = Size.stackInnerSpacing
+        recommendStack.alignment = .leading
+        recommendStack.distribution = .fill
+        
+        let contactStack = UIStackView(arrangedSubviews: [recommenderContactNumber, recommendContactTextField])
+        contactStack.axis = .vertical
+        contactStack.spacing = Size.stackInnerSpacing
+        contactStack.alignment = .leading
+        contactStack.distribution = .fill
+        
+        let stack = UIStackView(arrangedSubviews: [placeStack, addressStack, recommendStack, contactStack])
+        stack.axis = .vertical
+        stack.distribution = .equalSpacing
+        stack.spacing = 28
+        view.addSubview(stack)
+        stack.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: Size.paddingNormal, paddingLeft: Size.paddingNormal, paddingRight: Size.paddingNormal)
+        placeTextField.anchor(left: view.leftAnchor, right: view.rightAnchor, paddingLeft: Size.paddingNormal, paddingRight: Size.paddingNormal)
+        placeAddressTextField.anchor(left: view.leftAnchor, right: view.rightAnchor, paddingLeft: Size.paddingNormal, paddingRight: Size.paddingNormal)
+        recommendTextView.anchor(left: view.leftAnchor, right: view.rightAnchor, paddingLeft: Size.paddingNormal, paddingRight: Size.paddingNormal)
+        recommendContactTextField.anchor(left: view.leftAnchor, right: view.rightAnchor, paddingLeft: Size.paddingNormal, paddingRight: Size.paddingNormal)
+        
+        view.addSubview(submit)
+        submit.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingLeft: Size.paddingNormal, paddingBottom: 50, paddingRight: Size.paddingNormal, height: 50)
+    }
+    
+}
+
+// MARK: - UITextViewDelegate
+
+extension PlaceRequestViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .tertiaryLabel {
+            textView.text = nil
+            textView.textColor = CustomColor.nomadBlack
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = "추천 사유를 입력하세요."
+            textView.textColor = .tertiaryLabel
+        }
+    }
+}

--- a/BNomad/View/SettingView/PlaceRequestViewController.swift
+++ b/BNomad/View/SettingView/PlaceRequestViewController.swift
@@ -81,7 +81,7 @@ class PlaceRequestViewController: UIViewController {
         super.viewDidLoad()
         configUI()
         navigationController?.navigationBar.prefersLargeTitles = false
-        title = "장소 제보"
+        title = "장소 제안"
     }
     
     // MARK: - Actions

--- a/BNomad/View/SettingView/RequestTextField.swift
+++ b/BNomad/View/SettingView/RequestTextField.swift
@@ -1,0 +1,28 @@
+//
+//  RequestTextField.swift
+//  BNomad
+//
+//  Created by 박성수 on 2022/11/10.
+//
+
+import UIKit
+
+final class RequestTextField: UITextField {
+
+    init(placehold: String) {
+        super.init(frame: .zero)
+        
+        self.backgroundColor = CustomColor.nomadGray3
+        self.layer.cornerRadius = 12
+        self.leftView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 20, height: 50)))
+        self.leftViewMode = .always
+        self.clearButtonMode = .whileEditing
+        self.placeholder = placehold
+        self.setHeight(50)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}

--- a/BNomad/View/SettingView/SettingViewController.swift
+++ b/BNomad/View/SettingView/SettingViewController.swift
@@ -9,9 +9,107 @@ import UIKit
 
 class SettingViewController: UIViewController {
 
+    // MARK: - Properties
+    
+    enum listTitle {
+        static let placeRequest = "장소 제안"
+        static let withdrawUser = "회원 탈퇴"
+        static let logout = "로그아웃"
+    }
+    
+    private let settingTable: UITableView = {
+        let table = UITableView()
+        return table
+    }()
+    
+    private let settingListArr: [String] = [listTitle.placeRequest, listTitle.withdrawUser, listTitle.logout]
+    
+    // MARK: - LifeCycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationController?.navigationBar.isHidden = false
+        navigationController?.navigationBar.prefersLargeTitles = true
+        title = "설정"
+        configureUI()
+        configureTable()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        title = "설정"
+        navigationController?.navigationBar.prefersLargeTitles = true
+    }
+    
+    // MARK: - Actions
+    
+    // MARK: - Helpers
+    
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+    
+    func configureTable() {
+        settingTable.dataSource = self
+        settingTable.delegate = self
+        
+        view.addSubview(settingTable)
+        settingTable.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
         
     }
 
+}
+
+// MARK: - UITableViewDelegate
+
+extension SettingViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let selectedTitle = settingListArr[indexPath.row]
+        if selectedTitle == listTitle.placeRequest {
+            title = ""
+            let controller = PlaceRequestViewController()
+            navigationController?.pushViewController(controller, animated: true)
+        } else if selectedTitle == listTitle.withdrawUser {
+            title = ""
+            let controller = WithdrawViewController()
+            navigationController?.pushViewController(controller, animated: true)
+        } else if selectedTitle == listTitle.logout {
+            let alert = UIAlertController(title: listTitle.logout, message: "로그아웃 하시겠습니까?", preferredStyle: .alert)
+            let cancel = UIAlertAction(title: "취소", style: .cancel)
+            let logout = UIAlertAction(title: "확인", style: .destructive) { action in
+                // TODO: 로그아웃 액션
+                self.navigationController?.popToRootViewController(animated: true)
+            }
+            alert.addAction(cancel)
+            alert.addAction(logout)
+            self.present(alert, animated: true)
+        }
+    }
+    
+}
+
+// MARK: - UITableViewDataSource
+
+extension SettingViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return settingListArr.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell()
+        let selectedTitle = settingListArr[indexPath.row]
+        if selectedTitle == listTitle.logout {
+            cell.textLabel?.textColor = CustomColor.nomadBlue
+        } else {
+            let image = UIImageView(image: UIImage(systemName: "chevron.right"))
+            cell.addSubview(image)
+            image.anchor(right: cell.rightAnchor, paddingRight: 10)
+            image.centerY(inView: cell)
+        }
+        cell.textLabel?.text = selectedTitle
+        cell.selectionStyle = .none
+        
+        return cell
+    }
+    
 }

--- a/BNomad/View/SettingView/WithdrawViewController.swift
+++ b/BNomad/View/SettingView/WithdrawViewController.swift
@@ -1,0 +1,105 @@
+//
+//  WithdrawViewController.swift
+//  BNomad
+//
+//  Created by 박성수 on 2022/11/10.
+//
+
+import UIKit
+
+class WithdrawViewController: UIViewController {
+
+    // MARK: - Properties
+    
+    enum Size {
+        static let paddingNormal: CGFloat = 20
+    }
+    
+    private let withdrawLabel: UILabel = {
+        let label = UILabel()
+        label.text = "탈퇴 사유"
+        label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
+        return label
+    }()
+    
+    lazy var reasonTextView: UITextView = {
+        let textView = UITextView()
+        textView.backgroundColor = CustomColor.nomadGray3
+        textView.delegate = self
+        textView.layer.cornerRadius = 12
+        textView.text = "탈퇴사유를 입력하세요."
+        textView.textColor = .tertiaryLabel
+        textView.textContainerInset = UIEdgeInsets(top: 13, left: Size.paddingNormal, bottom: 13, right: Size.paddingNormal)
+        textView.font = .preferredFont(forTextStyle: .body, weight: .regular)
+        return textView
+    }()
+    
+    private lazy var withdrawButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("탈퇴하기", for: .normal)
+        button.tintColor = .white
+        button.backgroundColor = CustomColor.nomadBlue
+        button.layer.cornerRadius = 8
+        button.addTarget(self, action: #selector(withdraw), for: .touchUpInside)
+        return button
+    }()
+        
+    // MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "회원 탈퇴"
+        navigationController?.navigationBar.prefersLargeTitles = false
+        configUI()
+    }
+    
+    // MARK: - Actions
+    
+    @objc func withdraw() {
+        let alert = UIAlertController(title: "탈퇴하기", message: "탈퇴하시겠습니까?", preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        let withdrawConfirm = UIAlertAction(title: "탈퇴", style: .destructive) { action in
+            // TODO: 유저를 지우는 액션이 들어가 있어야 합니다.
+            print("탈퇴합니다")
+            self.navigationController?.popToRootViewController(animated: true)
+        }
+        alert.addAction(cancel)
+        alert.addAction(withdrawConfirm)
+        self.present(alert, animated: true)
+    }
+    
+    // MARK: - Helpers
+    
+    func configUI() {
+        view.backgroundColor = .systemBackground
+        
+        view.addSubview(withdrawLabel)
+        withdrawLabel.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, paddingTop: Size.paddingNormal, paddingLeft: Size.paddingNormal)
+        
+        view.addSubview(reasonTextView)
+        reasonTextView.anchor(top: withdrawLabel.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 10, paddingLeft: Size.paddingNormal, paddingRight: Size.paddingNormal, height: 178)
+        
+        view.addSubview(withdrawButton)
+        withdrawButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingLeft: Size.paddingNormal, paddingBottom: 50, paddingRight: Size.paddingNormal, height: 50)
+        
+    }
+
+}
+
+// MARK: - UITextViewDelegate
+
+extension WithdrawViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .tertiaryLabel {
+            textView.text = nil
+            textView.textColor = CustomColor.nomadBlack
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = "탈퇴사유를 입력하세요."
+            textView.textColor = .tertiaryLabel
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈들
- #192 

## 작업 내용
- 전반적 SettingViewController UI 작업
- 장소 제안 UI 작업
- 회원 탈퇴 UI 작업
- 로그아웃 UI 작업
- but 정확한 로직에 기반한 액션은 아직 안되어 있는 상태입니다.
- `PlaceRequestViewController`에서 동일한 UITextField의 중복되는 코드들을 줄여주기 위해서 `RequestTextField`로 만들어 따로 빼냈습니다.

## 리뷰 노트
- https://github.com/DeveloperAcademy-POSTECH/MacC-Team-NoPower/issues/192#issuecomment-1309833038 히로의 의견으로 로그인되어 있을때와 로그인되어 있지 않을때의 설정버튼 클릭시, 메뉴가 달라질 수 있겠다 라는 점도 같이 생각해주시면 좋을 것 같습니다!
- `MapViewController`에서 넘어오는 로직은 push되어 있지 않습니다. 하단의 이미지 로직이 추가되면 정상작동합니다🫡
    - `self.dismiss()` 를 해주는 이유로는, 세팅뷰로 들어가기 전에 열려있는 모달이 있으면, 모달을 닫아주고 네비게이션 액션을 해주기 위해서 입니다.
<img width="700" alt="스크린샷 2022-11-11 00 43 11" src="https://user-images.githubusercontent.com/72736657/201139991-f96c9290-0adb-4f3f-bdd5-3841fe9d82cf.png">

## 스크린샷(UX의 경우 gif)
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-11 at 00 44 16](https://user-images.githubusercontent.com/72736657/201140356-af4c65b2-e984-43ac-91d0-e0e26402aa15.gif)

## Reference
- [UITextView padding주기](https://m.blog.naver.com/thdeodls85/220686290870)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
