### PR TITLE
[Fix] 맵 버그 수정 완료

### DIFF
--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -203,10 +203,10 @@ class MapViewController: UIViewController {
         let sheet = CustomModalViewController()
         sheet.modalPresentationStyle = .pageSheet
         if let sheet = sheet.sheetPresentationController {
-            sheet.detents = [.large()]
+            sheet.detents = [.medium()]
             sheet.delegate = self
             sheet.prefersGrabberVisible = false
-//            sheet.largestUndimmedDetentIdentifier = .medium
+            sheet.largestUndimmedDetentIdentifier = .medium
             sheet.prefersScrollingExpandsWhenScrolledToEdge = false
             sheet.preferredCornerRadius = 12
         }
@@ -252,7 +252,6 @@ class MapViewController: UIViewController {
          navigationController?.navigationBar.isHidden = true
          navigationItem.backButtonTitle = ""
          checkInFloating()
-         checkInBinding()
      }
 
     override func viewDidLoad() {
@@ -260,6 +259,7 @@ class MapViewController: UIViewController {
         navigationController?.navigationBar.isHidden = true
         locationFuncs()
         configueMapUI()
+        checkInBinding()
         userCombine()
     }
     
@@ -411,7 +411,7 @@ extension MapViewController: MKMapViewDelegate {
             present(controller, animated: true)
         } else {
             guard let annotation = view.annotation else { return }
-            map.setRegion(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: annotation.coordinate.latitude, longitude: annotation.coordinate.longitude ), span: MKCoordinateSpan(latitudeDelta: map.region.span.latitudeDelta / 4, longitudeDelta: map.region.span.longitudeDelta / 4)), animated: true)
+            map.setRegion(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: annotation.coordinate.latitude, longitude: annotation.coordinate.longitude ), span: MKCoordinateSpan(latitudeDelta: map.region.span.latitudeDelta / 5, longitudeDelta: map.region.span.longitudeDelta / 5)), animated: true)
             print("THIS is CLUSTER")
         }
     }

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -366,6 +366,13 @@ class MapViewController: UIViewController {
 
 extension MapViewController: MKMapViewDelegate {
 
+    func mapView(_ mapView: MKMapView, didAdd views: [MKAnnotationView]) {
+        let userAnnotationView = mapView.view(for: mapView.userLocation)
+        userAnnotationView?.isUserInteractionEnabled = false
+        userAnnotationView?.canShowCallout = false
+        userAnnotationView?.isEnabled = false
+    }
+    
     // 맵 오버레이 rendering
     func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
         let overlay = MKCircleRenderer(circle: circleOverlay)

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -173,7 +173,7 @@ class MapViewController: UIViewController {
         let btn = MKUserTrackingButton(mapView: map)
         btn.backgroundColor = .white
         btn.tintColor = CustomColor.nomadBlue
-        btn.layer.cornerRadius = 20
+        btn.layer.cornerRadius = 4
         btn.layer.borderColor = CustomColor.nomadBlue?.cgColor
         btn.layer.borderWidth = 1
         return btn
@@ -192,7 +192,7 @@ class MapViewController: UIViewController {
         button.backgroundColor = .white
         button.setImage(UIImage(systemName: "list.bullet"), for: .normal)
         button.tintColor = CustomColor.nomadBlue
-        button.layer.cornerRadius = 20
+        button.layer.cornerRadius = 4
         button.layer.borderColor = CustomColor.nomadBlue?.cgColor
         button.layer.borderWidth = 1
         button.addTarget(self, action: #selector(presentPlaceViewModal), for: .touchUpInside)
@@ -203,7 +203,7 @@ class MapViewController: UIViewController {
         let sheet = CustomModalViewController()
         sheet.modalPresentationStyle = .pageSheet
         if let sheet = sheet.sheetPresentationController {
-            sheet.detents = [.medium()]
+            sheet.detents = [.large()]
             sheet.delegate = self
             sheet.prefersGrabberVisible = false
 //            sheet.largestUndimmedDetentIdentifier = .medium
@@ -324,7 +324,14 @@ class MapViewController: UIViewController {
             present(controller, animated: false)
         }
         
+        FirebaseManager.shared.fetchPlaceAll { place in
+            self.map.addAnnotation(MKAnnotationFromPlace.convertPlaceToAnnotation(place))
+            self.viewModel.places.append(place)
+            self.checkInBinding()
+        }
+        
         map.delegate = self
+        
         view.addSubview(map)
         map.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
         
@@ -335,15 +342,9 @@ class MapViewController: UIViewController {
         upperStack.anchor(top: map.topAnchor, left: map.leftAnchor, right: map.rightAnchor, paddingTop: 30, paddingLeft: 20, paddingRight: 20, height: 80)
         
         map.addSubview(compass)
-        compass.anchor(top: map.topAnchor, left: map.leftAnchor, paddingTop: 50, paddingLeft: 20, width: 40, height: 40)
+        compass.anchor(top: map.topAnchor, left: map.leftAnchor, paddingTop: 110, paddingLeft: 15, width: 40, height: 40)
         
         map.addOverlay(circleOverlay)
-        
-        FirebaseManager.shared.fetchPlaceAll { place in
-            self.map.addAnnotation(MKAnnotationFromPlace.convertPlaceToAnnotation(place))
-            self.viewModel.places.append(place)
-            self.checkInBinding()
-        }
         
         map.addSubview(listViewButton)
         listViewButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, paddingLeft: 15, paddingBottom: 70, width: 40, height: 40)


### PR DESCRIPTION
## 관련 이슈들
- #199 

## 작업 내용
- 자기 자신의 핀은 클릭되지 않도록 막았습니다.
- 리스트보기 버튼과 본인 위치로 가는 버튼의 디자인을 사각형으로 만들어서 user tracking 모드의 버튼과 디자인 통일성을 맞췄습니다.
- 리스트보기 모달은 large로 변경했다가 다시 medium으로 유지시켰습니다. (리스트 안의 장소를 클릭했을 때 모달 두개가 겹쳐 UI 불편)
- 나침반 위치를 수정했습니다.
- 시도때도 없이 체크인위치나 본인 위치로 맵이 리셋되던 것을 막고, 앱을 구동할 때만 리셋하도록 수정했습니다.

## 리뷰 노트
- 다른 지역을 탐색하다가 업무중 버튼을 누르면 체크인한 장소의 체크인뷰 모달이 떴다가 사라지는데, 맵은 여전히 다른 지역 모습 그대로인게 좀 어색하더라고요. 업무중 버튼에 scope 모양을 추가해서 저걸 누르면 map도 이동하고 모달도 뜨는 방식은 어떨까요?

<img width="185" alt="image" src="https://user-images.githubusercontent.com/103012800/201244631-6954c6ca-a2ed-421a-8e38-1db1d91325fb.png">


## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012800/201243701-37c8c92a-ea88-443b-ac23-591b5cfe765e.gif" width="300">


## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
