### PR TITLE
[Feat] #189 체크인뷰와 밋업뷰, 밋업생성뷰 연결

### DIFF
--- a/BNomad/Utils/Extensions/UIColor+Extension.swift
+++ b/BNomad/Utils/Extensions/UIColor+Extension.swift
@@ -44,4 +44,5 @@ class CustomColor {
     static let nomadGreen = UIColor(hex: "5DC878")
     static let nomadRed = UIColor(hex: "FF6961")
     static let nomadYellow = UIColor(hex: "FFBA33")
+    static let nomad2White = UIColor(hex: "F5F5F5")
 }

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -234,9 +234,11 @@ class MapViewController: UIViewController {
             user.currentPlaceUid == place.placeUid
         }
         controller.selectedPlace = tempPlace
-        controller.modalPresentationStyle = .fullScreen
+        let navigationController = UINavigationController(rootViewController: controller)
+//        controller.modalPresentationStyle = .fullScreen
+        navigationController.modalPresentationStyle = .fullScreen
         self.dismiss(animated: true) {
-            self.present(controller, animated: true)
+            self.present(navigationController, animated: true, completion: nil)
         }
     }
     

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -235,8 +235,8 @@ class MapViewController: UIViewController {
         }
         controller.selectedPlace = tempPlace
         let navigationController = UINavigationController(rootViewController: controller)
-//        controller.modalPresentationStyle = .fullScreen
         navigationController.modalPresentationStyle = .fullScreen
+        navigationController.navigationBar.tintColor = CustomColor.nomadBlue
         self.dismiss(animated: true) {
             self.present(navigationController, animated: true, completion: nil)
         }

--- a/BNomad/View/MeetUpView/MeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/MeetUpViewController.swift
@@ -11,7 +11,9 @@ class MeetUpViewController: UIViewController {
 
     // MARK: - Properties
     
-    private let meetUpTitleLabel: UILabel = {
+    var meetUp: TempMeetUp?
+    
+    private var meetUpTitleLabel: UILabel = {
         let label = UILabel()
         label.text = "점심에 맛찬들 같이 가실 분"
         label.font = .preferredFont(forTextStyle: .title1, weight: .bold)
@@ -47,7 +49,7 @@ class MeetUpViewController: UIViewController {
         return label
     }()
     
-    private let locationLabel: UILabel = {
+    private var locationLabel: UILabel = {
         let label = UILabel()
         label.text = "코워킹스페이스 입구"
         label.font = .preferredFont(forTextStyle: .headline)
@@ -56,7 +58,7 @@ class MeetUpViewController: UIViewController {
         return label
     }()
     
-    private let timeLabel: UILabel = {
+    private var timeLabel: UILabel = {
         let label = UILabel()
         label.text = "12시 30분"
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
@@ -83,7 +85,7 @@ class MeetUpViewController: UIViewController {
         return stack
     }()
     
-    private let contentLabel: UILabel = {
+    private var contentLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         label.text = "내용내용 맛있는 삼겹살 먹고싶은데 맛찬들 혼자가긴 좀 어쩌구저쩌구"
@@ -92,7 +94,7 @@ class MeetUpViewController: UIViewController {
         return label
     }()
     
-    private let participants: UILabel = {
+    private var participants: UILabel = {
         let label = UILabel()
         label.text = "참여 예정 노마더 ( 5 / 10 )"
         label.font = .preferredFont(forTextStyle: .subheadline)
@@ -177,6 +179,14 @@ class MeetUpViewController: UIViewController {
         
         view.addSubview(joinButton)
         joinButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingLeft: 20, paddingBottom: 60, paddingRight: 20, height: 48)
+    }
+    
+    func setMeetUpData(meetUp: TempMeetUp) {
+        meetUpTitleLabel.text = meetUp.title
+        locationLabel.text = meetUp.meetUpPlaceName
+        timeLabel.text = meetUp.time
+        contentLabel.text = meetUp.description
+        participants.text = "참여 예정 노마더 ( 1 / \(meetUp.maxPeopleNum) )"
     }
 }
 

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -303,11 +303,12 @@ class NewMeetUpViewController: UIViewController {
     }
     
     @objc func didTapDoneCreatingMeetUp() {
-        // TODO: 내용 저장
+        // TODO: 내용 저장 & self.dismiss 후 어디로 갈것인지? CheckInView? MeetUpView?
+        self.dismiss(animated: true)
     }
     
     @objc func didTapCancelCreatingMeetUp() {
-        // TODO: dismiss 동작
+        self.dismiss(animated: true)
     }
     
     // MARK: - Helpers

--- a/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
@@ -53,16 +53,11 @@ class CheckInCardViewCell: UICollectionViewCell {
         }
     }
     
-    var selectedPlaceTitle: UILabel = {
-        let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .headline, weight: .regular)
-        return label
-    }()
-    
     private let cardRectangleView: UIView = {
         let view = UIView()
-        view.backgroundColor = CustomColor.nomadGray2
-        view.layer.masksToBounds = false
+        view.backgroundColor = CustomColor.nomad2White
+        view.layer.borderWidth = 0.5
+        view.layer.borderColor = CustomColor.nomadGray2?.cgColor
         return view
     }()
 
@@ -253,12 +248,11 @@ class CheckInCardViewCell: UICollectionViewCell {
         stack.distribution = .equalCentering
         stack.spacing = 17
         
+        self.addSubview(cardRectangleView)
+        cardRectangleView.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingBottom: 20)
+        
         self.addSubview(stack)
         stack.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 90, paddingLeft: 20, paddingRight: 20, height: 290)
         checkOutButton.anchor(height: 50)
-        
-        self.addSubview(selectedPlaceTitle)
-        selectedPlaceTitle.anchor(bottom: stack.topAnchor, paddingBottom: 7)
-        selectedPlaceTitle.centerX(inView: self)
     }
 }

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -25,7 +25,6 @@ class PlaceCheckInViewController: UIViewController {
     
     var checkInHistory: [CheckIn]? {
         didSet {
-            placeTitleLabel.text =  selectedPlace?.name
             guard let checkInHistory = checkInHistory else { return }
             collectionView.reloadData()
         }
@@ -36,41 +35,22 @@ class PlaceCheckInViewController: UIViewController {
         checkInHistory?.count ?? 0
     }
     
-    private lazy var placeTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = " "
-        label.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
-        label.tintColor = CustomColor.nomadBlack
-        
-        return label
-    }()
-    
     private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
-    
-    lazy var cancelButton: UIButton = {
-        let button = UIButton()
-        button.setImage(UIImage(systemName: "xmark"), for: .normal)
-        button.layer.cornerRadius = 30 / 2
-        button.tintColor = .white
-        button.backgroundColor = .lightGray
-        button.layer.opacity = 0.5
-        button.addTarget(self, action: #selector(dismissPage), for: .touchUpInside)
-        return button
-    }()
     
     // MARK: - LifeCycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
         placeCheckInView()
-        configureCancelButton()
         view.backgroundColor = .white
         collectionView.backgroundColor = .white
+        
+        navigationItem.title = selectedPlace?.name
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "xmark"), style: .plain, target: self, action: #selector(dismissPage))
     }
     
     // MARK: - Actions
     
-    // TODO: 업무중 버튼 눌러서 들어왔을 때 dismiss 안됨
     @objc func dismissPage() {
         self.dismiss(animated: true)
     }
@@ -78,10 +58,6 @@ class PlaceCheckInViewController: UIViewController {
     // MARK: - Helpers
     
     func placeCheckInView() {
-
-        view.addSubview(placeTitleLabel)
-        placeTitleLabel.centerX(inView: view)
-        placeTitleLabel.anchor(top: view.topAnchor, paddingTop: 58)
         
         view.addSubview(collectionView)
         collectionView.contentInsetAdjustmentBehavior = .never
@@ -93,11 +69,6 @@ class PlaceCheckInViewController: UIViewController {
         self.collectionView.register(CheckedProfileListHeader.self, forCellWithReuseIdentifier: CheckedProfileListHeader.identifier)
         
         collectionView.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
-    }
-    
-    func configureCancelButton() {
-        view.addSubview(cancelButton)
-        cancelButton.anchor(top: view.topAnchor, right: view.rightAnchor, paddingTop: 50, paddingRight: 20, width: 30, height: 30)
     }
 }
 
@@ -118,7 +89,6 @@ extension PlaceCheckInViewController: UICollectionViewDataSource {
             checkInCardViewCell.checkOutDelegate = self
             checkInCardViewCell.user = viewModel.user
             checkInCardViewCell.checkIn = viewModel.user?.currentCheckIn
-            checkInCardViewCell.selectedPlaceTitle.text = selectedPlace?.name
             return checkInCardViewCell
         }
         else if indexPath.section == 1 {

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -123,6 +123,7 @@ extension PlaceCheckInViewController: UICollectionViewDataSource {
         else if indexPath.section == 1 {
             guard let placeInfoViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: PlaceInfoViewCell.identifier, for: indexPath) as? PlaceInfoViewCell else { return UICollectionViewCell() }
             placeInfoViewCell.place = selectedPlace
+            placeInfoViewCell.meetUpViewDelegate = self
             
             return placeInfoViewCell
         }
@@ -205,5 +206,15 @@ extension PlaceCheckInViewController: CheckOutAlert {
             self.checkOut()
         }))
         present(alert, animated: true)
+    }
+}
+
+// MARK: - newMeetUpViewShowable
+
+extension PlaceCheckInViewController: NewMeetUpViewShowable {
+    func didTapNewMeetUpButton() {
+        let newMeetUpView = NewMeetUpViewController()
+        let navBarOnModal: UINavigationController = UINavigationController(rootViewController: newMeetUpView)
+        present(navBarOnModal, animated: true, completion: nil)
     }
 }

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -70,6 +70,7 @@ class PlaceCheckInViewController: UIViewController {
     
     // MARK: - Actions
     
+    // TODO: 업무중 버튼 눌러서 들어왔을 때 dismiss 안됨
     @objc func dismissPage() {
         self.dismiss(animated: true)
     }
@@ -124,6 +125,7 @@ extension PlaceCheckInViewController: UICollectionViewDataSource {
             guard let placeInfoViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: PlaceInfoViewCell.identifier, for: indexPath) as? PlaceInfoViewCell else { return UICollectionViewCell() }
             placeInfoViewCell.place = selectedPlace
             placeInfoViewCell.meetUpViewDelegate = self
+            placeInfoViewCell.placeInfoViewCelldelegate = self
             
             return placeInfoViewCell
         }
@@ -216,5 +218,15 @@ extension PlaceCheckInViewController: NewMeetUpViewShowable {
         let newMeetUpView = NewMeetUpViewController()
         let navBarOnModal: UINavigationController = UINavigationController(rootViewController: newMeetUpView)
         present(navBarOnModal, animated: true, completion: nil)
+    }
+}
+
+// MARK: - PlaceInfoViewCellDelegate
+
+extension PlaceCheckInViewController: PlaceInfoViewCellDelegate {
+    func didTapMeetUpCell(_ cell: PlaceInfoViewCell, viewModel: TempMeetUp) {
+        let vc = MeetUpViewController()
+        vc.setMeetUpData(meetUp: viewModel)
+        navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol NewMeetUpViewShowable {
+    func didTapNewMeetUpButton()
+}
+
 class PlaceInfoViewCell: UICollectionViewCell {
     
     static let identifier = "placeInforViewCell"
@@ -23,6 +27,8 @@ class PlaceInfoViewCell: UICollectionViewCell {
             }
         }
     }
+    
+    var meetUpViewDelegate: NewMeetUpViewShowable?
     
     let collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -54,7 +60,7 @@ class PlaceInfoViewCell: UICollectionViewCell {
         let button = UIButton()
         button.setImage(UIImage(systemName: "plus"), for: .normal)
         button.tintColor = .black
-        button.addTarget(self, action: #selector(questAdd), for: .touchUpInside)
+        button.addTarget(self, action: #selector(addNewMeetUp), for: .touchUpInside)
         
         return button
     }()
@@ -74,8 +80,8 @@ class PlaceInfoViewCell: UICollectionViewCell {
     
     // MARK: - Actions
     
-    @objc func questAdd() {
-        print("QUEST ADD!!")
+    @objc func addNewMeetUp() {
+        meetUpViewDelegate?.didTapNewMeetUpButton()
     }
     
     // MARK: - Helpers
@@ -87,9 +93,6 @@ class PlaceInfoViewCell: UICollectionViewCell {
         collectionView.backgroundColor = .systemBackground
         collectionView.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor)
         collectionView.register(QuestCollectionViewCell.self, forCellWithReuseIdentifier: QuestCollectionViewCell.identifier)
-        
-//        self.addSubview(questLabel)
-//        questLabel.anchor(top: collectionView.topAnchor, left: collectionView.leftAnchor, paddingTop: 10, paddingLeft: 20)
         
         self.addSubview(plusButton)
         plusButton.anchor(top: collectionView.topAnchor, right: collectionView.rightAnchor, paddingTop: 10, paddingRight: 20, width: 24, height: 24)
@@ -117,7 +120,6 @@ extension PlaceInfoViewCell: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print(indexPath)
     }
-    
 }
 
 // MARK: - UICollectionViewDataSource

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -11,6 +11,27 @@ protocol NewMeetUpViewShowable {
     func didTapNewMeetUpButton()
 }
 
+protocol PlaceInfoViewCellDelegate: AnyObject {
+    func didTapMeetUpCell(_ cell: PlaceInfoViewCell, viewModel: TempMeetUp)
+}
+
+// TODO: TempMeetUp, TempMeetUpData는 QuestCollectionViewCell과 MeetUpView로의 연결작업을 위한 임의 데이터이며, 추후 실제 데이터 연결 필요
+struct TempMeetUp {
+    var title: String
+    var meetUpPlaceName: String
+    var time: String
+    var maxPeopleNum: Int
+    var description: String
+}
+
+struct TempMeetUpData {
+    var list = [
+        TempMeetUp(title: "점심에 맛찬들 가실 분~", meetUpPlaceName: "정문 앞", time: "12:30", maxPeopleNum: 4, description: "갑자기 삼겹살이 땡기는데 맛찬들 혼자가긴 좀 그렇네요 같이 가실 분 구합니다!"),
+        TempMeetUp(title: "탁구 30분만 치실 분", meetUpPlaceName: "탁구대 앞", time: "14:30", maxPeopleNum: 2, description: "점심먹으니 졸리네요.. 잠도 깰겸 탁구 30분만 딱 치고 다시 집중하고 싶어요~"),
+        TempMeetUp(title: "iOS 개발자 계신가요?", meetUpPlaceName: "휴게실", time: "15:00", maxPeopleNum: 3, description: "오늘 여기 사람이 많네요. 혹시 iOS 개발자도 계신지 궁금합니다! 저는 디자이너예요ㅎ")
+    ]
+}
+
 class PlaceInfoViewCell: UICollectionViewCell {
     
     static let identifier = "placeInforViewCell"
@@ -27,6 +48,9 @@ class PlaceInfoViewCell: UICollectionViewCell {
             }
         }
     }
+    
+    weak var placeInfoViewCelldelegate: PlaceInfoViewCellDelegate?
+    var meetUpList = TempMeetUpData().list
     
     var meetUpViewDelegate: NewMeetUpViewShowable?
     
@@ -49,7 +73,7 @@ class PlaceInfoViewCell: UICollectionViewCell {
     
     lazy var numberOfQuestLabel: UILabel = {
         let label = UILabel()
-        label.text = "5"
+        label.text = "\(meetUpList.count)"
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         label.textColor = CustomColor.nomadBlue
         
@@ -119,6 +143,8 @@ extension PlaceInfoViewCell: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print(indexPath)
+        let meetUp = meetUpList[indexPath.item]
+        placeInfoViewCelldelegate?.didTapMeetUpCell(self, viewModel: meetUp)
     }
 }
 
@@ -126,11 +152,14 @@ extension PlaceInfoViewCell: UICollectionViewDelegateFlowLayout {
 
 extension PlaceInfoViewCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 10
+        return meetUpList.count
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: QuestCollectionViewCell.identifier, for: indexPath) as? QuestCollectionViewCell else { return UICollectionViewCell() }
+        
+        let meetUpData = self.meetUpList[indexPath.item]
+        cell.updateMeetUpCell(meetUp: meetUpData)
         
         return cell
     }

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -33,12 +33,20 @@ class PlaceInfoViewCell: UICollectionViewCell {
         return collectionview
     }()
     
-    let questLabel: UILabel = {
+    private let questLabel: UILabel = {
         let label = UILabel()
-        label.text = "퀘스트 5"
-        label.asFont(targetString: "퀘스트", font: .preferredFont(forTextStyle: .title3, weight: .semibold))
-        label.asFont(targetString: "5", font: .preferredFont(forTextStyle: .title3, weight: .semibold))
-        label.asColor(targetString: "5", color: CustomColor.nomadBlue ?? .red)
+        label.text = "퀘스트"
+        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        label.textColor = CustomColor.nomadBlack
+        return label
+    }()
+    
+    lazy var numberOfQuestLabel: UILabel = {
+        let label = UILabel()
+        label.text = "5"
+        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        label.textColor = CustomColor.nomadBlue
+        
         return label
     }()
     
@@ -47,6 +55,7 @@ class PlaceInfoViewCell: UICollectionViewCell {
         button.setImage(UIImage(systemName: "plus"), for: .normal)
         button.tintColor = .black
         button.addTarget(self, action: #selector(questAdd), for: .touchUpInside)
+        
         return button
     }()
     
@@ -56,6 +65,7 @@ class PlaceInfoViewCell: UICollectionViewCell {
         super.init(frame: frame)
         
         configureCollectionView()
+        configQuestLabel()
     }
     
     required init?(coder: NSCoder) {
@@ -78,13 +88,23 @@ class PlaceInfoViewCell: UICollectionViewCell {
         collectionView.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor)
         collectionView.register(QuestCollectionViewCell.self, forCellWithReuseIdentifier: QuestCollectionViewCell.identifier)
         
-        self.addSubview(questLabel)
-        questLabel.anchor(top: collectionView.topAnchor, left: collectionView.leftAnchor, paddingTop: 10, paddingLeft: 20)
+//        self.addSubview(questLabel)
+//        questLabel.anchor(top: collectionView.topAnchor, left: collectionView.leftAnchor, paddingTop: 10, paddingLeft: 20)
         
         self.addSubview(plusButton)
         plusButton.anchor(top: collectionView.topAnchor, right: collectionView.rightAnchor, paddingTop: 10, paddingRight: 20, width: 24, height: 24)
     }
     
+    func configQuestLabel() {
+        let stack = UIStackView(arrangedSubviews: [questLabel, numberOfQuestLabel])
+        stack.axis = .horizontal
+        stack.spacing = 5
+        stack.alignment = .leading
+        stack.distribution = .fill
+        
+        self.addSubview(stack)
+        stack.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 10, paddingLeft: 20)
+    }
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -13,20 +13,32 @@ class QuestCollectionViewCell: UICollectionViewCell {
     
     static let identifier: String = String(describing: QuestCollectionViewCell.self)
     
+    var isMeetUpOwner = false
+    var isMeetUpGuest = false
+    
     let title: UILabel = {
         let title = UILabel()
-        title.font = .preferredFont(forTextStyle: .headline, weight: .regular)
+        title.font = .preferredFont(forTextStyle: .headline)
         title.text = "맛찬들 같이 가실 분!"
         title.numberOfLines = 1
         return title
     }()
     
-    let participateButton: UIButton = {
-        let button = UIButton()
-        let config = UIImage.SymbolConfiguration(pointSize: 32)
-        button.setImage(UIImage(systemName: "checkmark.circle.fill", withConfiguration: config), for: .normal)
-        button.tintColor = CustomColor.nomadBlue
-        return button
+    let checkImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "checkmark.circle.fill")
+        imageView.tintColor = CustomColor.nomadBlue
+        
+        return imageView
+    }()
+    
+    let unCheckView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.borderColor = CustomColor.nomadGray2?.cgColor
+        view.layer.borderWidth = 1
+        
+        return view
     }()
     
     let timeImage: UIImageView = {
@@ -102,6 +114,7 @@ class QuestCollectionViewCell: UICollectionViewCell {
         
         shadowSetting()
         configureUI()
+        configCheckMark()
     }
     
     required init?(coder: NSCoder) {
@@ -121,13 +134,23 @@ class QuestCollectionViewCell: UICollectionViewCell {
         self.layer.masksToBounds = false
         self.layer.shadowRadius = 15
         self.layer.shadowOffset = CGSize(width: 3, height: 4)
-        self.layer.shadowOpacity = 0.1
+        self.layer.shadowOpacity = 0.05
+    }
+    
+    func configCheckMark() {
+        let checkSize: CGFloat = 32
+        
+        if isMeetUpOwner == true || isMeetUpGuest == true {
+            self.addSubview(checkImage)
+            checkImage.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 10, paddingRight: 10, width: checkSize, height: checkSize)
+        } else {
+            self.addSubview(unCheckView)
+            unCheckView.layer.cornerRadius = checkSize / 2
+            unCheckView.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 10, paddingRight: 10, width: checkSize, height: checkSize)
+        }
     }
     
     func configureUI() {
-        self.addSubview(participateButton)
-        participateButton.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 10, paddingRight: 10)
-        
         self.addSubview(title)
         title.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 16, paddingLeft: 12)
         

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -13,10 +13,13 @@ class QuestCollectionViewCell: UICollectionViewCell {
     
     static let identifier: String = String(describing: QuestCollectionViewCell.self)
     
+    // TODO: 실제 MeetUp으로 바꿔야함
+    var meetUpList: [TempMeetUp] = []
+    
     var isMeetUpOwner = false
     var isMeetUpGuest = false
     
-    let title: UILabel = {
+    var title: UILabel = {
         let title = UILabel()
         title.font = .preferredFont(forTextStyle: .headline)
         title.text = "맛찬들 같이 가실 분!"
@@ -48,7 +51,7 @@ class QuestCollectionViewCell: UICollectionViewCell {
         return image
     }()
     
-    let time: UILabel = {
+    var time: UILabel = {
         let time = UILabel()
         time.text = "12:00"
         time.textColor = CustomColor.nomadGray1
@@ -62,7 +65,7 @@ class QuestCollectionViewCell: UICollectionViewCell {
         return image
     }()
     
-    let location: UILabel = {
+    var location: UILabel = {
         let location = UILabel()
         location.text = "입구 앞"
         location.textColor = CustomColor.nomadGray1
@@ -70,10 +73,11 @@ class QuestCollectionViewCell: UICollectionViewCell {
     }()
     
     let currentCheckedPeople: String = "1"
+    var maxNumberOfParticipant: Int = 2
     
     lazy var checkedPeople: UILabel = {
         let label = UILabel()
-        label.text = "\(currentCheckedPeople) / 4"
+        label.text = "\(currentCheckedPeople) / \(maxNumberOfParticipant)"
         label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
         label.textColor = CustomColor.nomadGray1
         return label
@@ -179,4 +183,10 @@ class QuestCollectionViewCell: UICollectionViewCell {
         checkedPeople.anchor(bottom: self.bottomAnchor, right: peopleStack.leftAnchor, paddingBottom: 15, paddingRight: 11)
     }
     
+    func updateMeetUpCell(meetUp: TempMeetUp) {
+        self.title.text = meetUp.title
+        self.time.text = meetUp.time
+        self.location.text = meetUp.meetUpPlaceName
+        self.checkedPeople.text = "\(currentCheckedPeople) / \(meetUp.maxPeopleNum)"
+    }
 }

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -174,8 +174,11 @@ class PlaceInfoModalViewController: UIViewController {
                 self.delegateForFloating?.checkInFloating()
                 let controller = PlaceCheckInViewController()
                 controller.selectedPlace = selectedPlace
-                controller.modalPresentationStyle = .fullScreen
-                self.present(controller, animated: true)
+                let navigationController = UINavigationController(rootViewController: controller)
+                navigationController.modalPresentationStyle = .fullScreen
+                navigationController.navigationItem.title = selectedPlace.name
+                navigationController.navigationBar.tintColor = CustomColor.nomadBlue
+                self.present(navigationController, animated: true, completion: nil)
             }))
             present(checkInAlert, animated: true)
         } else {


### PR DESCRIPTION
## 관련 이슈들
- #189 

## 작업 내용
- 체크인뷰에서 + 버튼 누르면 NewMeetUpView가 뜨도록 했습니다.
- TempMeetUp(모델), TempMeetUpData(임시데이터)를 만들어 퀘스트셀을 그리고 셀 하나를 탭하면 그 데이터로 MeetUpView를 그리도록 했습니다.
- MeetUpView는 체크인뷰 모달 내에서 네비게이션으로 이동되도록 했습니다.
- PlaceCheckInView UI를 피그마에 맞춰 일부 수정했습니다.

## 리뷰 노트
- MeetUp모델이 있는데 TempMeetUp를 만들어서 한 것은 각종 id값들을 임의로 넣기 어려워서.. 일단 단순히 콜렉션뷰셀 내 콜렉션뷰셀 탭했을 때 데이터를 가지고 상세뷰로 이동하는 것을 구현하기 위함이었습니다. 추후 데이터 연결 시 바꾸어야 합니다.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012157/201267067-6be5c0b6-eb9b-46eb-b366-cb63ee408dba.gif" width="300">

## Reference
- [TableViewCell 내 CollectionViewCell 탭하여 present/pushViewController 동작](https://www.youtube.com/watch?v=KCgYDCKqato)
- [모달 내 네비게이션 동작](https://stackoverflow.com/questions/56435510/presenting-modal-in-ios-13-fullscreen/58255416#58255416)
- [네비게이션 있는 모달 풀스크린으로 만들기](https://stackoverflow.com/questions/56435510/presenting-modal-in-ios-13-fullscreen/58255416#58255416)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
