### PR TITLE
[Fix] 캘린더뷰 비짓카드 다중생성 및 코드 리펙토링

### DIFF
--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -366,7 +366,7 @@ extension CalendarViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.item >= calendarDateFormatter.getStartingDayOfWeek(addedMonth: monthAddedMemory) {
             selectedCell = indexPath.item
-            let year = "2022"
+            let year = String(Contents.todayDate()["year"] ?? 0)
             let month = String(format: "%02d", (Contents.todayDate()["month"] ?? 0)+monthAddedMemory)
             let day = String(format: "%02d", (selectedCell ?? 0) - calendarDateFormatter.getStartingDayOfWeek(addedMonth: monthAddedMemory)+1)
             let dateString = year+"-"+month+"-"+day
@@ -382,10 +382,6 @@ extension CalendarViewController: UICollectionViewDelegate {
             calendarCollectionView.reloadData()
             visitInfoView.reloadData()
         }
-    }
-    
-    func check(completion: @escaping([CheckIn]) -> ()) {
-        
     }
     
 }

--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -18,6 +18,7 @@ class CalendarViewController: UIViewController {
     var calendarToggle: Bool = true
     private var selectedCell: Int? = Contents.todayDate()["day"]
     let calendarDateFormatter = CalendarDateFormatter()
+    var cardDataList: [CheckIn] = []
     
     private let visitCardListView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -44,7 +45,7 @@ class CalendarViewController: UIViewController {
         return collectionView
     }()
     
-    private let VisitInfoView: UICollectionView = {
+    private let visitInfoView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
@@ -155,8 +156,8 @@ class CalendarViewController: UIViewController {
         calendarCollectionView.dataSource = self
         calendarCollectionView.delegate = self
         
-        VisitInfoView.dataSource = self
-        VisitInfoView.delegate = self
+        visitInfoView.dataSource = self
+        visitInfoView.delegate = self
         
         visitCardListView.dataSource = self
         visitCardListView.delegate = self
@@ -203,7 +204,7 @@ class CalendarViewController: UIViewController {
         } else {
             calendarCollectionView.removeFromSuperview()
             calendarCollectionMonthHeader.removeFromSuperview()
-            VisitInfoView.removeFromSuperview()
+            visitInfoView.removeFromSuperview()
             dayOfWeekStackView.removeFromSuperview()
             minusMonthButton.removeFromSuperview()
             plusMonthButton.removeFromSuperview()
@@ -235,8 +236,8 @@ class CalendarViewController: UIViewController {
         calendarCollectionMonthHeader.anchor(top: calendarCollectionView.topAnchor, paddingTop: 10)
         calendarCollectionMonthHeader.centerX(inView: view)
         
-        view.addSubview(VisitInfoView)
-        VisitInfoView.anchor(top: view.topAnchor, left: view.leftAnchor, right: view.rightAnchor,
+        view.addSubview(visitInfoView)
+        visitInfoView.anchor(top: view.topAnchor, left: view.leftAnchor, right: view.rightAnchor,
                                 paddingTop: 557, paddingLeft: 14, paddingRight: 14, height: 256)
         
 //        view.addSubview(VisitInfoHeader)
@@ -270,8 +271,8 @@ extension CalendarViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if collectionView == calendarCollectionView {
             return self.calendarDateFormatter.days.count
-        } else if collectionView == VisitInfoView {
-            return 1 //TODO: 반응형 수정 필요
+        } else if collectionView == visitInfoView {
+            return cardDataList.count //TODO: 반응형 수정 필요
         } else {
             return CalendarViewController.checkInHistory?.count ?? 0
         }
@@ -328,7 +329,7 @@ extension CalendarViewController: UICollectionViewDelegate {
             
             return cell
             
-        } else if collectionView == VisitInfoView {
+        } else if collectionView == visitInfoView {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitingInfoCell.identifier , for: indexPath) as? VisitingInfoCell else {
                 return UICollectionViewCell()
             }
@@ -342,8 +343,8 @@ extension CalendarViewController: UICollectionViewDelegate {
             cell.layer.cornerRadius = 20
             
             cell.thisCellsDate = dateString
-            cell.checkInHistoryForCalendar = CalendarViewController.checkInHistory
-            
+//            cell.checkInHistoryForCalendar = CalendarViewController.checkInHistory
+            cell.checkInHistoryForCalendar = cardDataList[indexPath.item]
             return cell
             
         } else {
@@ -365,9 +366,26 @@ extension CalendarViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.item >= calendarDateFormatter.getStartingDayOfWeek(addedMonth: monthAddedMemory) {
             selectedCell = indexPath.item
+            let year = "2022"
+            let month = String(format: "%02d", (Contents.todayDate()["month"] ?? 0)+monthAddedMemory)
+            let day = String(format: "%02d", (selectedCell ?? 0) - calendarDateFormatter.getStartingDayOfWeek(addedMonth: monthAddedMemory)+1)
+            let dateString = year+"-"+month+"-"+day
+            cardDataList = []
+            guard let checkInHistory = CalendarViewController.checkInHistory else { return }
+            for checkin in checkInHistory {
+                if checkin.date == dateString {
+                    cardDataList.append(checkin)
+                }
+            }
+            
+            
             calendarCollectionView.reloadData()
-            VisitInfoView.reloadData()
+            visitInfoView.reloadData()
         }
+    }
+    
+    func check(completion: @escaping([CheckIn]) -> ()) {
+        
     }
     
 }
@@ -379,7 +397,7 @@ extension CalendarViewController: UICollectionViewDelegateFlowLayout {
         if collectionView == calendarCollectionView {
             return CGSize(width: 358/8, height: 358/7)
         } else {
-            return CGSize(width: VisitInfoView.frame.width, height: 119)
+            return CGSize(width: visitInfoView.frame.width, height: 119)
         }
         
     }

--- a/BNomad/View/ProfileView/ProfileGraphCell.swift
+++ b/BNomad/View/ProfileView/ProfileGraphCell.swift
@@ -47,7 +47,7 @@ class ProfileGraphCell: UICollectionViewCell {
         
         for index in 0...3 {
             let time = UILabel()
-            time.text = String(9 + index*5) //FIXME: 그래프 간격 어떻게 할건지? 현재는 데이터 로직 기준
+            time.text = String(9 + index*3) //FIXME: 그래프 간격 어떻게 할건지? 현재는 데이터 로직 기준
             time.textColor = .gray
             time.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
             time.translatesAutoresizingMaskIntoConstraints = false

--- a/BNomad/View/ProfileView/ProfileGraphCollectionCell.swift
+++ b/BNomad/View/ProfileView/ProfileGraphCollectionCell.swift
@@ -35,11 +35,11 @@ class ProfileGraphCollectionCell: UICollectionViewCell {
                     self.checkoutTime = formatter.string(from: checkin.checkOutTime ?? Date()).components(separatedBy: "-")
                     
                     //그래프의 시작/끝 픽셀 위치 잡아주는 계산
-                    let startAnchorCalculater = (((Double(checkinTime[0]) ?? 0) + (Double(checkinTime[1]) ?? 0) * Double(1.0/60.0)) - Double(9)) * Double(154.0/15.0)
-                    let endAnchorCalculater = Double(154.0) - ((((Double(checkoutTime[0]) ?? 0) + (Double(checkoutTime[1]) ?? 0) * Double(1.0/60.0)) - Double(9)) * Double(154.0/15.0))
+                    let startAnchorCalculater = (((Double(checkinTime[0]) ?? 0) + (Double(checkinTime[1]) ?? 0) * Double(1.0/60.0)) - Double(9)) * Double(154.0/9.0)
+                    let endAnchorCalculater = Double(154.0) - ((((Double(checkoutTime[0]) ?? 0) + (Double(checkoutTime[1]) ?? 0) * Double(1.0/60.0)) - Double(9)) * Double(154.0/9.0))
                     
-                    startAnchor = CGFloat(startAnchorCalculater)
-                    endAnchor = CGFloat(endAnchorCalculater)
+                    startAnchor = CGFloat(Int(startAnchorCalculater))
+                    endAnchor = CGFloat(Int(endAnchorCalculater))
                     
                     contentView.addSubview(graphRectView)
                     graphRectView.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, bottom: contentView.bottomAnchor, right: contentView.rightAnchor, paddingTop: self.startAnchor, paddingBottom: self.endAnchor)

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -29,7 +29,6 @@ class ProfileViewController: UIViewController {
         button.setImage(UIImage(systemName: "chevron.right"), for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
-        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
     
@@ -38,7 +37,6 @@ class ProfileViewController: UIViewController {
         button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
-        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
     
@@ -47,15 +45,13 @@ class ProfileViewController: UIViewController {
         
         profileGraphCellHeaderMaker(label: label, weekAdded: 0)
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
     private let visitCardCellHeaderLabel: UILabel = {
         let label = UILabel()
         label.text = "체크인 기록"
-        label.font = .preferredFont(forTextStyle: .headline, weight: .regular)
-        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
         return label
     }()
     
@@ -69,7 +65,6 @@ class ProfileViewController: UIViewController {
         collectionView.register(VisitingInfoCell.self, forCellWithReuseIdentifier: VisitingInfoCell.identifier)
         collectionView.register(ProfileGraphCell.self, forCellWithReuseIdentifier: ProfileGraphCell.identifier)
 
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
     
@@ -81,7 +76,6 @@ class ProfileViewController: UIViewController {
 //        collectionView.backgroundColor = .white
         collectionView.register(ProfileGraphCollectionCell.self, forCellWithReuseIdentifier: ProfileGraphCollectionCell.identifier)
 
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
     
@@ -116,6 +110,7 @@ class ProfileViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        profileGraphCollectionView.reloadData() //FIXME: 왜 리로드해야 정상표시되는지 ?? 버그픽스요망
         navigationController?.navigationBar.isHidden = false
     }
     
@@ -261,7 +256,8 @@ extension ProfileViewController: UICollectionViewDelegate {
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitingInfoCell.identifier , for: indexPath) as? VisitingInfoCell else {
                     return UICollectionViewCell()
                 }
-                
+                cell.layer.borderWidth = 2
+                cell.layer.borderColor = CustomColor.nomadBlue?.cgColor
                 cell.checkInHistoryForProfile = viewModel.user?.checkInHistory
                 cell.backgroundColor = .systemBackground
                 cell.layer.cornerRadius = 20

--- a/BNomad/View/ProfileView/VisitingInfoCell.swift
+++ b/BNomad/View/ProfileView/VisitingInfoCell.swift
@@ -33,37 +33,24 @@ class VisitingInfoCell: UICollectionViewCell {
         }
     }
     
-    var checkInHistoryForCalendar: [CheckIn]? {
+    var checkInHistoryForCalendar: CheckIn? {
         didSet {
-            viewOption = "calendar"
-            cardDataList = []
             guard let checkInHistory = checkInHistoryForCalendar else { return }
-            for checkin in checkInHistory {
-                if checkin.date == thisCellsDate {
-                    self.cardDataList.append(checkin)
-                }
-            }
-            
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "HH:mm"
             
-            if cardDataList.count != 0 {
-                cardDataList.forEach {
-                    let checkinTime = dateFormatter.string(from: $0.checkInTime)
+                    let checkinTime = dateFormatter.string(from: checkInHistory.checkInTime)
                     self.checkinTimeLabel.text = checkinTime
                     
-                    let stayedTime = Int(($0.checkOutTime?.timeIntervalSince($0.checkInTime) ?? 0) / 60)
+                    let stayedTime = Int((checkInHistory.checkOutTime?.timeIntervalSince(checkInHistory.checkInTime) ?? 0) / 60)
                     self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
-                }
-            } else {
-                self.checkinTimeLabel.text = ""
-                self.stayedTimeLabel.text = ""
-            }
-            let lastCheckIn = cardDataList.last
-            let place = self.viewModel.places.first {$0.placeUid == lastCheckIn?.placeUid}
+                
+
+            let place = self.viewModel.places.first {$0.placeUid == checkInHistory.placeUid}
             nameLabel.text = place?.name
         }
     }
+
     
     var checkInHistoryForProfile: [CheckIn]? {
         didSet {


### PR DESCRIPTION
## 관련 이슈들
- #205 

## 작업 내용
- 캘린더뷰에서 날짜 클릭 시 비짓카드가 하나만 생성되던 것을 체크인 갯수에 맞추어 여러개 생성될 수 있게 반응형 수정함
- 캘린더뷰컨트롤러, 캘린더뷰셀, 비짓카드셀 파일에 대해 상기 기능 구현에 관련된 로직 리펙토링 진행
- 프로필뷰의 통계 부분의 시간간격을 3시간으로 수정 (논의필요)
- 시간이 짧으면 보이지 않았던 문제 해결

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/70618615/201268583-a893898a-3b62-4392-af27-1d264c97ebcc.png" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
