### PR TITLE
[Feat] #208 3번째셀 구현

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		15B621FD2901469D00E31125 /* PlaceInfoViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B621FC2901469D00E31125 /* PlaceInfoViewCell.swift */; };
 		63159D1F291BD4A3000F41F5 /* ReviewSubCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63159D1E291BD4A3000F41F5 /* ReviewSubCell.swift */; };
 		631AD82B2906316B00EEED02 /* ReviewInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631AD82A2906316B00EEED02 /* ReviewInfoCell.swift */; };
+		633823EE291E1D5F004977BA /* WithNomadHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633823ED291E1D5F004977BA /* WithNomadHeader.swift */; };
 		6383330C2900CD6D005AB0C3 /* PlaceInfoModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383330B2900CD6D005AB0C3 /* PlaceInfoModalViewController.swift */; };
 		6383330E2900CDBA005AB0C3 /* PlaceInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383330D2900CDBA005AB0C3 /* PlaceInfoCell.swift */; };
 		7E5CF5D42906886A00641E74 /* CheckInCardViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5CF5D32906886A00641E74 /* CheckInCardViewCell.swift */; };
@@ -55,8 +56,8 @@
 		E25A675828F7E515004614B0 /* DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A675728F7E515004614B0 /* DummyData.swift */; };
 		E25AD9E42912239A00F815B2 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = E25AD9E32912239A00F815B2 /* FirebaseRemoteConfig */; };
 		E27CEECF2912C38900369A6E /* RCValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27CEECE2912C38900369A6E /* RCValue.swift */; };
-		E27CEED62919F57D00369A6E /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = E27CEED52919F57D00369A6E /* Kingfisher */; };
 		E27CEED12919118C00369A6E /* MeetUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27CEED02919118C00369A6E /* MeetUp.swift */; };
+		E27CEED62919F57D00369A6E /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = E27CEED52919F57D00369A6E /* Kingfisher */; };
 		E2ADB25A2906D44200082596 /* FirebaseTestVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2ADB2592906D44200082596 /* FirebaseTestVC.swift */; };
 		E2E6B23028FE7542005C0D77 /* CheckIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E6B22F28FE7542005C0D77 /* CheckIn.swift */; };
 		E2E6B23228FE757D005C0D77 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E6B23128FE757D005C0D77 /* Date+Extension.swift */; };
@@ -86,6 +87,7 @@
 		15B621FC2901469D00E31125 /* PlaceInfoViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceInfoViewCell.swift; sourceTree = "<group>"; };
 		63159D1E291BD4A3000F41F5 /* ReviewSubCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSubCell.swift; sourceTree = "<group>"; };
 		631AD82A2906316B00EEED02 /* ReviewInfoCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewInfoCell.swift; sourceTree = "<group>"; };
+		633823ED291E1D5F004977BA /* WithNomadHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithNomadHeader.swift; sourceTree = "<group>"; };
 		6383330B2900CD6D005AB0C3 /* PlaceInfoModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceInfoModalViewController.swift; sourceTree = "<group>"; };
 		6383330D2900CDBA005AB0C3 /* PlaceInfoCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceInfoCell.swift; sourceTree = "<group>"; };
 		7E5CF5D228FFB73400641E74 /* BNomad.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BNomad.entitlements; sourceTree = "<group>"; };
@@ -152,6 +154,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		633823EC291E1D34004977BA /* WithNomadCell */ = {
+			isa = PBXGroup;
+			children = (
+				633823ED291E1D5F004977BA /* WithNomadHeader.swift */,
+			);
+			path = WithNomadCell;
+			sourceTree = "<group>";
+		};
 		63A2951C291CB2F300181ECE /* ReviewSubCell */ = {
 			isa = PBXGroup;
 			children = (
@@ -289,6 +299,7 @@
 				6383330D2900CDBA005AB0C3 /* PlaceInfoCell.swift */,
 				631AD82A2906316B00EEED02 /* ReviewInfoCell.swift */,
 				63A2951C291CB2F300181ECE /* ReviewSubCell */,
+				633823EC291E1D34004977BA /* WithNomadCell */,
 			);
 			path = PlaceInfoView;
 			sourceTree = "<group>";
@@ -488,6 +499,7 @@
 				E2E6B23228FE757D005C0D77 /* Date+Extension.swift in Sources */,
 				E2E6B23428FE75F7005C0D77 /* String+Extension.swift in Sources */,
 				DF561CAD291A02840099D41D /* QuestCollectionViewCell.swift in Sources */,
+				633823EE291E1D5F004977BA /* WithNomadHeader.swift in Sources */,
 				7E97254E2919160800AA9F44 /* NewMeetUpViewController.swift in Sources */,
 				DF9618AE28FCEFC200E21D30 /* SignUpViewController.swift in Sources */,
 				8CC750912919F330009F9C91 /* RegionSelectViewController.swift in Sources */,

--- a/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
@@ -75,7 +75,7 @@ class PlaceInfoCell: UICollectionViewCell {
     
     lazy var questLabel: UILabel = {
         let questLabel = UILabel()
-        questLabel.text = "5개의 퀘스트"
+        questLabel.text = "5개의 MeetUp"
         questLabel.textColor = CustomColor.nomadBlack
         questLabel.font = .preferredFont(forTextStyle: .body, weight: .regular)
         let fullText = questLabel.text ?? ""

--- a/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
@@ -75,7 +75,7 @@ class PlaceInfoCell: UICollectionViewCell {
     
     lazy var questLabel: UILabel = {
         let questLabel = UILabel()
-        questLabel.text = "5개의 MeetUp"
+        questLabel.text = "5개의 밋업"
         questLabel.textColor = CustomColor.nomadBlack
         questLabel.font = .preferredFont(forTextStyle: .body, weight: .regular)
         let fullText = questLabel.text ?? ""
@@ -193,8 +193,6 @@ class PlaceInfoCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .white
-        
         configureUI()
     }
     

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -13,7 +13,15 @@ import MapKit
 class PlaceInfoModalViewController: UIViewController {
     
     // MARK: - Properties
-    var selectedPlace: Place?
+    var selectedPlace: Place? {
+        didSet {
+            guard let selectedPlace = selectedPlace else { return }
+            FirebaseManager.shared.fetchCheckInHistory(placeUid: selectedPlace.placeUid) { checkInHistory in
+                let history = checkInHistory.filter { $0.checkOutTime == nil }
+                self.checkInHistory = history
+            }
+        }
+    }
         
     let locationManager = CLLocationManager()
     lazy var currentLocation = locationManager.location
@@ -28,6 +36,19 @@ class PlaceInfoModalViewController: UIViewController {
         let placeInfoCollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowlayout)
         return placeInfoCollectionView
     }()
+    
+    var checkInHistory: [CheckIn]? {
+        didSet {
+            guard let checkInHistory = checkInHistory else { return }
+            numberOfUsers = checkInHistory.count
+            placeInfoCollectionView.reloadData()
+        }
+    }
+    
+    private var numberOfUsers: Int = 0
+//    {
+//        checkInHistory?.count ?? 0
+//    }
 
     // TODO: - checkIn, checkOut 버튼 하나로 통일 후 user.isChecked 기반으로 버튼 상태 변경
     lazy var checkInButton: UIButton = {
@@ -219,6 +240,7 @@ class PlaceInfoModalViewController: UIViewController {
         placeInfoCollectionView.backgroundColor = CustomColor.nomadGray3
         placeInfoCollectionView.register(PlaceInfoCell.self, forCellWithReuseIdentifier: PlaceInfoCell.cellIdentifier)
         placeInfoCollectionView.register(ReviewInfoCell.self, forCellWithReuseIdentifier: ReviewInfoCell.cellIdentifier)
+        placeInfoCollectionView.register(WithNomadHeader.self, forCellWithReuseIdentifier: WithNomadHeader.identifier)
         placeInfoCollectionView.register(CheckedProfileListViewCell.self, forCellWithReuseIdentifier: CheckedProfileListViewCell.identifier)
         view.addSubview(placeInfoCollectionView)
         placeInfoCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
@@ -256,22 +278,39 @@ class PlaceInfoModalViewController: UIViewController {
 // MARK: - UICollectionViewDataSource
 
 extension PlaceInfoModalViewController: UICollectionViewDataSource {
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        if section == 3 {
+            return self.checkInHistory?.count ?? 0
+        }
         return 1
     }
-    //enum 공부
+    
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if indexPath.section == 0 {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PlaceInfoCell.cellIdentifier, for: indexPath) as? PlaceInfoCell else { return UICollectionViewCell() }
             cell.position = currentLocation
             cell.place = selectedPlace
+            
             return cell
-        } else if indexPath.section == 1 {
+        }
+        else if indexPath.section == 1 {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReviewInfoCell.cellIdentifier, for: indexPath) as? ReviewInfoCell else { return UICollectionViewCell() }
             return cell
         }
         else if indexPath.section == 2 {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: WithNomadHeader.identifier, for: indexPath) as? WithNomadHeader else { return UICollectionViewCell() }
+            cell.numberOfUsers = numberOfUsers
+           
+            return cell
+        }
+        else if indexPath.section == 3 {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CheckedProfileListViewCell.identifier, for: indexPath) as? CheckedProfileListViewCell else { return UICollectionViewCell() }
+            
+            guard let checkIn = checkInHistory else { return UICollectionViewCell() }
+            let userUids = checkIn.compactMap {$0.userUid}
+            cell.userUid = userUids[indexPath.row]
+            
             return cell
         }
         
@@ -279,7 +318,7 @@ extension PlaceInfoModalViewController: UICollectionViewDataSource {
     }
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 3
+        return 4
     }
 }
 
@@ -307,16 +346,15 @@ extension PlaceInfoModalViewController: UICollectionViewDelegateFlowLayout {
         let sectionZeroHeight = sectionZeroCardHeight + sectionZeroBottomPadding
         
         if indexPath.section == 0 {
-            print(sectionZeroHeight)
             return CGSize(width: viewWidth, height: 400)
         } else if indexPath.section == 1 {
             return CGSize(width: viewWidth, height: 450)
         } else if indexPath.section == 2 {
-            return CGSize(width: viewWidth, height: 664)
+            return CGSize(width: viewWidth, height: 27)
         } else if indexPath.section == 3 {
             flow.sectionInset.top = 13
             
-            return CGSize(width: 356, height: 85)
+            return CGSize(width: 349, height: 68)
         } else {
             return CGSize(width: viewWidth, height: 0)
         }

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -46,9 +46,7 @@ class PlaceInfoModalViewController: UIViewController {
     }
     
     private var numberOfUsers: Int = 0
-//    {
-//        checkInHistory?.count ?? 0
-//    }
+
 
     // TODO: - checkIn, checkOut 버튼 하나로 통일 후 user.isChecked 기반으로 버튼 상태 변경
     lazy var checkInButton: UIButton = {
@@ -58,7 +56,7 @@ class PlaceInfoModalViewController: UIViewController {
         button.backgroundColor = CustomColor.nomadBlue
         button.layer.cornerRadius = 8
         button.addTarget(self, action: #selector(checkIn), for: .touchUpInside)
-//        button.isHidden = self.isCheckedIn ? true : false
+        
         return button
     }()
     
@@ -69,7 +67,7 @@ class PlaceInfoModalViewController: UIViewController {
         button.backgroundColor = CustomColor.nomadGray1
         button.layer.cornerRadius = 8
         button.addTarget(self, action: #selector(checkOut), for: .touchUpInside)
-//        button.isHidden = self.isCheckedIn ? false : true
+
         return button
     }()
     
@@ -80,7 +78,6 @@ class PlaceInfoModalViewController: UIViewController {
         configureCollectionView()
         configureCheckInButton()
         setupSheet()
-//        fetchPlaceAll()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -94,13 +91,6 @@ class PlaceInfoModalViewController: UIViewController {
         delegateForClearAnnotation?.clearAnnotation(view: MKAnnotationFromPlace.convertPlaceToAnnotation(selectedPlace))
     }
     
-//    func fetchPlaceAll() {
-//        FirebaseManager.shared.fetchPlaceAll { place in
-//            self.selectedPlace = place
-////            print(place)
-//        }
-//    }
-    
     // MARK: - Actions
     
     @objc func checkOut() {
@@ -108,8 +98,6 @@ class PlaceInfoModalViewController: UIViewController {
         let checkOutAlert = UIAlertController(title: "체크아웃", message: "체크아웃하시겠습니까?", preferredStyle: .alert)
         checkOutAlert.addAction(UIAlertAction(title: "취소", style: .cancel))
         checkOutAlert.addAction(UIAlertAction(title: "확인", style: .default, handler: { action in
-            // checkIn Uid 받아오기
-
             guard
                 var checkIn = self.viewModel.user?.currentCheckIn
             else {
@@ -159,7 +147,6 @@ class PlaceInfoModalViewController: UIViewController {
         }
     }
     
-    // 로그인 체크
     func loginCheck() {
         print("loginCheck")
         let checkOutAlert = UIAlertController(title: "로그인하시겠습니까?", message: "로그인하시면 체크인하실 수 있습니다.", preferredStyle: .alert)
@@ -172,7 +159,6 @@ class PlaceInfoModalViewController: UIViewController {
         present(checkOutAlert, animated: true)
     }
     
-    // 맵의 특정 장소가 500미터 반경 이내인지 체크
     func distanceChecker() {
         let boundary = CLCircularRegion(center: currentLocation?.coordinate ?? CLLocationCoordinate2D(latitude: 0, longitude: 0), radius: 100000000500.0, identifier: "반경 500m")
         
@@ -237,7 +223,7 @@ class PlaceInfoModalViewController: UIViewController {
     func configureCollectionView() {
         placeInfoCollectionView.dataSource = self
         placeInfoCollectionView.delegate = self
-        placeInfoCollectionView.backgroundColor = CustomColor.nomadGray3
+        placeInfoCollectionView.backgroundColor = .white
         placeInfoCollectionView.register(PlaceInfoCell.self, forCellWithReuseIdentifier: PlaceInfoCell.cellIdentifier)
         placeInfoCollectionView.register(ReviewInfoCell.self, forCellWithReuseIdentifier: ReviewInfoCell.cellIdentifier)
         placeInfoCollectionView.register(WithNomadHeader.self, forCellWithReuseIdentifier: WithNomadHeader.identifier)
@@ -348,7 +334,7 @@ extension PlaceInfoModalViewController: UICollectionViewDelegateFlowLayout {
         if indexPath.section == 0 {
             return CGSize(width: viewWidth, height: 400)
         } else if indexPath.section == 1 {
-            return CGSize(width: viewWidth, height: 450)
+            return CGSize(width: viewWidth, height: 370)
         } else if indexPath.section == 2 {
             return CGSize(width: viewWidth, height: 27)
         } else if indexPath.section == 3 {

--- a/BNomad/View/PlaceInfoView/ReviewInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/ReviewInfoCell.swift
@@ -44,8 +44,6 @@ class ReviewInfoCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .white
-        
         configureUI()
     }
     required init?(coder: NSCoder) {

--- a/BNomad/View/PlaceInfoView/WithNomadCell/WithNomadHeader.swift
+++ b/BNomad/View/PlaceInfoView/WithNomadCell/WithNomadHeader.swift
@@ -1,0 +1,62 @@
+//
+//  WithNomadHeader.swift
+//  BNomad
+//
+//  Created by 유재훈 on 2022/11/11.
+//
+
+import UIKit
+
+class WithNomadHeader: UICollectionViewCell {
+    
+    static let identifier = "WithNomadHeader"
+    
+    var numberOfUsers: Int = 0 {
+        didSet {
+            label.text = "함께 일하고 있는 \(numberOfUsers)명의 노마더"
+            let fullText = label.text ?? ""
+            let attribtuedString = NSMutableAttributedString(string: fullText)
+            let range = (fullText as NSString).range(of: "\(numberOfUsers)명")
+            attribtuedString.addAttribute(.foregroundColor, value: CustomColor.nomadBlue as Any, range: range)
+            label.attributedText = attribtuedString
+        }
+    }
+    
+
+    // MARK: - Properties
+    
+    lazy var label: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        label.textColor = CustomColor.nomadBlack
+
+        return label
+    }()
+    
+    lazy var numberOfPeople: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        label.textColor = CustomColor.nomadBlue
+        
+        return label
+    }()
+    
+    // MARK: - LifeCycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.addSubview(label)
+        setui()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Helpers
+    
+    func setui() {
+        label.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 0, paddingLeft: 20)
+    }
+}
+

--- a/BNomad/View/PlaceInfoView/WithNomadCell/WithNomadHeader.swift
+++ b/BNomad/View/PlaceInfoView/WithNomadCell/WithNomadHeader.swift
@@ -46,6 +46,7 @@ class WithNomadHeader: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.addSubview(label)
+        backgroundColor = .white
         setui()
     }
     

--- a/BNomad/View/PlaceInfoView/WithNomadCell/WithNomadHeader.swift
+++ b/BNomad/View/PlaceInfoView/WithNomadCell/WithNomadHeader.swift
@@ -13,41 +13,40 @@ class WithNomadHeader: UICollectionViewCell {
     
     var numberOfUsers: Int = 0 {
         didSet {
-            label.text = "함께 일하고 있는 \(numberOfUsers)명의 노마더"
-            let fullText = label.text ?? ""
+            withNomadCountLabel.text = "함께 일하고 있는 \(numberOfUsers)명의 노마더"
+            let fullText = withNomadCountLabel.text ?? ""
             let attribtuedString = NSMutableAttributedString(string: fullText)
             let range = (fullText as NSString).range(of: "\(numberOfUsers)명")
             attribtuedString.addAttribute(.foregroundColor, value: CustomColor.nomadBlue as Any, range: range)
-            label.attributedText = attribtuedString
+            withNomadCountLabel.attributedText = attribtuedString
         }
     }
     
 
     // MARK: - Properties
     
-    lazy var label: UILabel = {
-        let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
-        label.textColor = CustomColor.nomadBlack
+    lazy var withNomadCountLabel: UILabel = {
+        let withNomadCountLabel = UILabel()
+        withNomadCountLabel.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        withNomadCountLabel.textColor = CustomColor.nomadBlack
 
-        return label
+        return withNomadCountLabel
     }()
     
     lazy var numberOfPeople: UILabel = {
-        let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
-        label.textColor = CustomColor.nomadBlue
+        let numberOfPeople = UILabel()
+        numberOfPeople.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        numberOfPeople.textColor = CustomColor.nomadBlue
         
-        return label
+        return numberOfPeople
     }()
     
     // MARK: - LifeCycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.addSubview(label)
-        backgroundColor = .white
-        setui()
+        self.addSubview(withNomadCountLabel)
+        setUi()
     }
     
     required init?(coder: NSCoder) {
@@ -56,8 +55,8 @@ class WithNomadHeader: UICollectionViewCell {
     
     // MARK: - Helpers
     
-    func setui() {
-        label.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 0, paddingLeft: 20)
+    func setUi() {
+        withNomadCountLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 0, paddingLeft: 20)
     }
 }
 


### PR DESCRIPTION
## 관련 이슈들
- #208

## 작업 내용
- PlaceinfoModalViewController내 컬렉션뷰에 섹션 추가

- Header를 새로운 셀로 분리하여 데이터 바인딩, 텍스트 변경

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-11 at 16 51 05](https://user-images.githubusercontent.com/103012086/201292364-d261a017-9a37-4c76-a5da-8e7d57fe56f4.gif)


## Reference
-Will이 구현한 CheckedProfileListHeader 변경
-CheckedProfileListViewCell 3번 섹션에 적용

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
