### PR TITLE
[Fix] 맵 안에 보이는 장소들만 골라서 리스트에 보내주기

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -256,10 +256,10 @@
 			children = (
 				DFE747C829000FAF0048E70A /* ProfileEditView */,
 				0413519E28FE534D005D19CC /* SelfUserInfoCell.swift */,
+				DF9618AF28FCEFCB00E21D30 /* ProfileViewController.swift */,
 				041351A028FF7E72005D19CC /* VisitingInfoCell.swift */,
 				041351A228FF7E98005D19CC /* ProfileGraphCell.swift */,
 				041351AC29081D16005D19CC /* ProfileGraphCollectionCell.swift */,
-				DF9618AF28FCEFCB00E21D30 /* ProfileViewController.swift */,
 				041351A828FFF4FB005D19CC /* CalendarCell.swift */,
 				041351A628FFF459005D19CC /* CalendarViewController.swift */,
 			);

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -359,13 +359,6 @@ class MapViewController: UIViewController {
         map.addSubview(compass)
         compass.anchor(top: map.topAnchor, left: map.leftAnchor, paddingTop: 110, paddingLeft: 15, width: 40, height: 40)
         
-
-        FirebaseManager.shared.fetchPlaceAll { place in
-            self.map.addAnnotation(MKAnnotationFromPlace.convertPlaceToAnnotation(place))
-            self.viewModel.places.append(place)
-            self.checkInBinding()
-        }
-        
         map.addSubview(listViewButton)
         listViewButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, paddingLeft: 15, paddingBottom: 70, width: 40, height: 40)
         
@@ -396,14 +389,12 @@ extension MapViewController: MKMapViewDelegate {
     
 
     func mapViewDidChangeVisibleRegion(_ mapView: MKMapView) {
+        visiblePlacesOnMap = []
+        
         for place in viewModel.places {
-            if mapView.visibleMapRect.contains(MKMapRect(origin: MKMapPoint(CLLocationCoordinate2D(latitude: place.latitude, longitude: place.longitude)), size: MKMapSize(width: 0.2, height: 0.2))) // 맵 이동 시 정확도 검증을 위해 남겨둡니다.
-//            if mapView.visibleMapRect.contains(MKMapPoint(CLLocationCoordinate2D(latitude: place.latitude, longitude: place.longitude)))
+            if mapView.visibleMapRect.contains(MKMapPoint(CLLocationCoordinate2D(latitude: place.latitude, longitude: place.longitude)))
             {
                 print(place, "visible")
-                if visiblePlacesOnMap.contains { $0.name == place.name } {
-                    return
-                }
                 visiblePlacesOnMap.append(place)
             } else {
                 print(place, "invisible")

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -39,13 +39,7 @@ class MapViewController: UIViewController {
     
     var selectedRegion: Region?
     
-    var visiblePlacesOnMap: [Place] = [] {
-        didSet {
-            let vc = CustomModalViewController()
-            vc.places = visiblePlacesOnMap
-//            mapViewDidChangeVisibleRegion(map)
-        }
-    }
+    var visiblePlacesOnMap: [Place] = []
     
     // 맵 띄우기
     private lazy var map: MKMapView = {

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -153,7 +153,7 @@ class PlaceInfoModalViewController: UIViewController {
     
     // 맵의 특정 장소가 500미터 반경 이내인지 체크
     func distanceChecker() {
-        let boundary = CLCircularRegion(center: currentLocation?.coordinate ?? CLLocationCoordinate2D(latitude: 0, longitude: 0), radius: 100000000500.0, identifier: "반경 500m")
+        let boundary = CLCircularRegion(center: currentLocation?.coordinate ?? CLLocationCoordinate2D(latitude: 0, longitude: 0), radius: 1000, identifier: "반경 500m")
         
 
               // TODO: - 하드 코딩된 부분 변경 -> "노마드 제주에 체크인 하시겠습니까?" ---- 완료

--- a/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
+++ b/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
@@ -76,7 +76,10 @@ class CustomModalViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        places = viewModel.places
+//    places: [Place] = {
+//        let placesOnMap = viewModel.places.filter(map)
+//    }
+//        viewModel.places
         
 //        self.view.layer.backgroundColor = UIColor(red: 0.967, green: 0.967, blue: 0.967, alpha: 1).cgColor
         self.view.layer.backgroundColor = CustomColor.nomadGray3?.cgColor


### PR DESCRIPTION
## 관련 이슈들
- #202 

## 작업 내용
- 맵뷰 delegate 중 mapViewDidChangeVisibleRegion 메소드를 사용해서 지도에서 보는 영역을 바꿀 때마다 함수를 실행하게 했습니다.
- 맵 안에 보이는 영역 (mapView.visibleMapRect) 과 핀을 표시하는 포인트 (MKMapPoint) 를 비교해서 포인트가 영역 안에 포함되는지 판별하게 했습니다.
- 판별 후 영역 안에 있는 핀 -> 장소 정보는 visiblePlacesOnMap 이라는 커스텀 배열 안에 추가하고, 영역 안에서 사라지는 장소는 배열에서 뺍니다.
- 테스트 결과 작동은 합니다만, 정확도가 높지는 않습니다 ㅠㅠ 정확도를 높이기 위한 추가 작업을 할 예정입니다.

## 리뷰 노트
- 지도를 아주 조금만 움직여도 굉장히 많은 횟수로 영역 내 있는지 없는지 체크를 하는 걸 콘솔을 통해 볼 수 있었습니다. 나중에 앱 속도 저하 문제가 생기거나 하지는 않을지 걱정이 되네요.
- 정확도 문제가 2가지 부분에서 생기는 것 같습니다. 계속 개선할 예정인데 조언 부탁드립니다.
  - 맵 영역이 우리가 폰으로 보는 영역과 미세하게 다를 경우, 화면에는 핀이 약간 보이는데 앱은 영역 밖으로 나갔다고 인식
  - 영역 내 핀 포함여부를 제대로 인식하더라도 리스트에 바로 바인딩해주는 게 시차가 생기는 문제

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012800/201296171-6c6c2469-feb1-4fc6-b07b-4d1c08b5a074.gif" width="300">


## Reference
- https://developer.apple.com/documentation/mapkit/mkmapviewdelegate/2998428-mapviewdidchangevisibleregion
- https://developer.apple.com/documentation/mapkit/mkmapview/1452732-visiblemaprect

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
