### PR TITLE
[Feat] #210 애플로그인모달 UI완성

### DIFF
--- a/BNomad/View/LoginView/LoginViewController.swift
+++ b/BNomad/View/LoginView/LoginViewController.swift
@@ -12,17 +12,35 @@ class LoginViewController: UIViewController {
     
     // MARK: - Properties
     
-    private let logoView: UIImageView = {
-        let view = UIImageView()
-        view.image = UIImage(named: "tempLogo")
-        
-        return view
+    private let loginTitle: UILabel = {
+        let label = UILabel()
+        label.text = "로그인이 필요합니다!"
+        label.font = .preferredFont(forTextStyle: .title1, weight: .bold)
+        return label
+    }()
+    
+    private let reasonDescription: UILabel = {
+        let label = UILabel()
+        label.text = "업무공간 체크인, 퀘스트 참여 등을 위해 회원가입 및 로그인을 해주세요. 추후에 프로필, 체크인에 따라 다르게 바꿀예정"
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.font = .preferredFont(forTextStyle: .body, weight: .regular)
+        return label
     }()
     
     private let loginButton: ASAuthorizationAppleIDButton = {
         let button = ASAuthorizationAppleIDButton(type: .signIn, style: .whiteOutline)
-        button.cornerRadius = 50
-        
+        button.cornerRadius = 100
+        return button
+    }()
+    
+    private lazy var laterButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("다음에 하기", for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        button.setUnderline()
+        button.tintColor = CustomColor.nomadGray1
+        button.addTarget(self, action: #selector(later), for: .touchUpInside)
         return button
     }()
     
@@ -32,36 +50,15 @@ class LoginViewController: UIViewController {
         super.viewDidLoad()
         
         configUI()
-        setupProviderLoginView()
-    }
-    
-    // MARK: - Methods
-    
-    func setupProviderLoginView() {
         loginButton.addTarget(self, action: #selector(handleAuthorizationAppleIDButtonPress), for: .touchUpInside)
+        
     }
     
-    func configUI() {
-        let viewWidth = view.bounds.width
-        let viewHeight = view.bounds.height
-        let imageWidth = viewWidth * 196/390
-        let imageHeight = viewHeight * 33/844
-        let buttonWidth = viewWidth * 268/390
-        let buttonHeight = viewHeight * 50/844
-        let buttonBottom = viewHeight * 143/844
-        
-        view.backgroundColor = .white
-        
-        view.addSubview(logoView)
-        logoView.center(inView: view)
-        logoView.setDimensions(height: imageHeight, width: imageWidth)
-        
-        view.addSubview(loginButton)
-        loginButton.centerX(inView: logoView)
-        loginButton.anchor(bottom: view.bottomAnchor, paddingBottom: buttonBottom, width: buttonWidth, height: buttonHeight)
-    }
+    // MARK: - Action
     
-    // MARK: - Actions
+    @objc func later() {
+        self.dismiss(animated: true)
+    }
     
     @objc func handleAuthorizationAppleIDButtonPress() {
         let appleIDprovider = ASAuthorizationAppleIDProvider()
@@ -72,6 +69,28 @@ class LoginViewController: UIViewController {
         controller.delegate = self
         controller.presentationContextProvider = self
         controller.performRequests()
+    }
+    
+    // MARK: - Methods
+    
+    func configUI() {
+        view.backgroundColor = .systemBackground
+    
+        view.addSubview(loginTitle)
+        loginTitle.anchor(top: view.topAnchor, paddingTop: 80)
+        loginTitle.centerX(inView: view)
+        
+        view.addSubview(reasonDescription)
+        reasonDescription.anchor(top: loginTitle.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 26, paddingLeft: 60, paddingRight: 60)
+        reasonDescription.centerX(inView: view)
+        
+        view.addSubview(loginButton)
+        loginButton.anchor(top: reasonDescription.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 47, paddingLeft: 60, paddingRight: 60, height: 50)
+        
+        view.addSubview(laterButton)
+        laterButton.anchor(top: loginButton.bottomAnchor, paddingTop: 33, width: 100, height: 30)
+        laterButton.centerX(inView: view)
+        
     }
 }
 
@@ -87,6 +106,9 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
             print("#1 userIdentifier: \(userIdentifier)")
             print("#2 fullName: \(String(describing: fullName))")
             print("#3 email: \(String(describing: email))")
+            
+            // TODO: 추후 이 modal을 내리고 SignUpViewController를 띄우기 위함
+            // self.dismiss(animated: true)
             
             let signUpViewController = SignUpViewController()
             signUpViewController.modalPresentationStyle = .fullScreen
@@ -105,5 +127,17 @@ extension LoginViewController: ASAuthorizationControllerPresentationContextProvi
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         
         return self.view.window!
+    }
+}
+
+// MARK: - UIButton+setUnderline
+// REF: https://ios-development.tistory.com/742
+
+extension UIButton {
+    func setUnderline() {
+        guard let title = title(for: .normal) else { return }
+        let attributedString = NSMutableAttributedString(string: title)
+        attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 0, length: title.count))
+        setAttributedTitle(attributedString, for: .normal)
     }
 }


### PR DESCRIPTION
## 관련 이슈들
- #210 

## 작업 내용
- 기존 LoginViewController에서 UI를 업데이트해서 작업했습니다.
- LoginViewController의 기본 액션과 UI만 작성을 했기에, 뷰가 이어져 있지는 않습니다.

## 리뷰 노트
- @limhyoseok  apple login을 한뒤에 `SignUpViewController`로 이동하게 되는데, `SignUpViewController`를 꺼버리면, `LoginViewController`의 `authorizationController`에서 이미 FirebaseAuth에는 apple login이 완료되었다 생각해 정보가 올라가게 되지만, `SignUpViewController`에서 닉네임등을 다 작성해야 Firestore에 User 데이터가 올라가게되어 Auth와 Firestore가 일치하지 않는 문제가 있을 것 같습니다. 어떻게하면 좋을까요?

## 스크린샷(UX의 경우 gif)
피그마와 동일해, 하프모달에서 문제 없어 보입니다.
<img src="https://user-images.githubusercontent.com/72736657/201474200-2c655c78-b4be-4f00-8332-b11192d31ce4.png" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
