### PR TITLE
[Feat] #226 PlaceCheckInView 체크인, 이용시간 프로그레스바 구현

### DIFF
--- a/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
@@ -21,6 +21,11 @@ class CheckInCardViewCell: UICollectionViewCell {
     
     var viewModel = CombineViewModel.shared
     
+    private enum Value {
+        static let paddingLeftRight: CGFloat = 20.0
+        static let dayInMinutes: CGFloat = 1440.0
+    }
+    
     var user: User? {
         didSet {
             userNameLabel.text = user?.nickname
@@ -45,11 +50,24 @@ class CheckInCardViewCell: UICollectionViewCell {
             let hour = Int(timeInterval / 3600)
             let minute = Int(timeInterval / 60) % 60
             userTimeSpentLabel.text = String(hour) + "시간" + String(minute) + "분"
+
+            // 프로그래스바
+            var midnight: Date {
+                let cal = Calendar(identifier: .gregorian)
+                guard let checkInTime = checkIn?.checkInTime else { return Date() }
+                return cal.startOfDay(for: checkInTime)
+            }
+            guard let startTime = startTime else { return }
+            let checkInTimeInterval = startTime.timeIntervalSince(midnight)
+            let checkInTimeInMinutes = checkInTimeInterval / 60
+            let timeSpentInMinutes = timeInterval / 60
+
+            let timeBarWidth = self.bounds.width - (Value.paddingLeftRight * 2)
+            let checkInTimeBarPaddingLeft = timeBarWidth * checkInTimeInMinutes / Value.dayInMinutes
+            let checkInTimeBarPaddingRight = timeBarWidth * (1 - (checkInTimeInMinutes + timeSpentInMinutes) / Value.dayInMinutes )
             
-            // 이용시간 상태바
-            // MARK: 상태바가 표현할 정보 논의 후,
-            // 운영시간 대비 이용시간 비율에 맞게 표시해야함
-            
+            timeBar.addSubview(checkInTimeBar)
+            checkInTimeBar.anchor(top: timeBar.topAnchor, left: timeBar.leftAnchor, bottom: timeBar.bottomAnchor, right: timeBar.rightAnchor, paddingLeft: checkInTimeBarPaddingLeft, paddingRight: checkInTimeBarPaddingRight)
         }
     }
     
@@ -124,23 +142,23 @@ class CheckInCardViewCell: UICollectionViewCell {
     
     private let startTimeLabel: UILabel = {
         let label = UILabel()
-        label.text = "9:00"
-        label.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
+        label.text = "00:00"
+        label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
         label.textColor = CustomColor.nomadGray1
         return label
     }()
     
     private let endTimeLabel: UILabel = {
         let label = UILabel()
-        label.text = "22:00"
-        label.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
+        label.text = "24:00"
+        label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
         label.textColor = CustomColor.nomadGray1
         return label
     }()
     
     private let timeBar: UIView = {
         let view = UIView()
-        view.backgroundColor = CustomColor.nomadGray1
+        view.backgroundColor = CustomColor.nomadGray2
         view.layer.cornerRadius = 4
         return view
     }()
@@ -148,7 +166,6 @@ class CheckInCardViewCell: UICollectionViewCell {
     private let checkInTimeBar: UIView = {
         let view = UIView()
         view.backgroundColor = CustomColor.nomadBlue
-        view.tintColor = CustomColor.nomadBlue
         view.layer.cornerRadius = 4
         return view
     }()
@@ -199,11 +216,10 @@ class CheckInCardViewCell: UICollectionViewCell {
         timeStack.axis = .horizontal
         timeStack.distribution = .fill
         
-        timeBar.addSubview(checkInTimeBar)
-        checkInTimeBar.anchor(top: timeBar.topAnchor, left: timeBar.leftAnchor, bottom: timeBar.bottomAnchor, right: timeBar.rightAnchor, paddingLeft: 30, paddingRight: 30)
-        timeBar.anchor(height: 10)
+        timeBar.anchor(height: 8)
         let wholeStack = UIStackView(arrangedSubviews: [timeStack, timeBar])
         wholeStack.axis = .vertical
+        wholeStack.spacing = 4
         
         return wholeStack
     }()
@@ -252,7 +268,7 @@ class CheckInCardViewCell: UICollectionViewCell {
         cardRectangleView.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingBottom: 20)
         
         self.addSubview(stack)
-        stack.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 90, paddingLeft: 20, paddingRight: 20, height: 290)
+        stack.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 90, paddingLeft: Value.paddingLeftRight, paddingRight: Value.paddingLeftRight, height: 290)
         checkOutButton.anchor(height: 50)
     }
 }


### PR DESCRIPTION
- 피그마에 맞춰 자잘한 UI 수정
- 체크인, 이용시간 프로그래스바 구현

## 관련 이슈들
- (ex. #2, #3 ...)

## 작업 내용
- 0시부터 24시까지의 timeBar 위에 체크인 시간부터 이용시간(현재시간)까지 nomadBlue 컬러로 하이라이트 하였습니다.
    - timeBar 길이와 하루 길이(1440분)에 대한 비례식을 이용해서 checkInTimeBar의 좌우 padding이 달라지도록 했습니다.
- 피그마에 맞추어 자잘한 UI 수정했습니다.

## 리뷰 노트
- 프로그래스바가 `checkIn`의 `didSet` 안에서 그려지도록 했는데 더 좋은 방법이 있을지 모르겠습니다. configUI() 등 여러 위치에서 해봤는데 필요한 값(checkInTimeInMinutes)을 따로 변수로 만들어서 넣고 가져와도 값이 제대로 안들어가 있습니다..
 
## 스크린샷(UX의 경우 gif)
### iPhone 8(좌) / iPhone 14(우) 시뮬레이터

<img width="700" alt="Screen Shot 2022-11-14 at 4 37 40 PM" src="https://user-images.githubusercontent.com/103012157/201605072-8710dc05-e4fd-4de6-a428-ccc15abb1ef1.png">

## Reference
- 

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
