### PR TITLE
[Feat] 영업중 섹션 UI디자인 변경 적용

### DIFF
--- a/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
@@ -171,15 +171,15 @@ class PlaceInfoCell: UICollectionViewCell {
         return addressLable
     }()
     
-    private var chevronDirection: String = "chevron.down"
+//    private var chevronDirection: String = "chevron.down"
     
-    private lazy var openOperatingTimeButton: UIButton = {
-        let button = UIButton()
-        button.setImage(UIImage(systemName: chevronDirection)?.withTintColor(CustomColor.nomadGray1 ?? .blue, renderingMode: .alwaysOriginal), for: .normal)
-        button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
-        button.addTarget(self, action: #selector(openOrClose), for: .touchUpInside)
-        return button
-    }()
+//    private lazy var openOperatingTimeButton: UIButton = {
+//        let button = UIButton()
+//        button.setImage(UIImage(systemName: chevronDirection)?.withTintColor(CustomColor.nomadGray1 ?? .blue, renderingMode: .alwaysOriginal), for: .normal)
+//        button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
+//        button.addTarget(self, action: #selector(openOrClose), for: .touchUpInside)
+//        return button
+//    }()
     
     let horizontalDivider2: UILabel = {
         let horizontalDivider2 = UILabel()
@@ -199,20 +199,20 @@ class PlaceInfoCell: UICollectionViewCell {
         return horizontalDivider3
     }()
     //영업시간 외에 영업끝 함수 만들기
-    private var operatingStatusLabel: UILabel = {
-         var operatingStatusLabel = UILabel()
-        operatingStatusLabel.text = "영업중"
-        operatingStatusLabel.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
-        operatingStatusLabel.textColor = CustomColor.nomadBlack
-         return operatingStatusLabel
-     }()
+//    private var operatingStatusLabel: UILabel = {
+//         var operatingStatusLabel = UILabel()
+//        operatingStatusLabel.text = "영업중"
+//        operatingStatusLabel.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
+//        operatingStatusLabel.textColor = CustomColor.nomadBlack
+//         return operatingStatusLabel
+//     }()
     
     // 영업시간 데이터 없음
     private var operatingTimeLabel: UILabel = {
          var operatingTimeLabel = UILabel()
-        operatingTimeLabel.numberOfLines = 1
+        operatingTimeLabel.numberOfLines = 3
         operatingTimeLabel.lineBreakMode = .byWordWrapping
-        operatingTimeLabel.text = "            9 : 00 ~ 21 : 00\n\n월 9 : 00 ~ 21 : 00          토 9 : 00 ~ 21 : 00\n화 9 : 00 ~ 21 : 00          일 9 : 00 ~ 21 : 00\n수 9 : 00 ~ 21 : 00\n목 9 : 00 ~ 21 : 00\n금 9 : 00 ~ 21 : 00"
+        operatingTimeLabel.text = "주중 10:00 - 22:00\n주말 9:00 - 20:00\n한줄 여유"
         operatingTimeLabel.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
         operatingTimeLabel.textColor = CustomColor.nomadBlack
 
@@ -282,9 +282,9 @@ class PlaceInfoCell: UICollectionViewCell {
         self.addSubview(mapButton)
         self.addSubview(horizontalDivider2)
         self.addSubview(clockButton)
-        self.addSubview(operatingStatusLabel)
+//        self.addSubview(operatingStatusLabel)
         self.addSubview(operatingTimeLabel)
-        self.addSubview(openOperatingTimeButton)
+//        self.addSubview(openOperatingTimeButton)
         self.addSubview(horizontalDivider3)
         self.addSubview(addressLabel)
         self.addSubview(alreadyCheckIn)
@@ -307,9 +307,9 @@ class PlaceInfoCell: UICollectionViewCell {
         addressLabel.anchor(top: horizontalDivider1.bottomAnchor, left: self.leftAnchor, paddingTop: 9, paddingLeft: 60)
         horizontalDivider2.anchor(top: horizontalDivider1.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 34, paddingLeft: 20, paddingRight: 20, height: 1)
         clockButton.anchor(top: horizontalDivider2.bottomAnchor, left: self.leftAnchor, paddingTop: 7, paddingLeft: 27)
-        operatingStatusLabel.anchor(top: horizontalDivider2.bottomAnchor, left: self.leftAnchor, paddingTop: 9, paddingLeft: 60)
+//        operatingStatusLabel.anchor(top: horizontalDivider2.bottomAnchor, left: self.leftAnchor, paddingTop: 9, paddingLeft: 60)
         operatingTimeLabel.anchor(top: horizontalDivider2.bottomAnchor, left: self.leftAnchor, paddingTop: 9, paddingLeft: 60)
-        openOperatingTimeButton.anchor(top: horizontalDivider2.bottomAnchor, right: self.rightAnchor, paddingTop: 9, paddingRight: 38)
+//        openOperatingTimeButton.anchor(top: horizontalDivider2.bottomAnchor, right: self.rightAnchor, paddingTop: 9, paddingRight: 38)
         horizontalDivider3.anchor(top: operatingTimeLabel.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 8, paddingLeft: 20, paddingRight: 20, height: 1)
         checkInButton.anchor(top: placeNameLabel.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 38, paddingLeft: 20, paddingRight: 20, height: 48)
         checkOutButton.anchor(top: placeNameLabel.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 38, paddingLeft: 20, paddingRight: 20, height: 48)
@@ -321,16 +321,16 @@ class PlaceInfoCell: UICollectionViewCell {
         addressLabel.text = place.address
         phoneNumberLable.text = place.contact
     }
-    @objc func openOrClose() {
-        if self.chevronDirection == "chevron.down" {
-            self.chevronDirection = "chevron.up"
-            self.openOperatingTimeButton.setImage(UIImage(systemName: "chevron.up")?.withTintColor(CustomColor.nomadGray1 ?? .blue, renderingMode: .alwaysOriginal), for: .normal)
-            self.operatingTimeLabel.numberOfLines = 0
-        } else if self.chevronDirection == "chevron.up" {
-            self.chevronDirection = "chevron.down"
-            self.openOperatingTimeButton.setImage(UIImage(systemName: "chevron.down")?.withTintColor(CustomColor.nomadGray1 ?? .blue, renderingMode: .alwaysOriginal), for: .normal)
-            self.operatingTimeLabel.numberOfLines = 1
-        } else { return }
-    }
+//    @objc func openOrClose() {
+//        if self.chevronDirection == "chevron.down" {
+//            self.chevronDirection = "chevron.up"
+//            self.openOperatingTimeButton.setImage(UIImage(systemName: "chevron.up")?.withTintColor(CustomColor.nomadGray1 ?? .blue, renderingMode: .alwaysOriginal), for: .normal)
+//            self.operatingTimeLabel.numberOfLines = 0
+//        } else if self.chevronDirection == "chevron.up" {
+//            self.chevronDirection = "chevron.down"
+//            self.openOperatingTimeButton.setImage(UIImage(systemName: "chevron.down")?.withTintColor(CustomColor.nomadGray1 ?? .blue, renderingMode: .alwaysOriginal), for: .normal)
+//            self.operatingTimeLabel.numberOfLines = 1
+//        } else { return }
+//    }
 }
 

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -214,6 +214,7 @@ extension PlaceInfoModalViewController: UICollectionViewDataSource {
         else if indexPath.section == 1 {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReviewInfoCell.cellIdentifier, for: indexPath) as? ReviewInfoCell else { return UICollectionViewCell() }
             cell.reviewHistory = reviewHistory
+            cell.delegate = self
             return cell
         }
         else if indexPath.section == 2 {
@@ -303,5 +304,14 @@ extension PlaceInfoModalViewController: ReviewPage {
         let controller = ReviewDetailViewController()
         controller.sheetPresentationController?.detents = [.large()]
         self.present(controller, animated: true)
+    }
+}
+
+// MARK: - ShowReviewListView
+
+extension PlaceInfoModalViewController: ShowReviewListView {
+    func didTapShowReviewListView() {
+        let ReviewListView = ReviewListViewController()
+        self.present(ReviewListView, animated: true, completion: nil)
     }
 }

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -341,3 +341,12 @@ extension PlaceInfoModalViewController: ReviewPage {
         self.present(controller, animated: true)
     }
 }
+
+// MARK: - ShowReviewListView
+
+extension PlaceInfoModalViewController: ShowReviewListView {
+    func didTapShowReviewListView() {
+        let ReviewListView = ReviewListViewController()
+        self.present(ReviewListView, animated: true, completion: nil)
+    }
+}

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -262,7 +262,7 @@ extension PlaceInfoModalViewController: UICollectionViewDelegateFlowLayout {
         let sectionZeroHeight = sectionZeroCardHeight + sectionZeroBottomPadding
         
         if indexPath.section == 0 {
-            return CGSize(width: viewWidth, height: 400)
+            return CGSize(width: viewWidth, height: 350)
         } else if indexPath.section == 1 {
             return CGSize(width: viewWidth, height: 370)
         } else if indexPath.section == 2 {

--- a/BNomad/View/PlaceInfoView/ReviewInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/ReviewInfoCell.swift
@@ -7,25 +7,65 @@
 
 import UIKit
 
+protocol ShowReviewListView {
+    func didTapShowReviewListView()
+}
+
 class ReviewInfoCell: UICollectionViewCell {
     
     // MARK: - Properties
-
+    var delegate: ShowReviewListView?
+    
     var reviewHistory: [Review]? {
         didSet {
             guard let reviewHistory = reviewHistory else { return }
             reviewCollectionView.reloadData()
+            self.reviewCountLabel.text = "\(reviewHistory.count)"
+            
         }
     }
+
     
     static let cellIdentifier = "ReviewInfoCell"
-    let reviewInfoTitleLabel = UILabel()
-    let reviewCountLabel = UILabel()
-    let horizontalDivider1 = UILabel()
-    let horizontalDivider2 = UILabel()
-    let horizontalDivider3 = UILabel()
-    let horizontalDivider4 = UILabel()
-    let horizontalDivider5 = UILabel()
+    let reviewInfoTitleLabel: UILabel = {
+        let reviewInfoTitleLabel = UILabel()
+        reviewInfoTitleLabel.text = "방문자 리뷰"
+        reviewInfoTitleLabel.font = UIFont.preferredFont(forTextStyle: .title3, weight: .semibold)
+        reviewInfoTitleLabel.textColor = CustomColor.nomadBlack
+        return reviewInfoTitleLabel
+    }()
+    let reviewCountLabel: UILabel = {
+        let reviewCountLabel = UILabel()
+        reviewCountLabel.font = UIFont.preferredFont(forTextStyle: .title3, weight: .semibold)
+        reviewCountLabel.textColor = CustomColor.nomadBlue
+        return reviewCountLabel
+    }()
+    let horizontalDivider1: UILabel = {
+        let horizontalDivider1 = UILabel()
+        horizontalDivider1.backgroundColor = CustomColor.nomadGray2
+        return horizontalDivider1
+    }()
+    
+    let horizontalDivider2: UILabel = {
+        let horizontalDivider2 = UILabel()
+        horizontalDivider2.backgroundColor = CustomColor.nomadGray2
+        return horizontalDivider2
+    }()
+    let horizontalDivider3: UILabel = {
+        let horizontalDivider3 = UILabel()
+        horizontalDivider3.backgroundColor = CustomColor.nomadGray2
+        return horizontalDivider3
+    }()
+    let horizontalDivider4: UILabel = {
+        let horizontalDivider4 = UILabel()
+        horizontalDivider4.backgroundColor = CustomColor.nomadGray2
+        return horizontalDivider4
+    }()
+    let horizontalDivider5: UILabel = {
+        let horizontalDivider5 = UILabel()
+        horizontalDivider5.backgroundColor = CustomColor.nomadGray2
+        return horizontalDivider5
+    }()
     let reviewCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .vertical
@@ -43,8 +83,7 @@ class ReviewInfoCell: UICollectionViewCell {
         let config = UIImage.SymbolConfiguration(pointSize: 13)
         viewAllButton.setImage(UIImage(systemName: "chevron.right", withConfiguration: config), for: .normal)
         viewAllButton.tintColor = CustomColor.nomadGray1
-        
-        
+        viewAllButton.addTarget(self, action: #selector(ShowReviewListView), for: .touchUpInside)
         return viewAllButton
     }()
     // MARK: - Lifecycle
@@ -56,6 +95,13 @@ class ReviewInfoCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: - Actions
+    
+    @objc func ShowReviewListView() {
+        delegate?.didTapShowReviewListView()
+    }
+
     
     // MARK: - Helpers
     
@@ -73,24 +119,13 @@ class ReviewInfoCell: UICollectionViewCell {
     }
     
     private func setAttributes() {
-        reviewInfoTitleLabel.text = "방문자 리뷰"
-        reviewInfoTitleLabel.font = UIFont.preferredFont(forTextStyle: .title3, weight: .semibold)
-        reviewInfoTitleLabel.textColor = CustomColor.nomadBlack
         reviewInfoTitleLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 19, paddingLeft: 19)
-        reviewCountLabel.text = "213"
-        reviewCountLabel.font = UIFont.preferredFont(forTextStyle: .title3, weight: .semibold)
-        reviewCountLabel.textColor = CustomColor.nomadBlue
         reviewCountLabel.anchor(top: self.topAnchor, left: reviewInfoTitleLabel.rightAnchor, paddingTop: 19, paddingLeft: 3)
-        horizontalDivider1.backgroundColor = CustomColor.nomadGray2
         horizontalDivider1.anchor(top: reviewInfoTitleLabel.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 8, paddingLeft: 19, paddingRight: 19, height: 1)
-        horizontalDivider2.backgroundColor = CustomColor.nomadGray2
-        horizontalDivider2.anchor(top: horizontalDivider1.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 65, paddingLeft: 19, paddingRight: 19, height: 1)
-        horizontalDivider3.backgroundColor = CustomColor.nomadGray2
-        horizontalDivider3.anchor(top: horizontalDivider2.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 64, paddingLeft: 19, paddingRight: 19, height: 1)
-        horizontalDivider4.backgroundColor = CustomColor.nomadGray2
-        horizontalDivider4.anchor(top: horizontalDivider3.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 64, paddingLeft: 19, paddingRight: 19, height: 1)
-        horizontalDivider5.backgroundColor = CustomColor.nomadGray2
-        horizontalDivider5.anchor(top: horizontalDivider4.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 64, paddingLeft: 19, paddingRight: 19, height: 1)
+        horizontalDivider2.anchor(top: horizontalDivider1.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 69, paddingLeft: 19, paddingRight: 19, height: 1)
+        horizontalDivider3.anchor(top: horizontalDivider2.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 69, paddingLeft: 19, paddingRight: 19, height: 1)
+        horizontalDivider4.anchor(top: horizontalDivider3.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 69, paddingLeft: 19, paddingRight: 19, height: 1)
+        horizontalDivider5.anchor(top: horizontalDivider4.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 69, paddingLeft: 19, paddingRight: 19, height: 1)
         NSLayoutConstraint.activate([
             reviewCollectionView.centerXAnchor.constraint(equalTo: self.centerXAnchor, constant: 0),
             reviewCollectionView.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: 0),
@@ -101,7 +136,7 @@ class ReviewInfoCell: UICollectionViewCell {
         reviewCollectionView.dataSource = self
         reviewCollectionView.delegate = self
         reviewCollectionView.register(ReviewSubCell.self, forCellWithReuseIdentifier: ReviewSubCell.cellIdentifier)
-        viewAllButton.centerX(inView: contentView, topAnchor: horizontalDivider5.bottomAnchor, paddingTop: 8)
+        viewAllButton.centerX(inView: self, topAnchor: horizontalDivider5.bottomAnchor, paddingTop: 8)
     }
 }
 

--- a/BNomad/View/PlaceInfoView/ReviewSubCell/ReviewSubCell.swift
+++ b/BNomad/View/PlaceInfoView/ReviewSubCell/ReviewSubCell.swift
@@ -45,11 +45,15 @@ class ReviewSubCell: UICollectionViewCell {
     
     var reviewImageView: UIImageView = {
         let reviewImageView = UIImageView()
+        reviewImageView.layer.cornerRadius = 5
+        reviewImageView.clipsToBounds = true
         return reviewImageView
     }()
     
     var profileImageView: UIImageView = {
-        let profileImageView = UIImageView()        
+        let profileImageView = UIImageView()
+        profileImageView.layer.cornerRadius = 10
+        profileImageView.clipsToBounds = true
         return profileImageView
     }()
     


### PR DESCRIPTION

## 관련 이슈들
- (#233)

## 작업 내용
 - 영업중 레이블 삭제
- 영업시간 정보 표기 방법 변경
- 확장버튼(쉐브론) 및 기능 삭제
- 셀 간격 조정

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img width="300" alt="스크린샷 2022-11-15 오전 9 44 20" src="https://user-images.githubusercontent.com/103012086/201798487-c44081d4-2e43-4d2d-859b-a752ef173989.png">


## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
