### PR TITLE
[Feat] 프로필뷰 리펙터링(그래프 뷰컨->셀 이동) 및 비짓카드컬렉션뷰 헤더 생성

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		041351A728FFF459005D19CC /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041351A628FFF459005D19CC /* CalendarViewController.swift */; };
 		041351A928FFF4FB005D19CC /* CalendarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041351A828FFF4FB005D19CC /* CalendarCell.swift */; };
 		041351AD29081D16005D19CC /* ProfileGraphCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041351AC29081D16005D19CC /* ProfileGraphCollectionCell.swift */; };
+		04CC781D29231A02005F3079 /* VisitCardHeaderCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CC781C29231A02005F3079 /* VisitCardHeaderCollectionView.swift */; };
 		04D095A82922165900F1AB3A /* VisitCardCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D095A72922165900F1AB3A /* VisitCardCollectionViewController.swift */; };
 		159F831428FF711D00DBF98B /* PlaceCheckInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159F831328FF711D00DBF98B /* PlaceCheckInViewController.swift */; };
 		159F831828FF79B700DBF98B /* CheckedProfileListViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159F831728FF79B700DBF98B /* CheckedProfileListViewCell.swift */; };
@@ -88,6 +89,7 @@
 		041351A628FFF459005D19CC /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		041351A828FFF4FB005D19CC /* CalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCell.swift; sourceTree = "<group>"; };
 		041351AC29081D16005D19CC /* ProfileGraphCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileGraphCollectionCell.swift; sourceTree = "<group>"; };
+		04CC781C29231A02005F3079 /* VisitCardHeaderCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitCardHeaderCollectionView.swift; sourceTree = "<group>"; };
 		04D095A72922165900F1AB3A /* VisitCardCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitCardCollectionViewController.swift; sourceTree = "<group>"; };
 		159F831328FF711D00DBF98B /* PlaceCheckInViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceCheckInViewController.swift; sourceTree = "<group>"; };
 		159F831728FF79B700DBF98B /* CheckedProfileListViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckedProfileListViewCell.swift; sourceTree = "<group>"; };
@@ -285,12 +287,13 @@
 			children = (
 				DFE747C829000FAF0048E70A /* ProfileEditView */,
 				0413519E28FE534D005D19CC /* SelfUserInfoCell.swift */,
-				DF9618AF28FCEFCB00E21D30 /* ProfileViewController.swift */,
 				041351A028FF7E72005D19CC /* VisitingInfoCell.swift */,
 				041351A228FF7E98005D19CC /* ProfileGraphCell.swift */,
 				041351AC29081D16005D19CC /* ProfileGraphCollectionCell.swift */,
+				DF9618AF28FCEFCB00E21D30 /* ProfileViewController.swift */,
 				041351A828FFF4FB005D19CC /* CalendarCell.swift */,
 				041351A628FFF459005D19CC /* CalendarViewController.swift */,
+				04CC781C29231A02005F3079 /* VisitCardHeaderCollectionView.swift */,
 				04D095A72922165900F1AB3A /* VisitCardCollectionViewController.swift */,
 			);
 			path = ProfileView;
@@ -555,6 +558,7 @@
 				F6DFE0B329194CB400C808AF /* ReviewCell.swift in Sources */,
 				DF9618B028FCEFCB00E21D30 /* ProfileViewController.swift in Sources */,
 				DFE747CA29000FC80048E70A /* ProfileEditViewController.swift in Sources */,
+				04CC781D29231A02005F3079 /* VisitCardHeaderCollectionView.swift in Sources */,
 				DF9618A628FCEF6A00E21D30 /* MapViewController.swift in Sources */,
 				DF9618AC28FCEFB600E21D30 /* LoginViewController.swift in Sources */,
 				E251E6DC2907F07E00638C15 /* CombineViewModel.swift in Sources */,

--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -24,7 +24,7 @@ class CalendarViewController: UIViewController {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = UIColor(hex: "F5F5F5")
+        collectionView.backgroundColor = CustomColor.nomad2White
         collectionView.isScrollEnabled = true
         collectionView.register(VisitingInfoCell.self, forCellWithReuseIdentifier: VisitingInfoCell.identifier)
         
@@ -48,7 +48,7 @@ class CalendarViewController: UIViewController {
         layout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.isScrollEnabled = false
-        collectionView.backgroundColor = UIColor(hex: "F5F5F5")
+        collectionView.backgroundColor = CustomColor.nomad2White
         collectionView.register(VisitingInfoCell.self, forCellWithReuseIdentifier: VisitingInfoCell.identifier)
         
         return collectionView
@@ -208,7 +208,7 @@ class CalendarViewController: UIViewController {
     // MARK: - Helpers
     
     func configureUI() {
-        view.backgroundColor = UIColor(hex: "F5F5F5")
+        view.backgroundColor = CustomColor.nomad2White
     }
     
     func render() {

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -78,16 +78,6 @@ class ProfileViewController: UIViewController {
         return collectionView
     }()
     
-    private let profileGraphCollectionView:  UICollectionView = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.isScrollEnabled = false
-        collectionView.register(ProfileGraphCollectionCell.self, forCellWithReuseIdentifier: ProfileGraphCollectionCell.identifier)
-
-        return collectionView
-    }()
-    
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
@@ -104,9 +94,6 @@ class ProfileViewController: UIViewController {
         profileCollectionView.dataSource = self
         profileCollectionView.delegate = self
         
-        profileGraphCollectionView.dataSource = self
-        profileGraphCollectionView.delegate = self
-        
         plusWeek.addTarget(self, action: #selector(plusWeekTapButton), for: .touchUpInside)
         minusWeek.addTarget(self, action: #selector(minusWeekTapButton), for: .touchUpInside)
         
@@ -122,7 +109,6 @@ class ProfileViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        profileGraphCollectionView.reloadData() //FIXME: 왜 리로드해야 정상표시되는지 ?? 버그픽스요망
         navigationController?.navigationBar.isHidden = false
     }
     
@@ -145,7 +131,6 @@ class ProfileViewController: UIViewController {
     @objc func plusWeekTapButton() {
         ProfileGraphCell.editWeek(edit: 1)
         profileCollectionView.reloadData()
-        profileGraphCollectionView.reloadData()
         
         ProfileViewController.profileGraphCellHeaderMaker(label: profileGraphCellHeaderLabel, weekAdded: 1)
     }
@@ -153,7 +138,6 @@ class ProfileViewController: UIViewController {
     @objc func minusWeekTapButton() {
         ProfileGraphCell.editWeek(edit: -1)
         profileCollectionView.reloadData()
-        profileGraphCollectionView.reloadData()
         
         ProfileViewController.profileGraphCellHeaderMaker(label: profileGraphCellHeaderLabel, weekAdded: -1)
     }
@@ -226,9 +210,6 @@ class ProfileViewController: UIViewController {
         
         view.addSubview(plusWeek)
         plusWeek.anchor(top: view.topAnchor, right: view.rightAnchor, paddingTop: 570, paddingRight: 45)
-        
-        view.addSubview(profileGraphCollectionView)
-        profileGraphCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: 615, paddingLeft: 58, width: 345/390*view.frame.width-35, height: 154)
     }
     
 }
@@ -238,18 +219,10 @@ class ProfileViewController: UIViewController {
 extension ProfileViewController: UICollectionViewDataSource {
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        if collectionView == profileCollectionView {
             return 3
-        } else {
-            return 1
-        }
     }
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        if collectionView == profileCollectionView {
             return 1
-        } else {
-            return 7
-        }
     }
     
 }
@@ -259,7 +232,6 @@ extension ProfileViewController: UICollectionViewDataSource {
 extension ProfileViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        if collectionView == profileCollectionView {
             
             if indexPath.section == 0 {
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelfUserInfoCell.identifier , for: indexPath) as? SelfUserInfoCell else {
@@ -297,23 +269,7 @@ extension ProfileViewController: UICollectionViewDelegate {
                 cell.layer.cornerRadius = 20
                 return cell
             }
-        } else {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfileGraphCollectionCell.identifier , for: indexPath) as? ProfileGraphCollectionCell else {
-                return UICollectionViewCell()
-            }
-            
-            let weekCalculator = ProfileViewController.weekAddedMemory * 7
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd"
-            
-            let dayCalculator = (86400 * (1-Contents.todayOfTheWeek + weekCalculator + indexPath.item))
-            let cellDate = formatter.string(from: Date(timeIntervalSinceNow: TimeInterval(dayCalculator)))
-            
-            cell.cellDate = cellDate
-            cell.checkInHistory = viewModel.user?.checkInHistory
-            cell.backgroundColor = .systemBackground
-            return cell
-        }
+        
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -329,7 +285,6 @@ extension ProfileViewController: UICollectionViewDelegate {
 extension ProfileViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize{
-        if collectionView == profileCollectionView {
             if indexPath.section == 0 {
                 return CGSize(width: profileCollectionView.frame.width, height: 166)
             } else if indexPath.section == 1 {
@@ -337,27 +292,12 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
             } else {
                 return CGSize(width: profileCollectionView.frame.width, height: 190)
             }
-        }else {
-            return CGSize(width: 27, height: 154)
-        }
         
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-            if collectionView == profileCollectionView {
                return UIEdgeInsets(top: 0, left: 0, bottom: 50, right: 0)
-            }else {
-                return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-            }
         }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        if collectionView == profileCollectionView {
-            return CGFloat(0)
-        }else {
-            return CGFloat(profileCollectionView.frame.width - 55 - 27*7)/6
-        }
-    }
 }
 
 // MARK: - MovePage

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -18,6 +18,7 @@ class ProfileViewController: UIViewController {
     
     var userFromListUid: String?
     
+    
     private lazy var profileImageView: UIImageView = {
         let iv = UIImageView()
         iv.contentMode = .scaleAspectFill
@@ -69,7 +70,7 @@ class ProfileViewController: UIViewController {
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.isScrollEnabled = false
-        collectionView.backgroundColor = UIColor(hex: "F5F5F5")
+        collectionView.backgroundColor = CustomColor.nomad2White
         collectionView.register(SelfUserInfoCell.self, forCellWithReuseIdentifier: SelfUserInfoCell.identifier)
         collectionView.register(VisitingInfoCell.self, forCellWithReuseIdentifier: VisitingInfoCell.identifier)
         collectionView.register(ProfileGraphCell.self, forCellWithReuseIdentifier: ProfileGraphCell.identifier)
@@ -199,7 +200,7 @@ class ProfileViewController: UIViewController {
     }
     
     func configureUI() {
-        view.backgroundColor = UIColor(hex: "F5F5F5")
+        view.backgroundColor = CustomColor.nomad2White
     }
     
     func render() {

--- a/BNomad/View/ProfileView/VisitCardCollectionViewController.swift
+++ b/BNomad/View/ProfileView/VisitCardCollectionViewController.swift
@@ -12,16 +12,26 @@ class VisitCardCollectionViewController: UIViewController {
     
     // MARK: - Properties
     
-    static var checkInHistory: [CheckIn]?
-    
+    static var checkInHistory: [CheckIn]? {
+        didSet {
+//            guard let checkinHistory = checkInHistory else { return }
+//            for index in 0..<checkinHistory.count-1 {
+//                if checkinHistory[index].date != checkinHistory[index+1].date {
+//
+//                }
+//            }
+        }
+    }
     
     private let visitCardListView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = UIColor(hex: "F5F5F5")
+        collectionView.backgroundColor = CustomColor.nomad2White
         collectionView.isScrollEnabled = true
         collectionView.register(VisitingInfoCell.self, forCellWithReuseIdentifier: VisitingInfoCell.identifier)
+        collectionView.register(VisitCardHeaderCollectionView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: VisitCardHeaderCollectionView.identifier)
+        collectionView.alwaysBounceVertical = true
         
         return collectionView
     }()
@@ -40,21 +50,19 @@ class VisitCardCollectionViewController: UIViewController {
     
     }
     
-    
     // MARK: - Actions
     
     
     // MARK: - Helpers
     
     func configureUI() {
-        view.backgroundColor = UIColor(hex: "F5F5F5")
+        view.backgroundColor = CustomColor.nomad2White
     }
     
     func render() {
         
         view.addSubview(visitCardListView)
-        visitCardListView.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor,
-                                 paddingTop: 100, paddingLeft: 14, paddingRight: 14)
+        visitCardListView.frame = view.bounds
         
     }
     
@@ -65,11 +73,11 @@ class VisitCardCollectionViewController: UIViewController {
 extension VisitCardCollectionViewController: UICollectionViewDataSource {
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
+        return VisitCardCollectionViewController.checkInHistory?.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return VisitCardCollectionViewController.checkInHistory?.count ?? 0
+        return 1
     }
     
 }
@@ -88,11 +96,20 @@ extension VisitCardCollectionViewController: UICollectionViewDelegate {
             cell.layer.cornerRadius = 20
             
             let checkinHistoryCount = VisitCardCollectionViewController.checkInHistory?.count
-            cell.checkinHistoryForList = VisitCardCollectionViewController.checkInHistory?[(checkinHistoryCount ?? 0)-indexPath.item-1]
+            cell.checkinHistoryForList = VisitCardCollectionViewController.checkInHistory?[(checkinHistoryCount ?? 0)-indexPath.section-1]
             
             return cell
         
     }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+                guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: VisitCardHeaderCollectionView.identifier, for: indexPath) as? VisitCardHeaderCollectionView else {
+                    return UICollectionViewCell()
+                }
+        header.configure(with: VisitCardCollectionViewController.checkInHistory?[indexPath.section].date ?? "")
+                return header
+            
+        }
     
 }
 
@@ -116,8 +133,12 @@ extension VisitCardCollectionViewController: UICollectionViewDelegateFlowLayout 
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         
-        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        return UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
         
     }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+            return CGSize(width: view.frame.size.width, height: 30)
+        }
     
 }

--- a/BNomad/View/ProfileView/VisitCardHeaderCollectionView.swift
+++ b/BNomad/View/ProfileView/VisitCardHeaderCollectionView.swift
@@ -1,0 +1,52 @@
+//
+//  VisitCardHeaderCollectionView.swift
+//  BNomad
+//
+//  Created by Beone on 2022/11/15.
+//
+
+import UIKit
+
+class VisitCardHeaderCollectionView: UICollectionReusableView {
+    static let identifier = "VisitCardHeaderCollectionView"
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.clipsToBounds = true
+        imageView.contentMode = .scaleAspectFill
+        return imageView
+    }()
+    
+    private let VisitInfoHeader: UILabel = {
+        let content = Contents.todayDate()
+        let day = String(content["month"] ?? 0) + "월 " + String(content["day"] ?? 0) + "일"
+        
+        let label = UILabel()
+        label.text = day
+        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        label.textColor = CustomColor.nomadBlue
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    private func setUI() {
+//        backgroundColor = .systemPink
+        addSubview(VisitInfoHeader)
+        VisitInfoHeader.anchor(left: self.leftAnchor, paddingLeft: 20)
+        VisitInfoHeader.centerY(inView: self)
+
+    }
+    
+    func configure(with date: String) {
+        VisitInfoHeader.text = date
+    }
+}


### PR DESCRIPTION
## 관련 이슈들
- (ex. #2, #3 ...)

## 작업 내용
- 기존 profileCollectionView 위에 얹혀있던 profileGraphCollectionView를 프로필뷰컨 -> 프로필컬렉션뷰셀으로 이동하여 한 묶음으로 처리하는 리펙터링 진행
- 이외 자잘한 리펙터링

- 비짓카드컬렉션뷰 헤더 생성 (현재 모든 셀에 대해 날자 헤더가 생성됨, 추후 월별/주별 등 분리 필요)

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.
- static을 너무 많이 쓴 것 같습니다 특히 프로필그래프셀 내에서

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/70618615/201813944-f72d1eae-8cf0-4583-911b-069843d94716.png" width="300">
<img src="src="https://user-images.githubusercontent.com/70618615/201813977-fc2cd8f2-4b21-43e8-be87-f162409cb341.png" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
