### PR TITLE
[Feat] 방문했던 장소만 모아보는 토글 구현 완료

### DIFF
--- a/BNomad/View/MapView/MapData.swift
+++ b/BNomad/View/MapView/MapData.swift
@@ -22,10 +22,10 @@ class MKAnnotationFromPlace: NSObject, MKAnnotation {
         annotation.coordinate = CLLocationCoordinate2D(latitude: place.latitude, longitude: place.longitude)
         annotation.title = place.name
         annotation.placeUid = place.placeUid
-        // TODO: - 랜덤 제거 후 PlaceType이 nil 경우의 annotation 사용. 
-        let randomNum = Int.random(in: 0...1)
-        let randomType = PlaceType(rawValue: randomNum)
-        annotation.type = randomType ?? .coworking
+//        // TODO: - 랜덤 제거 후 PlaceType이 nil 경우의 annotation 사용.
+//        let randomNum = Int.random(in: 0...1)
+//        let randomType = PlaceType(rawValue: randomNum)
+        annotation.type = .coworking
         return annotation
     }
 }

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -34,12 +34,15 @@ class MapViewController: UIViewController {
     private var currentAnnotation: MKAnnotation?
     
     lazy var viewModel: CombineViewModel = CombineViewModel.shared
+    var store = Set<AnyCancellable>()
     
     var selectedRegion: Region?
-    
     var visiblePlacesOnMap: [Place] = []
     var allAnnotation: [MKAnnotation] = []
     var visitedAnnotation: [MKAnnotation] = []
+    var newAnnotation: [MKAnnotation] = []
+    
+    fileprivate let mapBtnBackgroundColor: UIColor = .white.withAlphaComponent(0.5)
     
     // 맵 띄우기
     private lazy var map: MKMapView = {
@@ -101,15 +104,14 @@ class MapViewController: UIViewController {
     
     // 지역명 표기 및 지역 변경 버튼
     
-    private let regionChangeBtn: UIButton = {
+    private let appTitle: UIButton = {
         var btn = UIButton()
-        btn.setTitle("지역 선택 ", for: .normal)
+        btn.setTitle("B.nomad ", for: .normal)
         btn.semanticContentAttribute = .forceRightToLeft
         btn.titleLabel?.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
         btn.setTitleColor(.black, for: .normal)
-        btn.setImage(UIImage(systemName: "chevron.down"), for: .normal)
         btn.tintColor = CustomColor.nomadBlue
-        btn.addTarget(self, action: #selector(presentRegionSelector), for: .touchUpInside)
+//        btn.addTarget(self, action: #selector(presentRegionSelector), for: .touchUpInside) // 앱 네임을 눌렀을 때 pop-up이나 credit, contact 정보 뜨도록?
         return btn
     }()
     
@@ -122,13 +124,11 @@ class MapViewController: UIViewController {
         topRightBtn.tintColor = CustomColor.nomadBlue
         topRightBtn.distribution = .fillProportionally
         topRightBtn.anchor(width: 60)
-        topRightBtn.translatesAutoresizingMaskIntoConstraints = false
         
-        let upperStack = UIStackView(arrangedSubviews: [regionChangeBtn, topRightBtn])
+        let upperStack = UIStackView(arrangedSubviews: [appTitle, topRightBtn])
         upperStack.axis = .horizontal
         upperStack.alignment = .fill
         upperStack.distribution = .equalSpacing
-        upperStack.translatesAutoresizingMaskIntoConstraints = false
         return upperStack
     }()
     
@@ -141,16 +141,7 @@ class MapViewController: UIViewController {
         return background
     }()
     
-    // TODO: - 장소 모달 뷰 보다가 현재 위치로 이동 시 보던 장소 모달 dismiss 필요
-    lazy var userTrackingBtn: MKUserTrackingButton = {
-        let btn = MKUserTrackingButton(mapView: map)
-        btn.backgroundColor = .white
-        btn.tintColor = CustomColor.nomadBlue
-        btn.layer.cornerRadius = 4
-        btn.layer.borderColor = CustomColor.nomadBlue?.cgColor
-        btn.layer.borderWidth = 1
-        return btn
-    }()
+
     
     // 유저 위치 중심으로 circle overlay (radius distance 미터 단위)
     // TODO: - 실시간으로 위치 이동 시 Circle도 따라가 계속 그려져야 함
@@ -162,7 +153,7 @@ class MapViewController: UIViewController {
     
     lazy var listViewButton: UIButton = {
         let button = UIButton()
-        button.backgroundColor = .white
+        button.backgroundColor = mapBtnBackgroundColor
         button.setImage(UIImage(systemName: "list.bullet"), for: .normal)
         button.tintColor = CustomColor.nomadBlue
         button.layer.cornerRadius = 4
@@ -184,8 +175,6 @@ class MapViewController: UIViewController {
         return button
     }()
     
-    var store = Set<AnyCancellable>()
-    
     @objc func goBackToCheckInView() {
         let controller = PlaceCheckInViewController()
         guard let user = viewModel.user else { return print("USER ERR") }
@@ -202,11 +191,63 @@ class MapViewController: UIViewController {
         }
     }
     
-    private let visitedPlaceToggle: UISwitch = {
-        let toggle = UISwitch()
-        toggle.preferredStyle = .sliding
-        toggle.addTarget(self, action: #selector(visitedPlacesSwitch), for: .valueChanged)
-        return toggle
+    private lazy var visitedPlaceMenu: UIButton = {
+        
+        let allPlaceAction = UIAction(title: "모든 스팟", handler: { _ in
+            self.map.removeAnnotations(self.map.annotations)
+            self.map.addAnnotations(self.allAnnotation)
+        })
+        
+        let visitedPlaceAction = UIAction(title: "방문한 스팟", handler: { _ in
+            self.map.removeAnnotations(self.map.annotations)
+            self.visitedPlacesMapping()
+            self.map.addAnnotations(self.visitedAnnotation)
+        })
+        
+        let newPlaceAction = UIAction(title: "새로운 스팟", handler: { _ in
+            self.map.removeAnnotations(self.map.annotations)
+            self.visitedPlacesMapping()
+            self.map.addAnnotations(self.newAnnotation)
+        })
+        
+        allPlaceAction.state = .on // 기본적으로는 '모든 스팟'에 체크되어 있음
+        
+        let menu = UIMenu(title: "노마드 스팟 골라보기", options: .singleSelection, children: [allPlaceAction, visitedPlaceAction, newPlaceAction])
+        
+        let btn = UIButton()
+        btn.showsMenuAsPrimaryAction = true
+        btn.menu = menu
+        btn.backgroundColor = mapBtnBackgroundColor
+        btn.setImage(UIImage(systemName: "square.on.square"), for: .normal)
+        btn.tintColor = CustomColor.nomadBlue
+        btn.layer.cornerRadius = 4
+        btn.layer.borderColor = CustomColor.nomadBlue?.cgColor
+        btn.layer.borderWidth = 1
+        return btn
+    }()
+    
+    lazy var regionSelectBtn: UIButton = {
+        let btn = UIButton()
+        btn.backgroundColor = mapBtnBackgroundColor
+        btn.setImage(UIImage(systemName: "map"), for: .normal)
+        btn.tintColor = CustomColor.nomadBlue
+        btn.layer.cornerRadius = 4
+        btn.layer.borderColor = CustomColor.nomadBlue?.cgColor
+        btn.layer.borderWidth = 1
+        btn.anchor(width: 40, height: 40)
+        btn.addTarget(self, action: #selector(presentRegionSelector), for: .touchUpInside)
+        return btn
+    }()
+    
+    lazy var userTrackingBtn: MKUserTrackingButton = {
+        let btn = MKUserTrackingButton(mapView: map)
+        btn.backgroundColor = mapBtnBackgroundColor
+        btn.tintColor = CustomColor.nomadBlue
+        btn.layer.cornerRadius = 4
+        btn.layer.borderColor = CustomColor.nomadBlue?.cgColor
+        btn.layer.borderWidth = 1
+        btn.anchor(width: 40, height: 40)
+        return btn
     }()
     
     // MARK: - LifeCycle
@@ -284,6 +325,25 @@ class MapViewController: UIViewController {
         navigationController?.pushViewController(SettingViewController(), animated: true)
     }
     
+    // 방문했던/안했던 장소 분리하여 배열에 추가
+    func visitedPlacesMapping() {
+        self.visitedAnnotation.removeAll()
+        self.newAnnotation.removeAll()
+        
+        for place in viewModel.places {
+            guard let user = self.viewModel.user else { return }
+            guard let history = user.checkInHistory else { return }
+            
+            if history.contains(where: { checkIn in
+                checkIn.placeUid == place.placeUid
+            }) {
+                self.visitedAnnotation.append(MKAnnotationFromPlace.convertPlaceToAnnotation(place))
+            } else {
+                self.newAnnotation.append(MKAnnotationFromPlace.convertPlaceToAnnotation(place))
+            }
+        }
+    }
+    
     // MARK: - Helpers
     
     // 위치 권한 받아서 현재 위치 확인
@@ -304,13 +364,13 @@ class MapViewController: UIViewController {
                     place.placeUid == viewModel.user?.currentPlaceUid
                 }) {
                     self.setMapRegion(place.latitude, place.longitude, spanDelta: 0.01)
-                    let annotation = MKAnnotationFromPlace.convertPlaceToAnnotation(place)
-                    self.map.selectAnnotation(annotation, animated: true)
-                    let controller = PlaceInfoModalViewController()
-                    controller.selectedPlace = place
-                    controller.delegateForFloating = self
-                    controller.presentationController?.delegate = self
-                    present(controller, animated: true)
+//                    let annotation = MKAnnotationFromPlace.convertPlaceToAnnotation(place)
+//                    self.map.selectAnnotation(annotation, animated: true)
+//                    let controller = PlaceInfoModalViewController()
+//                    controller.selectedPlace = place
+//                    controller.delegateForFloating = self
+//                    controller.presentationController?.delegate = self
+//                    present(controller, animated: true)
                 }
                 
                 print("체크인 상태로 맵 세팅 끝")
@@ -362,44 +422,18 @@ class MapViewController: UIViewController {
         
         map.addSubview(compass)
         compass.anchor(top: map.topAnchor, left: map.leftAnchor, paddingTop: 110, paddingLeft: 15, width: 40, height: 40)
-        
-        map.addSubview(visitedPlaceToggle)
-        visitedPlaceToggle.anchor(top: map.topAnchor, right: map.rightAnchor, paddingTop: 110, paddingRight: 30, width: 30, height: 20)
-        
+
+        map.addSubview(visitedPlaceMenu)
+        visitedPlaceMenu.anchor(left: map.leftAnchor, bottom: map.bottomAnchor, paddingLeft: 15, paddingBottom: 115, width: 40, height: 40)
+       
         map.addSubview(listViewButton)
         listViewButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, paddingLeft: 15, paddingBottom: 70, width: 40, height: 40)
         
-        map.addSubview(userTrackingBtn)
-        userTrackingBtn.anchor(bottom: view.bottomAnchor, right: view.rightAnchor, paddingBottom: 70, paddingRight: 15, width: 40, height: 40)
-    }
-    
-    func visitedPlacesMapping() {
-        self.visitedAnnotation.removeAll()
+        map.addSubview(regionSelectBtn)
+        regionSelectBtn.anchor(bottom: view.bottomAnchor, right: view.rightAnchor, paddingBottom: 115, paddingRight: 15, width: 40, height: 85)
         
-        for place in viewModel.places {
-            guard let user = self.viewModel.user else { return }
-            guard let history = user.checkInHistory else { return }
-            
-            if history.contains(where: { checkIn in
-                checkIn.placeUid == place.placeUid
-            }) {
-                self.visitedAnnotation.append(MKAnnotationFromPlace.convertPlaceToAnnotation(place))
-            }
-        }
-    }
-    
-    @objc func visitedPlacesSwitch(sender: UISwitch) {
-        print("remove")
-        map.removeAnnotations(map.annotations)
-
-        if sender.isOn {
-            visitedPlacesMapping()
-            map.addAnnotations(visitedAnnotation)
-            print(visitedAnnotation)
-        } else {
-            map.addAnnotations(allAnnotation)
-            print(allAnnotation)
-        }
+        map.addSubview(userTrackingBtn)
+        userTrackingBtn.anchor(bottom: view.bottomAnchor, right: view.rightAnchor, paddingBottom: 70, paddingRight: 15, width: 40, height: 85)
     }
     
     func userCombine() {

--- a/BNomad/View/MapView/PlaceAnnotation.swift
+++ b/BNomad/View/MapView/PlaceAnnotation.swift
@@ -26,7 +26,7 @@ class CoworkingAnnotationView: PlaceAnnotationView {
     override func prepareForDisplay() {
         super.prepareForDisplay()
         displayPriority = .defaultHigh
-        markerTintColor = .systemPink
+        markerTintColor = CustomColor.nomadBlue
         glyphImage = UIImage(systemName: "laptopcomputer")
     }
 }


### PR DESCRIPTION
## 관련 이슈들
- #230 

## 작업 내용
- 스위치 on/off 시에 기존의 맵 annotation 모두 삭제한 뒤 방문했던 장소만 추가하거나 모든 장소 추가하는 방식으로 구현
- 토글을 누른 순간에만 체크인 히스토리 중에 방문한 장소를 골라내어 지도에 표시

## 리뷰 노트
- 임시로 토글로 구현했는데 어울리는 디자인이 나오면 변경 예정입니다.
- 방문했던 장소만 보는 토글 상태일 때 좌측 하단의 장소 리스트 누르면 비방문 장소까지 다 나오는 상황입니다. 이 부분 UI 상 어색하지 않을지 의견부탁드립니다.
- 스크린샷에는 실시간으로 체크인, 체크아웃 하는 장소는 토글에 반영이 되지 않지만 스크린샷 캡쳐 후에 다시 수정해서 앱을 껐다 켜지 않아도 체크아웃한 장소는 토글에 정상 반영됩니다.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012800/201818240-b4f6b3dd-d7c6-4c08-b4e5-1a57ceafbc8b.gif" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
