### PR TITLE
[Feat] #224 애플로그인, UI작동, 로그인, 로그아웃, 회원탈퇴

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		DF288B5128F7D70F002838A4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF288B5028F7D70F002838A4 /* SceneDelegate.swift */; };
 		DF288B5828F7D710002838A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DF288B5728F7D710002838A4 /* Assets.xcassets */; };
 		DF288B5B28F7D710002838A4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DF288B5928F7D710002838A4 /* LaunchScreen.storyboard */; };
+		DF404CC729229293002C987E /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = DF404CC629229293002C987E /* FirebaseAuth */; };
 		DF561CA52918A0B40099D41D /* MeetUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF561CA42918A0B40099D41D /* MeetUpViewController.swift */; };
 		DF561CA82918A0C40099D41D /* ReviewListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF561CA72918A0C40099D41D /* ReviewListViewController.swift */; };
 		DF561CAB2918A0DA0099D41D /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF561CAA2918A0DA0099D41D /* SettingViewController.swift */; };
@@ -66,7 +67,6 @@
 		E2E6B23028FE7542005C0D77 /* CheckIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E6B22F28FE7542005C0D77 /* CheckIn.swift */; };
 		E2E6B23228FE757D005C0D77 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E6B23128FE757D005C0D77 /* Date+Extension.swift */; };
 		E2E6B23428FE75F7005C0D77 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E6B23328FE75F7005C0D77 /* String+Extension.swift */; };
-		F6183CAF28FFA74000185A1F /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = F6183CAE28FFA74000185A1F /* FirebaseAuth */; };
 		F6183CB128FFA74000185A1F /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = F6183CB028FFA74000185A1F /* FirebaseDatabase */; };
 		F6183CB328FFA74000185A1F /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F6183CB228FFA74000185A1F /* FirebaseDatabaseSwift */; };
 		F6183CB528FFA74000185A1F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = F6183CB428FFA74000185A1F /* FirebaseStorage */; };
@@ -77,7 +77,6 @@
 		F6B5E67E28FFA5B400557596 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F6B5E67D28FFA5B400557596 /* GoogleService-Info.plist */; };
 		F6DFE0B329194CB400C808AF /* ReviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DFE0B229194CB400C808AF /* ReviewCell.swift */; };
 		F6DFE0B7291B2CF900C808AF /* ReviewDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DFE0B6291B2CF900C808AF /* ReviewDetailViewController.swift */; };
-
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -156,10 +155,10 @@
 				F6183CB328FFA74000185A1F /* FirebaseDatabaseSwift in Frameworks */,
 				F6183CB528FFA74000185A1F /* FirebaseStorage in Frameworks */,
 				E27CEED62919F57D00369A6E /* Kingfisher in Frameworks */,
+				DF404CC729229293002C987E /* FirebaseAuth in Frameworks */,
 				F6183CB928FFA83F00185A1F /* FirebaseAnalytics in Frameworks */,
 				F6183CB128FFA74000185A1F /* FirebaseDatabase in Frameworks */,
 				F6183CB728FFA83800185A1F /* FirebaseFirestore in Frameworks */,
-				F6183CAF28FFA74000185A1F /* FirebaseAuth in Frameworks */,
 				E25AD9E42912239A00F815B2 /* FirebaseRemoteConfig in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -430,7 +429,6 @@
 			);
 			name = BNomad;
 			packageProductDependencies = (
-				F6183CAE28FFA74000185A1F /* FirebaseAuth */,
 				F6183CB028FFA74000185A1F /* FirebaseDatabase */,
 				F6183CB228FFA74000185A1F /* FirebaseDatabaseSwift */,
 				F6183CB428FFA74000185A1F /* FirebaseStorage */,
@@ -439,6 +437,7 @@
 				E226DA6D29120A540071E289 /* FirebasePerformance */,
 				E25AD9E32912239A00F815B2 /* FirebaseRemoteConfig */,
 				E27CEED52919F57D00369A6E /* Kingfisher */,
+				DF404CC629229293002C987E /* FirebaseAuth */,
 			);
 			productName = BNomad;
 			productReference = DF288B4B28F7D70F002838A4 /* BNomad.app */;
@@ -700,9 +699,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = BNomad/BNomad.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = DF85MB57QP;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BNomad/Application/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 앱에 접근합니다";
@@ -721,6 +722,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.nopower.b.nomad;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = BnomadProvisioningProfile;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -734,9 +736,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = BNomad/BNomad.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = DF85MB57QP;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BNomad/Application/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 앱에 접근합니다";
@@ -755,6 +759,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.nopower.b.nomad;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = BnomadProvisioningProfile;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -804,6 +809,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		DF404CC629229293002C987E /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F6183CAD28FFA74000185A1F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
+		};
 		E226DA6D29120A540071E289 /* FirebasePerformance */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F6183CAD28FFA74000185A1F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
@@ -818,11 +828,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E27CEED42919F57D00369A6E /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
-		};
-		F6183CAE28FFA74000185A1F /* FirebaseAuth */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F6183CAD28FFA74000185A1F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAuth;
 		};
 		F6183CB028FFA74000185A1F /* FirebaseDatabase */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/BNomad/Application/SceneDelegate.swift
+++ b/BNomad/Application/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Firebase
+import FirebaseAuth
 import Kingfisher
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -16,30 +17,35 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         _ = RCValue.shared
-        let deviceUid = UIDevice.current.identifierForVendor?.uuidString
-        guard let deviceUid = deviceUid else { return }
         
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
         
-        FirebaseManager.shared.checkUserExist(userUid : deviceUid) { isExist in
-            if isExist {
-                FirebaseManager.shared.fetchUser(id: deviceUid) { user in
-                    self.viewModel.user = user
-                    self.fetchProfileImage()
-                    
-                    FirebaseManager.shared.fetchCheckInHistory(userUid: deviceUid) { checkInHistory in
-                        self.viewModel.user?.checkInHistory = checkInHistory
-                        print("checkIn 유무", self.viewModel.user?.isChecked)
-                        self.window?.rootViewController = UINavigationController(rootViewController: MapViewController())
-                        self.window?.makeKeyAndVisible()
+        let current = Auth.auth().currentUser
+        if current != nil {
+            guard let uid = current?.uid else { return }
+            FirebaseManager.shared.checkUserExist(userUid : uid) { isExist in
+                if isExist {
+                    FirebaseManager.shared.fetchUser(id: uid) { user in
+                        self.viewModel.user = user
+                        self.fetchProfileImage()
+                        
+                        FirebaseManager.shared.fetchCheckInHistory(userUid: uid) { checkInHistory in
+                            self.viewModel.user?.checkInHistory = checkInHistory
+                            print("checkIn 유무", self.viewModel.user?.isChecked)
+                            self.window?.rootViewController = UINavigationController(rootViewController: MapViewController())
+                            self.window?.makeKeyAndVisible()
+                        }
                     }
+                } else {
+                    print("no user")
+                    self.window?.rootViewController = UINavigationController(rootViewController: MapViewController())
+                    self.window?.makeKeyAndVisible()
                 }
-            } else {
-                print("no user")
-                self.window?.rootViewController = UINavigationController(rootViewController: MapViewController())
-                self.window?.makeKeyAndVisible()
             }
+        } else {
+            self.window?.rootViewController = UINavigationController(rootViewController: MapViewController())
+            self.window?.makeKeyAndVisible()
         }
     }
     

--- a/BNomad/BNomad.entitlements
+++ b/BNomad/BNomad.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/BNomad/View/LoginView/LoginViewController.swift
+++ b/BNomad/View/LoginView/LoginViewController.swift
@@ -6,12 +6,22 @@
 //
 
 import AuthenticationServices
+import CryptoKit
 import UIKit
+import FirebaseAuth
+import Firebase
+
+protocol LogInToSignUp {
+    func logInToSignUp(userIdentifier: String)
+}
 
 class LoginViewController: UIViewController {
     
     // MARK: - Properties
-    
+    fileprivate var currentNonce: String?
+    var delegate: LogInToSignUp?
+    var viewModel = CombineViewModel.shared
+
     private let loginTitle: UILabel = {
         let label = UILabel()
         label.text = "로그인이 필요합니다!"
@@ -61,14 +71,11 @@ class LoginViewController: UIViewController {
     }
     
     @objc func handleAuthorizationAppleIDButtonPress() {
-        let appleIDprovider = ASAuthorizationAppleIDProvider()
-        let request = appleIDprovider.createRequest()
-        request.requestedScopes = [.fullName, .email]
-        
-        let controller = ASAuthorizationController(authorizationRequests: [request])
-        controller.delegate = self
-        controller.presentationContextProvider = self
-        controller.performRequests()
+        let request = createAppleIDRequest()
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
     }
     
     // MARK: - Methods
@@ -99,25 +106,49 @@ class LoginViewController: UIViewController {
 extension LoginViewController: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-            let userIdentifier = appleIDCredential.user
-            let fullName = appleIDCredential.fullName
-            let email = appleIDCredential.email
+            print("email", appleIDCredential.email)
+            print("fullname", appleIDCredential.fullName?.description)
             
-            print("#1 userIdentifier: \(userIdentifier)")
-            print("#2 fullName: \(String(describing: fullName))")
-            print("#3 email: \(String(describing: email))")
+            guard let nonce = currentNonce else {
+                fatalError("Invalid state: A login callback was received, but no login request was sent.")
+            }
             
-            // TODO: 추후 이 modal을 내리고 SignUpViewController를 띄우기 위함
-             self.dismiss(animated: true)
+            guard let appleIDtoken = appleIDCredential.identityToken else {
+                print("Unable to fetch identity token")
+                return
+            }
             
-//            if userIdentifier가 저장되어 있지 않다면 {
-                let signUpViewController = SignUpViewController()
-                signUpViewController.modalPresentationStyle = .fullScreen
-                present(signUpViewController, animated: true)
-//            } else {
-//                원래 하려던 동작으로 연결하거나 return 만 해줘도 될듯
-//            }
+            guard let idTokenString = String(data: appleIDtoken, encoding: .utf8) else {
+                print("Unable to serialize token string from data: \(appleIDtoken.debugDescription)")
+                return
+            }
             
+            print(idTokenString)
+            let credential = OAuthProvider.credential(withProviderID: "apple.com",
+                                                                       idToken: idTokenString,
+                                                                       rawNonce: nonce)
+            Auth.auth().signIn(with: credential) { (authDataResult, error) in
+                if let user = authDataResult?.user {
+                    print("애플 로그인 성공!", user.uid, user.email ?? "-")
+                    FirebaseManager.shared.checkUserExist(userUid: user.uid) { isExist in
+                        if isExist {
+                            FirebaseManager.shared.fetchUser(id: user.uid) { user in
+                                self.viewModel.user = user
+                            }
+                            self.dismiss(animated: true)
+                        } else {
+                            self.dismiss(animated: true)
+                            self.delegate?.logInToSignUp(userIdentifier: user.uid)
+                        }
+                    }
+                }
+                if error != nil {
+                    print(error?.localizedDescription ?? "error" as Any)
+                    return
+                }
+            }
+        } else {
+            print("ERRRRRR")
         }
     }
     
@@ -145,4 +176,62 @@ extension UIButton {
         attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 0, length: title.count))
         setAttributedTitle(attributedString, for: .normal)
     }
+}
+
+extension LoginViewController {
+    @available(iOS 13, *)
+    func createAppleIDRequest() -> ASAuthorizationAppleIDRequest {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        // 애플로그인은 사용자에게서 2가지 정보를 요구함
+        request.requestedScopes = [.fullName, .email]
+        
+        let nonce = randomNonceString()
+        request.nonce = sha256(nonce)
+        currentNonce = nonce
+        
+        return request
+    }
+    
+    @available(iOS 13, *)
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            return String(format: "%02x", $0)
+        }.joined()
+        
+        return hashString
+    }
+    
+    // Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: Array<Character> =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+        
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        return result
+    }
+    
 }

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -72,8 +72,10 @@ class MapViewController: UIViewController {
         checkOutAlert.addAction(UIAlertAction(title: "취소", style: .cancel))
         checkOutAlert.addAction(UIAlertAction(title: "로그인", style: .default, handler: { action in
             
-            let controller = SignUpViewController() // 추후 로그인뷰로 변경
-            controller.modalPresentationStyle = .fullScreen
+            let controller = LoginViewController() // 추후 로그인뷰로 변경
+            controller.delegate = self
+//            controller.modalPresentationStyle = .fullScreen
+            controller.sheetPresentationController?.detents = [.medium()]
             self.present(controller, animated: true)
         }))
         present(checkOutAlert, animated: true)
@@ -328,11 +330,11 @@ class MapViewController: UIViewController {
     
     // 맵 UI 그리기
     func configueMapUI() {
-        if RCValue.shared.bool(forKey: ValueKey.isLoginFirst) && !viewModel.isLogIn {
-            let controller = SignUpViewController()
-            controller.modalPresentationStyle = .fullScreen
-            present(controller, animated: false)
-        }
+//        if RCValue.shared.bool(forKey: ValueKey.isLoginFirst) && !viewModel.isLogIn {
+//            let controller = SignUpViewController()
+//            controller.modalPresentationStyle = .fullScreen
+//            present(controller, animated: false)
+//        }
         
         FirebaseManager.shared.fetchPlaceAll { place in
             self.map.addAnnotation(MKAnnotationFromPlace.convertPlaceToAnnotation(place))
@@ -389,10 +391,10 @@ extension MapViewController: MKMapViewDelegate {
         for place in viewModel.places {
             if mapView.visibleMapRect.contains(MKMapPoint(CLLocationCoordinate2D(latitude: place.latitude, longitude: place.longitude)))
             {
-                print(place, "visible")
+//                print(place, "visible")
                 visiblePlacesOnMap.append(place)
             } else {
-                print(place, "invisible")
+//                print(place, "invisible")
                 visiblePlacesOnMap.removeAll { $0.name == place.name }
 
             }
@@ -498,5 +500,16 @@ extension MapViewController: ReviewPage {
         let controller = ReviewDetailViewController()
         controller.sheetPresentationController?.detents = [.large()]
         self.present(controller, animated: true)
+    }
+}
+
+// MARK: - LogInToSignUp
+
+extension MapViewController: LogInToSignUp {
+    func logInToSignUp(userIdentifier: String) {
+        let signUpViewController = SignUpViewController()
+        signUpViewController.modalPresentationStyle = .fullScreen
+        signUpViewController.userIdentifier = userIdentifier
+        self.present(signUpViewController, animated: true)
     }
 }

--- a/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
@@ -237,19 +237,25 @@ class PlaceInfoCell: UICollectionViewCell {
     func userCheck() {
         viewModel.$user
             .sink { user in
-                guard let user = user else { return }
-                if user.isChecked && self.place?.placeUid == user.currentCheckIn?.placeUid {
-                    self.checkInButton.isHidden = true
-                    self.checkOutButton.isHidden = false
-                    self.alreadyCheckIn.isHidden = true
-                } else if user.isChecked && self.place?.placeUid != user.currentCheckIn?.placeUid {
-                    self.checkInButton.isHidden = true
-                    self.checkOutButton.isHidden = true
-                    self.alreadyCheckIn.isHidden = false
-                } else {
+                if user == nil {
                     self.checkInButton.isHidden = false
                     self.checkOutButton.isHidden = true
                     self.alreadyCheckIn.isHidden = true
+                } else {
+                    guard let user = user else { return }
+                    if user.isChecked && self.place?.placeUid == user.currentCheckIn?.placeUid {
+                        self.checkInButton.isHidden = true
+                        self.checkOutButton.isHidden = false
+                        self.alreadyCheckIn.isHidden = true
+                    } else if user.isChecked && self.place?.placeUid != user.currentCheckIn?.placeUid {
+                        self.checkInButton.isHidden = true
+                        self.checkOutButton.isHidden = true
+                        self.alreadyCheckIn.isHidden = false
+                    } else {
+                        self.checkInButton.isHidden = false
+                        self.checkOutButton.isHidden = true
+                        self.alreadyCheckIn.isHidden = true
+                    }
                 }
             }
             .store(in: &store)

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -173,8 +173,9 @@ class PlaceInfoModalViewController: UIViewController {
         let checkOutAlert = UIAlertController(title: "로그인하시겠습니까?", message: "로그인하시면 체크인하실 수 있습니다.", preferredStyle: .alert)
         checkOutAlert.addAction(UIAlertAction(title: "취소", style: .cancel))
         checkOutAlert.addAction(UIAlertAction(title: "로그인", style: .default, handler: { action in
-            let controller = SignUpViewController() // 추후 로그인뷰로 변경
-            controller.modalPresentationStyle = .fullScreen
+            let controller = LoginViewController()
+            controller.delegate = self
+            controller.sheetPresentationController?.detents = [.medium()]
             self.present(controller, animated: true)
         }))
         present(checkOutAlert, animated: true)
@@ -303,5 +304,14 @@ extension PlaceInfoModalViewController: ReviewPage {
         let controller = ReviewDetailViewController()
         controller.sheetPresentationController?.detents = [.large()]
         self.present(controller, animated: true)
+    }
+}
+
+extension PlaceInfoModalViewController: LogInToSignUp {
+    func logInToSignUp(userIdentifier: String) {
+        let signUpViewController = SignUpViewController()
+        signUpViewController.modalPresentationStyle = .fullScreen
+        signUpViewController.userIdentifier = userIdentifier
+        self.present(signUpViewController, animated: true)
     }
 }

--- a/BNomad/View/SettingView/SettingViewController.swift
+++ b/BNomad/View/SettingView/SettingViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import FirebaseAuth
 
 class SettingViewController: UIViewController {
 
@@ -16,6 +17,8 @@ class SettingViewController: UIViewController {
         static let withdrawUser = "회원 탈퇴"
         static let logout = "로그아웃"
     }
+    
+    var viewModel = CombineViewModel.shared
     
     private let settingTable: UITableView = {
         let table = UITableView()
@@ -77,8 +80,19 @@ extension SettingViewController: UITableViewDelegate {
             let alert = UIAlertController(title: listTitle.logout, message: "로그아웃 하시겠습니까?", preferredStyle: .alert)
             let cancel = UIAlertAction(title: "취소", style: .cancel)
             let logout = UIAlertAction(title: "확인", style: .destructive) { action in
-                // TODO: 로그아웃 액션
-                self.navigationController?.popToRootViewController(animated: true)
+                if Auth.auth().currentUser != nil {
+                    do {
+                        // 체크인 되어 있는 사람이 탈퇴하려할때, 어떻게 해주고 탈퇴시켜야 하나..?!
+                        try Auth.auth().signOut()
+                        self.viewModel.user = nil
+                        self.navigationController?.popToRootViewController(animated: true)
+                    } catch {
+                        print("No current User now")
+                    }
+                } else {
+                    print("로그아웃할 유저가 없습니다.")
+                    self.navigationController?.popToRootViewController(animated: true)
+                }
             }
             alert.addAction(cancel)
             alert.addAction(logout)

--- a/BNomad/View/SettingView/WithdrawViewController.swift
+++ b/BNomad/View/SettingView/WithdrawViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import FirebaseAuth
 
 class WithdrawViewController: UIViewController {
 
@@ -14,6 +15,7 @@ class WithdrawViewController: UIViewController {
     enum Size {
         static let paddingNormal: CGFloat = 20
     }
+    var viewModel = CombineViewModel.shared
     
     private let withdrawLabel: UILabel = {
         let label = UILabel()
@@ -59,7 +61,17 @@ class WithdrawViewController: UIViewController {
         let alert = UIAlertController(title: "탈퇴하기", message: "탈퇴하시겠습니까?", preferredStyle: .alert)
         let cancel = UIAlertAction(title: "취소", style: .cancel)
         let withdrawConfirm = UIAlertAction(title: "탈퇴", style: .destructive) { action in
-            // TODO: 유저를 지우는 액션이 들어가 있어야 합니다.
+            if Auth.auth().currentUser != nil {
+                Auth.auth().currentUser?.delete()
+                do {
+                    try Auth.auth().signOut()
+                } catch {
+                    print("signOut 에러")
+                }
+                self.viewModel.user = nil
+            } else {
+                // 로그인되지 않았는데 탈퇴 버튼을 누를경우의 액션
+            }
             print("탈퇴합니다")
             self.navigationController?.popToRootViewController(animated: true)
         }

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -7,12 +7,15 @@
 
 import UIKit
 import Firebase
+import FirebaseAuth
 
 class SignUpViewController: UIViewController {
     
     // MARK: - Properties
     
     lazy var viewModel: CombineViewModel = CombineViewModel.shared
+    
+    var userIdentifier: String = ""
     
     lazy var cancelButton: UIButton = {
         let button = UIButton()
@@ -276,10 +279,7 @@ class SignUpViewController: UIViewController {
     // MARK: - Methods
     
     func setUser(nickname: String, occupation: String, intro: String) -> User? {
-        let deviceUid = UIDevice.current.identifierForVendor?.uuidString
-        guard let userUid = deviceUid else { return nil}
-        
-        let user = User(userUid: userUid, nickname: nickname, occupation: occupation, introduction: intro)
+        let user = User(userUid: userIdentifier, nickname: nickname, occupation: occupation, introduction: intro)
         FirebaseManager.shared.setUser(user: user)
         return user
     }


### PR DESCRIPTION
## 관련 이슈들
- #224 

## 작업 내용
- 애플로그인을 Firebase와 연결했습니다.(회원가입 + 로그인)
- 로그아웃을 만들었습니다.
- 회원 탈퇴를 만들었습니다.
- user가 nil일때의 PlaceInfoModal UI를 수정했습니다.
- FirebaseAuth에 맞게 Scenedelegate를 수정했습니다.

## 리뷰 노트
- FirebaseAuth 재설정한 것들이 project파일에 순서 변화를 준 것 같습니다.
- GoogleService-info.plist 변경이 있어, 머지된 이후에 팀원 전부가 설정해야 할 것이 있습니다.
- 유저의 상태가 기존상태에서 늘었습니다. (회원가입O, 회원가입X) -> (로그인+회원가입O, 로그인+회원가입X, 로그인된 유저X)
- 애플로그인 보안토큰 생성을 위해 Firebase, Apple example code를 사용했습니다
- 이 PR이 머지된 이후로는, 회원가입을 애플로그인을 통해서만 진행하기 때문에, 시뮬레이터에서 테스트하지 못하는 경우가 있습니다.
    - 추가로 설정해야할 파일이 `team provisioning파일설정`과 `팀인증서 등록`이 있기 때문에, 저에게 파일을 요청하면 됩니다!👍(직접 해드림!)
- 아마 로그인 로그아웃 상태에서의 빈 로직이 있을 것 같은데 같이 찾아보면 좋을 것 같습니다👨‍💻

## Reference
- [애플로그인](https://www.kyulabs.app/3813c4d9-8343-40c6-a02c-26ccfa7e2731)
- [firebaseAuth + 애플로그인](https://huree-can-do-it.notion.site/Firebase-Apple-Login-dbabbe8d59a04d5cb96ef1da2ede9a9a)
- [애플로그인 설정](https://spiralmoon.tistory.com/entry/Apple-애플-로그인-설정하기-Sign-In-with-Apple)
- [팀 인증서 설정](https://yesiamnahee.tistory.com/185)
- https://www.blueswt.com/123
- [p12인증서 내보내기](https://kihun5393.tistory.com/44)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
