### PR TITLE
[Enhancement] #236 SignUpView 업데이트

### DIFF
--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -16,15 +16,13 @@ class SignUpViewController: UIViewController {
     
     lazy var cancelButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(systemName: "xmark"), for: .normal)
-        button.layer.cornerRadius = 30 / 2
-        button.tintColor = .white
-        button.backgroundColor = .lightGray
-        button.layer.opacity = 0.5
-        button.addTarget(self, action: #selector(dismissPage), for: .touchUpInside)
-        if RCValue.shared.bool(forKey: ValueKey.isLoginFirst) { 
-            button.isHidden = true 
-        }
+        button.setTitle("취소", for: .normal)
+        button.setTitleColor(CustomColor.nomadGray1, for: .normal)
+        button.addTarget(self, action: #selector(didTapCancelButon), for: .touchUpInside)
+// A/B 테스트 시 사용예정
+//        if RCValue.shared.bool(forKey: ValueKey.isLoginFirst) {
+//            button.isHidden = true
+//        }
         return button
     }()
 
@@ -438,12 +436,9 @@ class SignUpViewController: UIViewController {
     func configCancelButton() {
         view.addSubview(cancelButton)
         cancelButton.anchor(
-            top: view.topAnchor,
+            bottom: requestLabel.topAnchor,
             right: view.rightAnchor,
-            paddingTop: 50,
-            paddingRight: 20,
-            width: 30,
-            height: 30
+            paddingRight: 20
         )
     }
     
@@ -478,8 +473,13 @@ class SignUpViewController: UIViewController {
         }
     }
     
-    @objc func dismissPage() {
-        self.dismiss(animated: true)
+    @objc func didTapCancelButon() {
+        let cancelAlert = UIAlertController(title: "취소하시겠습니까?", message: "취소하면 작성한 내용이 저장되지 않습니다.", preferredStyle: .alert)
+        cancelAlert.addAction(UIAlertAction(title: "작성 취소", style: .default, handler: { action in
+            self.dismiss(animated: true)
+        }))
+        cancelAlert.addAction(UIAlertAction(title: "계속 작성", style: .cancel))
+        present(cancelAlert, animated: true)
     }
     
     @objc func didTapProfileImageButton() {

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -576,11 +576,9 @@ class SignUpViewController: UIViewController {
             
                 let user = setUser(nickname: nickname, occupation: occupation, intro: intro)
                 viewModel.user = user
-                guard let userUid = viewModel.user?.userUid else { return }
-                
-                FirebaseManager.shared.uploadUserProfileImage(userUid: userUid, image: image) { url in
+                FirebaseManager.shared.uploadUserProfileImage(userUid: userIdentifier, image: image) { url in
                     self.viewModel.user?.profileImageUrl = url
-                    let user = User(userUid: userUid, nickname: nickname, profileImageUrl: self.viewModel.user?.profileImageUrl)
+                    let user = User(userUid: self.userIdentifier, nickname: nickname, profileImageUrl: self.viewModel.user?.profileImageUrl)
                     FirebaseManager.shared.setUser(user: user)
                 }
                 

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -576,7 +576,12 @@ class SignUpViewController: UIViewController {
                 let user = setUser(nickname: nickname, occupation: occupation, intro: intro)
                 viewModel.user = user
                 Analytics.logEvent("signUpCompleted", parameters: nil)
-                self.dismiss(animated: true) // 마지막 확인 버튼 클릭 후 dismiss 안됨
+                
+                let completedAlert = UIAlertController(title: "회원가입 완료", message: "회원가입이 완료되었습니다.", preferredStyle: .alert)
+                completedAlert.addAction(UIAlertAction(title: "확인", style: .default, handler: { action in
+                    self.dismiss(animated: true)
+                }))
+                present(completedAlert, animated: true)
             }
         }
     }

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -572,9 +572,18 @@ class SignUpViewController: UIViewController {
         
         // 사진 업로드 화면일 때 -> 드디어 저장(사진 업로드 여부 체크 X)
         } else if profileImageButton.isHidden == false {
-            if let nickname = nicknameField.text, let occupation = occupationField.text, let intro = introductionField.text {
+            if let nickname = nicknameField.text, let occupation = occupationField.text, let intro = introductionField.text, let image = profileImageButton.image(for: .normal) {
+            
                 let user = setUser(nickname: nickname, occupation: occupation, intro: intro)
                 viewModel.user = user
+                guard let userUid = viewModel.user?.userUid else { return }
+                
+                FirebaseManager.shared.uploadUserProfileImage(userUid: userUid, image: image) { url in
+                    self.viewModel.user?.profileImageUrl = url
+                    let user = User(userUid: userUid, nickname: nickname, profileImageUrl: self.viewModel.user?.profileImageUrl)
+                    FirebaseManager.shared.setUser(user: user)
+                }
+                
                 Analytics.logEvent("signUpCompleted", parameters: nil)
                 
                 let completedAlert = UIAlertController(title: "회원가입 완료", message: "회원가입이 완료되었습니다.", preferredStyle: .alert)


### PR DESCRIPTION
## 관련 이슈들
- #236 

## 작업 내용
- 닉네임, 직업, 자기소개 작성 후 다음 버튼을 누르면 세 가지의 입력칸들이 사라지고 사진 업로드 버튼이 나타납니다.
- 가입 중 상단의 취소 버튼을 누르면 계속 작성/작성 취소 alert가 뜹니다.
- 모두 완료하고 확인 버튼을 누르면 회원가입이 완료되었다는 alert가 뜨고 맵뷰로 돌아갑니다.

## 리뷰 노트
- 입력단계별 다음/확인 버튼의 액션을 작성하는 코드가 복잡하여 우선 주석으로 각 단계를 표시해 놓았는데, 추후 enum과 별도 함수로 나눠서 stage별로 필요한 함수가 실행되도록 리팩토링해볼 생각입니다...

## 스크린샷(UX의 경우 gif)
### 닉네임, 직업, 자기소개 입력 후 사진 업로드로 넘어가기(좌), 작성 중 취소 버튼 동작(우)
<p list="left">
<img src="https://user-images.githubusercontent.com/103012157/202069621-67ca6df2-5356-4246-be34-6a2f3c58f109.gif" width="300">
<img src="https://user-images.githubusercontent.com/103012157/202068545-6befa276-dd2b-4765-8d07-c16ee105021f.gif" width="300">
</p>

### (추가) 프로필이미지 저장 확인
<img src="https://user-images.githubusercontent.com/103012157/202110845-6d28da14-6621-4d33-95c1-7d40238b5f09.gif" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
