### PR TITLE
[Feat] #246 MeetUpView 밋업 프로필사진 둥글게, 참여중인 경우 참여 취소 버튼

### DIFF
--- a/BNomad/API/FirebaseManager.swift
+++ b/BNomad/API/FirebaseManager.swift
@@ -396,6 +396,22 @@ class FirebaseManager {
         }
     }
 
+    /// meetUp 취소하기
+    func cancelMeetUp(userUid: String, meetUpUid: String, placeUid: String, completion: @escaping() -> Void) {
+        let date = Date().toDateString()
+        
+        ref.updateChildValues(["meetUpUser/\(userUid)/\(meetUpUid)" : nil,
+                               "meetUp/\(meetUpUid)/currentPeopleUids/\(userUid)" : nil,
+                               "meetUpPlace/\(placeUid)/\(date)/\(meetUpUid)/currentPeopleUids/\(userUid)" : nil]) {
+            (error: Error?, ref: DatabaseReference) in
+            if let error: Error = error {
+                print("meetUp cancle could not be completed: \(error).")
+            } else {
+                completion()
+            }
+        }
+    }
+
     /// profile 이미지 업로드
     func uploadUserProfileImage(userUid: String, image: UIImage, completion: @escaping(String) -> Void) {
         let storageRef = Storage.storage().reference()

--- a/BNomad/View/MeetUpView/MeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/MeetUpViewController.swift
@@ -195,7 +195,6 @@ class MeetUpViewController: UIViewController {
                 let userUid = self.viewModel.user?.userUid,
                 let meetUpUid = self.meetUpViewModel?.meetUp?.meetUpUid,
                 let placeUid = self.meetUpViewModel?.meetUp?.placeUid,
-                let peopleUid = self.meetUpViewModel?.meetUp?.currentPeopleUids
             else { return }
             FirebaseManager.shared.cancelMeetUp(userUid: userUid, meetUpUid: meetUpUid, placeUid: placeUid) { }
             

--- a/BNomad/View/MeetUpView/MeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/MeetUpViewController.swift
@@ -24,6 +24,14 @@ class MeetUpViewController: UIViewController {
             contentLabel.text = meetUp.description
             participants.text = "참여 예정 노마더 ( \(meetUp.currentPeopleUids?.count ?? 0) / \(meetUp.maxPeopleNum) )"
             participantCollectionView.reloadData()
+            
+            guard let participants = currentPeopleUids else { return }
+            guard let user = viewModel.user?.userUid else { return }
+                
+            if participants.contains(user) {
+                configJoinCancelButton()
+            }
+            
         }
     }
     
@@ -179,7 +187,40 @@ class MeetUpViewController: UIViewController {
         self.present(alert, animated: true)
     }
     
+    @objc func cancelJoinMeetUp() {
+        let alert = UIAlertController(title: "밋업 참여 취소", message: "\(meetUpTitleLabel.text ?? "") 밋업 참여를 취소합니다.", preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        let cancelJoin = UIAlertAction(title: "확인", style: .default, handler: { action in
+            guard
+                let userUid = self.viewModel.user?.userUid,
+                let meetUpUid = self.meetUpViewModel?.meetUp?.meetUpUid,
+                let placeUid = self.meetUpViewModel?.meetUp?.placeUid,
+                let peopleUid = self.meetUpViewModel?.meetUp?.currentPeopleUids
+            else { return }
+            FirebaseManager.shared.participateMeetUp(userUid: userUid, meetUpUid: meetUpUid, placeUid: placeUid) {
+                if let index = peopleUid.firstIndex(of: userUid) {
+                    self.meetUpViewModel?.meetUp?.currentPeopleUids?.remove(at: index)
+                }
+            }
+            self.navigationController?.popToRootViewController(animated: true)
+        })
+        alert.addAction(cancel)
+        alert.addAction(cancelJoin)
+        self.present(alert, animated: true)
+    }
+    
     // MARK: - Helpers
+    
+    func configJoinCancelButton() {
+        joinButton.setTitle("참여 취소", for: .normal)
+        joinButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        joinButton.backgroundColor = CustomColor.nomad2White
+        joinButton.layer.borderWidth = 1
+        joinButton.layer.borderColor = CustomColor.nomadBlue?.cgColor
+        joinButton.setTitleColor(CustomColor.nomadBlue, for: .normal)
+        joinButton.removeTarget(self, action: #selector(joinMeetUp), for: .touchUpInside)
+        joinButton.addTarget(self, action: #selector(cancelJoinMeetUp), for: .touchUpInside)
+    }
     
     func configUI() {
         

--- a/BNomad/View/MeetUpView/MeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/MeetUpViewController.swift
@@ -197,11 +197,8 @@ class MeetUpViewController: UIViewController {
                 let placeUid = self.meetUpViewModel?.meetUp?.placeUid,
                 let peopleUid = self.meetUpViewModel?.meetUp?.currentPeopleUids
             else { return }
-            FirebaseManager.shared.participateMeetUp(userUid: userUid, meetUpUid: meetUpUid, placeUid: placeUid) {
-                if let index = peopleUid.firstIndex(of: userUid) {
-                    self.meetUpViewModel?.meetUp?.currentPeopleUids?.remove(at: index)
-                }
-            }
+            FirebaseManager.shared.cancelMeetUp(userUid: userUid, meetUpUid: meetUpUid, placeUid: placeUid) { }
+            
             self.navigationController?.popToRootViewController(animated: true)
         })
         alert.addAction(cancel)

--- a/BNomad/View/MeetUpView/ParticipantCell.swift
+++ b/BNomad/View/MeetUpView/ParticipantCell.swift
@@ -47,6 +47,8 @@ class ParticipantCell: UICollectionViewCell {
     private let profileImageView: UIImageView = {
         let image = UIImageView()
         image.tintColor = CustomColor.nomadGray1
+        image.clipsToBounds = true
+        
         return image
     }()
     
@@ -76,18 +78,16 @@ class ParticipantCell: UICollectionViewCell {
         crownView.anchor(top: self.topAnchor, width: 22, height: 18)
         crownView.centerX(inView: self)
         
+        let screenWidth = UIScreen.main.bounds.width
+        let profileImageSize = screenWidth * 58/390
+        
         self.addSubview(profileImageView)
-        profileImageView.anchor(top: crownView.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 8, paddingLeft: 7, paddingRight: 7)
-        profileImageView.heightAnchor.constraint(equalTo: self.profileImageView.widthAnchor, multiplier: 1.0/1.0).isActive = true
+        profileImageView.anchor(top: crownView.bottomAnchor, paddingTop: 8, width: profileImageSize, height: profileImageSize)
+        profileImageView.centerX(inView: self)
+        profileImageView.layer.cornerRadius = profileImageSize / 2
         
         self.addSubview(nicknameLabel)
         nicknameLabel.anchor(top: profileImageView.bottomAnchor, paddingTop: 14)
         nicknameLabel.centerX(inView: self)
-        
-//        if isOrganizer == true {
-//            crownView.isHidden = false
-//        } else {
-//            crownView.isHidden = true
-//        }
     }
 }

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -24,25 +24,14 @@ class QuestCollectionViewCell: UICollectionViewCell {
             location.text = meetUp.meetUpPlaceName
             checkedPeople.text = "\(meetUp.currentPeopleUids?.count ?? 0) / \(meetUp.maxPeopleNum)"
             
-            checkedInPeople = meetUp.currentPeopleUids?.map { userUid in
-                let image = UIImageView()
-                image.anchor(width: 32, height: 32)
-                image.tintColor = CustomColor.nomadGray1
-                FirebaseManager.shared.fetchUser(id: userUid) { user in
-                    guard let profileImageUrl = user.profileImageUrl else { return }
-                    image.kf.setImage(with: URL(string: profileImageUrl))
-                }
-                return image
+            let organizer = meetUp.organizerUid
+            FirebaseManager.shared.fetchUser(id: organizer) { user in
+                guard let organizerImageUrl = user.profileImageUrl else { return }
+                self.organizerImage.kf.setImage(with: URL(string: organizerImageUrl))
             }
 
             guard let userUid = viewModel.user?.userUid else { return }
             isParticipated = meetUp.currentPeopleUids?.contains(userUid)
-        }
-    }
-    
-    var checkedInPeople: [UIImageView]? {
-        didSet {
-            configureCheckInPeopleUI()
         }
     }
     
@@ -109,6 +98,15 @@ class QuestCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
+    var organizerImage: UIImageView = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "person.crop.circle.fill")
+        image.tintColor = CustomColor.nomadGray1
+        image.clipsToBounds = true
+        
+        return image
+    }()
+    
     // MARK: - LifeCycle
     
     override init(frame: CGRect) {
@@ -117,6 +115,7 @@ class QuestCollectionViewCell: UICollectionViewCell {
         shadowSetting()
         configureUI()
         configCheckMark()
+        configurePeopleUI()
     }
     
     required init?(coder: NSCoder) {
@@ -175,17 +174,15 @@ class QuestCollectionViewCell: UICollectionViewCell {
         checkImage.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 10, paddingRight: 10, width: checkSize, height: checkSize)
     }
     
-    func configureCheckInPeopleUI() {
-        guard let checkedInPeople = checkedInPeople else { return }
+    func configurePeopleUI() {
+        let screenWidth = UIScreen.main.bounds.width
+        let organizerImageSize = screenWidth * 36/390
         
-        let peopleStack = UIStackView(arrangedSubviews: checkedInPeople)
-        peopleStack.axis = .horizontal
-        peopleStack.spacing = -10
-        
-        self.addSubview(peopleStack)
-        peopleStack.anchor(bottom: self.bottomAnchor, right: self.rightAnchor, paddingBottom: 13, paddingRight: 14)
+        self.addSubview(organizerImage)
+        organizerImage.anchor(bottom: self.bottomAnchor, right: self.rightAnchor, paddingBottom: 13, paddingRight: 14, width: organizerImageSize, height: organizerImageSize)
+        organizerImage.layer.cornerRadius = organizerImageSize / 2
         
         self.addSubview(checkedPeople)
-        checkedPeople.anchor(bottom: self.bottomAnchor, right: peopleStack.leftAnchor, paddingBottom: 15, paddingRight: 11)
+        checkedPeople.anchor(bottom: self.bottomAnchor, right: organizerImage.leftAnchor, paddingBottom: 15, paddingRight: 11)
     }
 }


### PR DESCRIPTION
## 관련 이슈들
- #246 

## 작업 내용
- 체크인뷰에 보이는 밋업셀에는 협의된 것과 같이 작성자의 프로필이미지만 보이도록 했습니다.
- 밋업셀, 밋업 상세뷰의 프로필 이미지가 동그라미로 나오도록 했습니다.
- 참여중인 밋업의 경우 밋업상세뷰에서 참여하기 대신 참여 취소 버튼이 나오도록 했습니다.
- (수정) 참여 취소 버튼을 누르면 확인 alert이 나오고 확인을 누르면 참여가 취소됩니다.

## 리뷰 노트
- ~~참여 취소가 되도록 구현하고 싶었는데 FirebaseManager에 참여 취소 함수가 별도로 없습니다.~~
    - ~~참여할 때 participateMeetUp() 함수를 불러와 currentPeopleUids에 userUid를 .append시키길래.. 참여 취소는 같은 함수에 remove를 넣어보았는데 제대로 동작하지 않는 것 같습니다(아래 그림). 작성자가 참여 취소해서 그런걸까요..? participateMeetUp()을 이용하면 안되는 걸까요? @limhyoseok~~ → (수정) FirebaseManager에 참여 취소 함수가 추가되어 해결되었습니다!!

### 수정 전(좌), 수정 후(우)
<p list="left">
 <img width="300" alt="Nov-17-2022 01-23-41" src="https://user-images.githubusercontent.com/103012157/202237305-7f07a0b4-ec61-46e2-a524-54794b572f93.gif">
<img width="300" alt="Nov-17-2022 11-08-09" src="https://user-images.githubusercontent.com/103012157/202336988-4cb6fc47-375b-4586-b6f1-ab1e18f7b352.gif">
</p>

## 스크린샷(UX의 경우 gif)
12시 넘으니까 어제 많던 밋업이랑 참여자가 다 없어졌네요ㅜㅠ

### 동그란 프로필 이미지
<p list="left">
<img width="300" alt="Screen Shot 2022-11-17 at 1 16 40 AM" src="https://user-images.githubusercontent.com/103012157/202234714-7e00728b-6f40-4f9c-8041-be1e05474278.png">
<img width="300" alt="Screen Shot 2022-11-17 at 1 17 03 AM" src="https://user-images.githubusercontent.com/103012157/202234773-4f0092b0-95db-42b6-9fdb-b9d63e7764e0.png">
</p>

### 참여 취소 버튼
<p list="left">
<img width="300" alt="Screen Shot 2022-11-17 at 1 26 33 AM" src="https://user-images.githubusercontent.com/103012157/202236951-a3a5ab17-228b-4253-bdb8-6718f02ef8d2.png">
<img width="300" alt="Screen Shot 2022-11-17 at 1 27 18 AM" src="https://user-images.githubusercontent.com/103012157/202237132-bfc0c966-d2bf-4ae6-8189-c03755e0c683.png">
</p>

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
