### PR TITLE
[Enhancement] #250 리뷰 데이터 바인딩 및 Firebase 업데이트

### DIFF
--- a/BNomad/API/FirebaseManager.swift
+++ b/BNomad/API/FirebaseManager.swift
@@ -483,7 +483,7 @@ class FirebaseManager {
 
     /// 리뷰 사진 업로드
     func uploadReviewImages(reviewUid: String, placeUid: String, image: UIImage?, completion: @escaping(String) -> Void) {
-        guard let image = image else { return }
+        guard let image = image else { return completion("no image") }
         
         let storageRef = Storage.storage().reference().child("reviewImage/\(reviewUid)")
         if let uploadData = image.jpegData(compressionQuality: 0.1) {
@@ -511,6 +511,7 @@ class FirebaseManager {
         let createTime = review.createTime.toDateTimeString()
 
         uploadReviewImages(reviewUid: review.reviewUid, placeUid: review.placeUid, image: image) { url in
+            completion()
         }
         ref.updateChildValues(["review/\(review.placeUid)/\(review.reviewUid)" : ["userUid" : review.userUid,
                                                                                 "createTime" : createTime,

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -494,10 +494,11 @@ extension MapViewController: setMap {
 // MARK: - ReviewPage
 
 extension MapViewController: ReviewPage {
-    func reviewPageShow() {
+    func reviewPageShow(place: Place) {
         // TODO: PlaceInfoModalViweController가 띄워져 있으면 Review 모달이 안뜨는 오류가 있음
         self.dismiss(animated: true)
         let controller = ReviewDetailViewController()
+        controller.place = place
         controller.sheetPresentationController?.detents = [.large()]
         self.present(controller, animated: true)
     }

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Combine
 
 protocol ReviewPage {
-    func reviewPageShow()
+    func reviewPageShow(place: Place)
 }
 
 class PlaceCheckInViewController: UIViewController {
@@ -193,8 +193,8 @@ extension PlaceCheckInViewController {
             guard let index = index else { return }
             self.viewModel.user?.checkInHistory?[index] = checkIn
             self.dismiss(animated: true)
-            
-            self.delegate?.reviewPageShow()
+            guard let selectedPlace = self.selectedPlace else { return }
+            self.delegate?.reviewPageShow(place: selectedPlace)
         }
     }
 }

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -335,9 +335,10 @@ extension PlaceInfoModalViewController: CheckInOut {
 // MARK: - ReviewPage
 
 extension PlaceInfoModalViewController: ReviewPage {
-    func reviewPageShow() {
+    func reviewPageShow(place: Place) {
         self.dismiss(animated: false)
         let controller = ReviewDetailViewController()
+        controller.place = place
         controller.sheetPresentationController?.detents = [.large()]
         self.present(controller, animated: true)
     }

--- a/BNomad/View/ReviewView/ReviewDetailViewController.swift
+++ b/BNomad/View/ReviewView/ReviewDetailViewController.swift
@@ -179,9 +179,8 @@ class ReviewDetailViewController: UIViewController {
         let alert = UIAlertController(title: "리뷰 작성 완료하시겠습니까?", message: "리뷰를 작성을 완료합니다.", preferredStyle: .alert)
         let cancel = UIAlertAction(title: "취소", style: .cancel)
         let save = UIAlertAction(title: "확인", style: .default) { action in
+            self.dismiss(animated: true)
             FirebaseManager.shared.writeReview(review: Review(placeUid: placeUid, userUid: user.uid , reviewUid: UUID().uuidString, createTime: Date(), content: self.reviewTextView.text), image: image == UIImage() ? nil : image) {
-                print("REVIEW SAVE Done")
-                self.dismiss(animated: true)
             }
         }
         alert.addAction(cancel)

--- a/BNomad/View/ReviewView/ReviewDetailViewController.swift
+++ b/BNomad/View/ReviewView/ReviewDetailViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import AVFoundation
+import FirebaseAuth
 
 class ReviewDetailViewController: UIViewController {
     
@@ -21,12 +22,17 @@ class ReviewDetailViewController: UIViewController {
         return button
     }()
     
-    private let placeName: UILabel = {
+    var place: Place? {
+        didSet {
+            placeName.text = place?.name
+        }
+    }
+    
+    let placeName: UILabel = {
         let title = UILabel()
         title.backgroundColor = .clear
         title.textColor = .black
         title.font = .preferredFont(forTextStyle: .title1, weight: .bold)
-        title.text = "쌍사벅스"
         title.textAlignment = .center
         return title
     }()
@@ -87,7 +93,6 @@ class ReviewDetailViewController: UIViewController {
         button.tintColor = UIColor(hex: "3C3C43")?.withAlphaComponent(0.6)
         button.backgroundColor = UIColor(hex: "F5F5F5")
         button.addTarget(self, action: #selector(chooseCameraOrAlbum), for: .touchUpInside)
-//        button.anchor(width: (UIScreen.main.bounds.width-64)/3, height: (UIScreen.main.bounds.width-64)/3)
         return button
     }()
     
@@ -129,6 +134,7 @@ class ReviewDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        hideKeyboardWhenTappedAround()
     }
     
     // MARK: - Actions
@@ -164,7 +170,23 @@ class ReviewDetailViewController: UIViewController {
     
     @objc func saveReview() {
         // TODO: alert이후에 저장을 하거나, 바로 저장을 하거나 선택해야함
-        self.dismiss(animated: true)
+        guard let user = Auth.auth().currentUser else { return }
+        guard let placeUid = place?.placeUid else { return }
+        var image = UIImage()
+        if removePhotoCell.image != UIImage(named: "AppIcon") {
+            image = removePhotoCell.image ?? UIImage()
+        }
+        let alert = UIAlertController(title: "리뷰 작성 완료하시겠습니까?", message: "리뷰를 작성을 완료합니다.", preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        let save = UIAlertAction(title: "확인", style: .default) { action in
+            FirebaseManager.shared.writeReview(review: Review(placeUid: placeUid, userUid: user.uid , reviewUid: UUID().uuidString, createTime: Date(), content: self.reviewTextView.text), image: image == UIImage() ? nil : image) {
+                print("REVIEW SAVE Done")
+                self.dismiss(animated: true)
+            }
+        }
+        alert.addAction(cancel)
+        alert.addAction(save)
+        self.present(alert, animated: true)
     }
     
     @objc func dismissPage() {


### PR DESCRIPTION
## 관련 이슈들
- #250 

## 작업 내용
- 리뷰 작성 페이지로 넘어갈때, 장소 title을 넘겨줍니다
- 리뷰 작성 완료를 누르면 Firebase로 저장됩니다.
- 이미지 데이터가 있을때와 없을때의 분기 처리를 해주었습니다.

## 리뷰 노트
- 로그인 할때도 그렇고, 지금도 그렇고 이미지 업로드에 꽤 많은 시간이 드는 것 같아 다 합치고 spinner 작업을 해주어야 할 것 같습니다.

## 스크린샷(UX의 경우 gif)
https://user-images.githubusercontent.com/72736657/202362841-6628d944-351b-4ee7-a2a0-c47830766d37.mov


## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
