### PR TITLE
[Feat] 프로필뷰 UI수정, 오토레이아웃 및 버그 픽스

### DIFF
--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -18,6 +18,18 @@ class ProfileViewController: UIViewController {
     
     var userFromListUid: String?
     
+    let scrollView: UIScrollView = {
+        let scroll = UIScrollView()
+        scroll.backgroundColor = CustomColor.nomad2White
+        return scroll
+    }()
+    
+    let contentView: UIView = {
+        let ui = UIView()
+        ui.backgroundColor = CustomColor.nomad2White
+        return ui
+    }()
+    
     private lazy var profileImageView: UIImageView = {
         let iv = UIImageView()
         iv.contentMode = .scaleAspectFill
@@ -101,13 +113,25 @@ class ProfileViewController: UIViewController {
     
     func render() {
         
-        view.addSubview(profileImageView)
-        profileImageView.anchor(top: view.topAnchor, left: view.leftAnchor, paddingTop: 120, paddingLeft: 29, width: 78, height: 78)
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
         
-        view.addSubview(profileCollectionView)
-        profileCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, right: view.rightAnchor,
-                                     paddingTop: 220, paddingLeft: 16, paddingRight: 16,
-                                     height: 600)
+        scrollView.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
+        contentView.anchor(top: scrollView.topAnchor, left: scrollView.leftAnchor, bottom: scrollView.bottomAnchor, right: scrollView.rightAnchor)
+
+        let contentViewHeight = contentView.heightAnchor.constraint(greaterThanOrEqualTo: view.heightAnchor)
+        contentViewHeight.priority = .defaultLow
+        contentViewHeight.isActive = true
+        
+        contentView.addSubview(profileCollectionView)
+        contentView.addSubview(profileImageView)
+        
+        profileImageView.anchor(top: contentView.topAnchor, paddingTop: 25, width: 120, height: 120)
+        profileImageView.centerX(inView: view)
+        
+        profileCollectionView.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: view.rightAnchor,
+                                             paddingTop: 100, paddingLeft: 16, paddingRight: 16,
+                                             height: 600)
         
     }
     
@@ -204,7 +228,7 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize{
         if indexPath.section == 0 {
-            return CGSize(width: profileCollectionView.frame.width, height: 166)
+            return CGSize(width: profileCollectionView.frame.width, height: 182)
         } else if indexPath.section == 1 {
             return CGSize(width: profileCollectionView.frame.width, height: 119)
         } else {

--- a/BNomad/View/ProfileView/SelfUserInfoCell.swift
+++ b/BNomad/View/ProfileView/SelfUserInfoCell.swift
@@ -95,19 +95,19 @@ class SelfUserInfoCell: UICollectionViewCell {
     func render() {
 
         contentView.addSubview(nameLabel)
-        nameLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 25, paddingLeft: 20)
+        nameLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 40, paddingLeft: 20)
         
         contentView.addSubview(editingButton)
-        editingButton.anchor(top: contentView.topAnchor, right: contentView.rightAnchor, paddingTop: 18, paddingRight: 12, width: 55, height: 13)
+        editingButton.anchor(top: contentView.topAnchor, right: contentView.rightAnchor, paddingTop: 33, paddingRight: 12, width: 55, height: 13)
         
         contentView.addSubview(jobLabel)
-        jobLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 60, paddingLeft: 20, paddingRight: 20)
+        jobLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 75, paddingLeft: 20, paddingRight: 20)
         
         contentView.addSubview(dividerLine)
-        dividerLine.anchor(top: jobLabel.bottomAnchor, left: contentView.leftAnchor, bottom: jobLabel.bottomAnchor, right: contentView.rightAnchor, paddingTop: 17, paddingLeft: 10, paddingBottom: -18, paddingRight: 10, width: 340, height: 1)
+        dividerLine.anchor(top: jobLabel.bottomAnchor, left: contentView.leftAnchor, bottom: jobLabel.bottomAnchor, right: contentView.rightAnchor, paddingTop: 33, paddingLeft: 10, paddingBottom: -18, paddingRight: 10, width: 340, height: 1)
         
         contentView.addSubview(statusLabel)
-        statusLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 110, paddingLeft: 20, paddingRight: 20)
+        statusLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 125, paddingLeft: 20, paddingRight: 20)
         
     }
 


### PR DESCRIPTION
## 관련 이슈들
- (ex. #2, #3 ...)

## 작업 내용
- 프로필뷰 UI가 피그마와 같아졌습니다
- 프로필컬렉션뷰 리펙터링이 진행되었습니다
- 프로필 오토레이아웃 수정 및 스크롤뷰가 추가되었습니다

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img width="300" alt="스크린샷 2022-11-17 18 58 48" src="https://user-images.githubusercontent.com/70618615/202415843-1622d3b5-05c1-4996-b9d1-fe8c2840e753.png">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
