### PR TITLE
[Feat] #231 밋업 편집 구현

### DIFF
--- a/BNomad/View/MeetUpView/MeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/MeetUpViewController.swift
@@ -145,11 +145,11 @@ class MeetUpViewController: UIViewController {
         super.viewDidLoad()
     
         configUI()
+        configEditButton()
         
         participantCollectionView.dataSource = self
         participantCollectionView.delegate = self
         
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "편집", style: .plain, target: self, action: #selector(editMeetUpContent))
         navigationController?.navigationBar.tintColor = CustomColor.nomadBlue
     }
     
@@ -184,6 +184,14 @@ class MeetUpViewController: UIViewController {
     }
     
     // MARK: - Helpers
+    
+    func configEditButton() {
+        guard let userUid = viewModel.user?.userUid else { return }
+        guard let organizerUid = meetUpViewModel?.meetUp?.organizerUid else { return }
+        if userUid == organizerUid {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(title: "편집", style: .plain, target: self, action: #selector(editMeetUpContent))
+        }
+    }
     
     func configUI() {
         
@@ -236,10 +244,19 @@ extension MeetUpViewController: UICollectionViewDelegate {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ParticipantCell.identifier, for: indexPath) as? ParticipantCell else {
             return UICollectionViewCell()
         }
-        cell.organizerUid = organizerUid
-        cell.userUid = currentPeopleUids?[indexPath.row]
-        cell.backgroundColor = .white
         
+        var people: [String] = []
+        if let originalPeople = meetUpViewModel?.meetUp?.currentPeopleUids, let organizerUid = organizerUid {
+            people = originalPeople
+            if let index = people.firstIndex(of: organizerUid) {
+                people.remove(at: index)
+                people.insert(organizerUid, at: 0)
+            }
+        }
+        cell.organizerUid = organizerUid
+        cell.userUid = people[indexPath.row]
+        cell.backgroundColor = .white
+
         return cell
     }
 }

--- a/BNomad/View/MeetUpView/MeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/MeetUpViewController.swift
@@ -156,7 +156,11 @@ class MeetUpViewController: UIViewController {
     // MARK: - Actions
     
     @objc func editMeetUpContent() {
-        // TODO: 편집뷰로 이동
+        let controller = NewMeetUpViewController()
+        controller.isNewMeetUp = false
+        controller.meetUpViewModel = meetUpViewModel
+        self.navigationItem.backButtonTitle = ""
+        navigationController?.pushViewController(controller, animated: true)
     }
     
     @objc func joinMeetUp() {

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -297,6 +297,7 @@ class NewMeetUpViewController: UIViewController {
     
     // MARK: - Actions
     
+    // TODO: 현재시간 이전으로는 설정 못하도록 해야함(피커에서 막기 vs. 저장할때 안되게)
     @objc func didTimePickerValueChange() {
         let formatter = DateFormatter()
         formatter.dateStyle = .none
@@ -340,6 +341,17 @@ class NewMeetUpViewController: UIViewController {
     
     @objc func didTapDoneEditingMeetUp() {
          // TODO: 편집 변경사항 저장 & PlaceCheckInView로 가기
+        let alert = UIAlertController(title: "편집을 완료하시겠습니까?", message: "밋업 편집을 완료합니다.", preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        let done = UIAlertAction(title: "확인", style: .default, handler: { action in
+
+            
+            self.navigationController?.popToRootViewController(animated: true)
+        })
+        alert.addAction(cancel)
+        alert.addAction(done)
+        self.present(alert, animated: true)
+        
      }
     
     // MARK: - Helpers

--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -11,8 +11,27 @@ class NewMeetUpViewController: UIViewController {
 
     // MARK: - Properties
     
+    let viewModel = CombineViewModel.shared
+    
+    var meetUpViewModel: MeetUpViewModel? {
+        didSet {
+            if isNewMeetUp == false {
+                guard let meetUp = meetUpViewModel?.meetUp else { return }
+                subjectField.text = meetUp.title
+                timeField.text = meetUp.time.toTimeString()
+                timePicker.date = meetUp.time
+                locationField.text = meetUp.meetUpPlaceName
+                counter = meetUp.maxPeopleNum
+                contentField.text = meetUp.description
+                contentField.textColor = CustomColor.nomadBlack
+            }
+        }
+    }
+    
     var placeUid : String?
     var userUid : String?
+    
+    var isNewMeetUp: Bool?
     
     private enum Value {
         static let cornerRadius: CGFloat = 12.0
@@ -263,10 +282,12 @@ class NewMeetUpViewController: UIViewController {
         
         configUI()
         
-        navigationItem.title = "새로운 모임 생성"
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(didTapDoneCreatingMeetUp))
-                 navigationController?.navigationBar.tintColor = CustomColor.nomadBlue
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(didTapCancelCreatingMeetUp))
+        if isNewMeetUp == true {
+            configNewMeetUp()
+        } else {
+            configEditMeetUp()
+        }
+        navigationController?.navigationBar.tintColor = CustomColor.nomadBlue
         
         subjectField.delegate = self
         locationField.delegate = self
@@ -306,8 +327,6 @@ class NewMeetUpViewController: UIViewController {
     }
     
     @objc func didTapDoneCreatingMeetUp() {
-        // TODO: 내용 저장 & self.dismiss 후 어디로 갈것인지? CheckInView? MeetUpView?
-        
         if let placeUid = placeUid, let userUid = userUid, let title = subjectField.text, let meetUpPlaceName = locationField.text, let description = contentField.text {
             let meetUp = MeetUp(meetUpUid: UUID().uuidString, placeUid: placeUid, organizerUid: userUid, title: title, meetUpPlaceName: meetUpPlaceName, time: timePicker.date, maxPeopleNum: counter, description: description)
             FirebaseManager.shared.createMeetUp(meetUp: meetUp) { meetUp in }
@@ -319,7 +338,22 @@ class NewMeetUpViewController: UIViewController {
         self.dismiss(animated: true)
     }
     
+    @objc func didTapDoneEditingMeetUp() {
+         // TODO: 편집 변경사항 저장 & PlaceCheckInView로 가기
+     }
+    
     // MARK: - Helpers
+    
+    func configNewMeetUp() {
+        navigationItem.title = "새로운 모임 생성"
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(didTapCancelCreatingMeetUp))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(didTapDoneCreatingMeetUp))
+    }
+
+    func configEditMeetUp() {
+        navigationItem.title = "밋업 편집"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(didTapDoneEditingMeetUp))
+    }
     
     func configUI() {
         

--- a/BNomad/View/MeetUpView/ParticipantCell.swift
+++ b/BNomad/View/MeetUpView/ParticipantCell.swift
@@ -83,11 +83,5 @@ class ParticipantCell: UICollectionViewCell {
         self.addSubview(nicknameLabel)
         nicknameLabel.anchor(top: profileImageView.bottomAnchor, paddingTop: 14)
         nicknameLabel.centerX(inView: self)
-        
-//        if isOrganizer == true {
-//            crownView.isHidden = false
-//        } else {
-//            crownView.isHidden = true
-//        }
     }
 }

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -180,6 +180,13 @@ extension PlaceCheckInViewController: UICollectionViewDelegateFlowLayout {
             navigationController?.pushViewController(controller, animated: true)
         }
     }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
+        if section == 3 {
+            return CGSize(width: view.frame.size.width, height: 70)
+        }
+        return CGSize()
+    }
 }
 
 // MARK: - pageDismiss

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -219,6 +219,7 @@ extension PlaceCheckInViewController: NewMeetUpViewShowable {
         let newMeetUpView = NewMeetUpViewController()
         newMeetUpView.placeUid = selectedPlace?.placeUid
         newMeetUpView.userUid = viewModel.user?.userUid
+        newMeetUpView.isNewMeetUp = true
         let navBarOnModal: UINavigationController = UINavigationController(rootViewController: newMeetUpView)
         present(navBarOnModal, animated: true, completion: nil)
     }

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -31,6 +31,7 @@ class PlaceInfoViewCell: UICollectionViewCell {
     var meetUpViewModels: [MeetUpViewModel]? {
         didSet {
             guard let meetUpViewModels = meetUpViewModels else { return }
+            numberOfQuestLabel.text = "\(meetUpViewModels.count)"
             self.collectionView.reloadData()
         }
     }


### PR DESCRIPTION
## 관련 이슈들
- #231 

## 작업 내용
- 밋업 작성자에게만 편집 버튼이 보입니다.
- 편집 버튼을 누르면 편집뷰로 넘어가고 제목, 장소, 내용에 빈칸이 있으면 경고문구가 나오도록 했습니다.
- 완료 버튼을 누르면 저장하겠냐는 alert가 뜨고 확인을 누르면 변경 내용이 저장됩니다.

## 리뷰 노트
- ~~스크린샷 찍다보니 오거나이저인데도 불구하고 참여하기 버튼으로 나오네요.. 별도로 수정하겠습니다ㅜㅜ~~ → 다른 브랜치는 제대로 나오네요^^.. dev pull 해서 다시 체크하겠습니다...(그래도 안되면 제대로 나오는 브랜치 머지된 후..)

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012157/202437003-c7c0c562-dea1-440a-8611-5e63e28bb721.gif" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
