### PR TITLE
[Feat] #256 체크인뷰의 노마드들을 클릭하면 각자의 프로필뷰로 이동

### DIFF
--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -313,7 +313,10 @@ class MapViewController: UIViewController {
         /// 케이스 2 기존 유저 : 프로필 버튼 클릭 -> (비로그인 상태) -> 로그인 화면 -> 로그인 완료 -> 프로필 뷰
         /// 케이스 3 기존 유저 : 프로필 버튼 클릭 -> (로그인 상태) -> 프로필 뷰
         if viewModel.isLogIn {
-            navigationController?.pushViewController(ProfileViewController(), animated: true)
+            let controller = ProfileViewController()
+            controller.isMyProfile = true
+            controller.nomad = viewModel.user
+            navigationController?.pushViewController(controller, animated: true)
         } else {
             
             // TODO: - 회원가입 창 띄우기 전에 모달 띄우기

--- a/BNomad/View/MeetUpView/ParticipantCell.swift
+++ b/BNomad/View/MeetUpView/ParticipantCell.swift
@@ -48,6 +48,7 @@ class ParticipantCell: UICollectionViewCell {
         let image = UIImageView()
         image.tintColor = CustomColor.nomadGray1
         image.clipsToBounds = true
+        image.contentMode = .scaleAspectFill
         
         return image
     }()

--- a/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
@@ -89,6 +89,10 @@ class CheckInCardViewCell: UICollectionViewCell {
         view.image = UIImage(systemName: "person.circle.fill")
         view.tintColor = CustomColor.nomadGray2
         view.anchor(width: 80, height: 80)
+        view.layer.cornerRadius = 80/2
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        
         return view
     }()
     

--- a/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
@@ -41,6 +41,8 @@ class CheckedProfileListViewCell: UICollectionViewCell {
         let userProfileImg = UIImageView()
         userProfileImg.tintColor = CustomColor.nomadGray2
         userProfileImg.translatesAutoresizingMaskIntoConstraints = false
+        userProfileImg.clipsToBounds = true
+        userProfileImg.contentMode = .scaleAspectFill
         return userProfileImg
     }()
     
@@ -82,6 +84,7 @@ class CheckedProfileListViewCell: UICollectionViewCell {
         self.addSubview(userProfileImg)
         userProfileImg.anchor(left: self.leftAnchor, paddingLeft: 14, width: 50, height: 50)
         userProfileImg.centerY(inView: self)
+        userProfileImg.layer.cornerRadius = 50/2
         
         let nameJobStack = UIStackView(arrangedSubviews: [usernameLabel, occupationLabel])
         nameJobStack.axis = .horizontal

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -20,6 +20,8 @@ class PlaceCheckInViewController: UIViewController {
     
     lazy var viewModel: CombineViewModel = CombineViewModel.shared
     
+    var selectedUser: User?
+    
     var selectedPlace: Place? {
         didSet {
             guard let place = selectedPlace else { return }
@@ -176,7 +178,11 @@ extension PlaceCheckInViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section == 3 {
             let controller = ProfileViewController()
-            controller.userFromListUid = checkInHistory?[indexPath.row].userUid
+            guard let nomadUid = checkInHistory?[indexPath.row].userUid else { return }
+            FirebaseManager.shared.fetchUser(id: nomadUid) { user in
+                controller.nomad = user
+            }
+            controller.isMyProfile = false
             navigationController?.pushViewController(controller, animated: true)
         }
     }

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -46,12 +46,7 @@ class PlaceCheckInViewController: UIViewController {
     
     var meetUpViewModels: [MeetUpViewModel]?
 
-    var checkInHistory: [CheckIn]? {
-        didSet {
-            guard let checkInHistory = checkInHistory else { return }
-            collectionView.reloadData()
-        }
-    }
+    var checkInHistory: [CheckIn]?
 
     // MARK: - Properties
     private var numberOfUsers: Int {

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -103,6 +103,7 @@ class QuestCollectionViewCell: UICollectionViewCell {
         image.image = UIImage(systemName: "person.crop.circle.fill")
         image.tintColor = CustomColor.nomadGray1
         image.clipsToBounds = true
+        image.contentMode = .scaleAspectFill
         
         return image
     }()

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -69,7 +69,6 @@ class ProfileViewController: UIViewController {
         
         configureUI()
         render()
-//        setProfileImage()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -113,23 +112,7 @@ class ProfileViewController: UIViewController {
         profileCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, right: view.rightAnchor,
                                      paddingTop: 220, paddingLeft: 16, paddingRight: 16,
                                      height: 600)
-        
     }
-    
-//    func setProfileImage() {
-//        if isMyProfile == true {
-//            guard let user = viewModel.user else { return }
-//            if user.profileImage == nil {
-//                guard let profileImageUrl = user.profileImageUrl else { return }
-//                profileImageView.kf.setImage(with: URL(string: profileImageUrl))
-//            }
-//        } else {
-//            guard let nomad = nomad else { return }
-//            guard let profileImageUrl = nomad.profileImageUrl else { return }
-//            profileImageView.kf.setImage(with: URL(string: profileImageUrl))
-//        }
-//    }
-    
 }
 
 // MARK: - UICollectionViewDataSource

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -16,16 +16,20 @@ class ProfileViewController: UIViewController {
     
     static var weekAddedMemory: Int = 0
     
-    var userFromListUid: String?
+    var isMyProfile: Bool?
+    
+    var nomad: User? {
+        didSet {
+            guard let profileImageUrl = nomad?.profileImageUrl else { return }
+            profileImageView.kf.setImage(with: URL(string: profileImageUrl))
+            self.profileCollectionView.reloadData()
+            
+        }
+    }
     
     private lazy var profileImageView: UIImageView = {
         let iv = UIImageView()
         iv.contentMode = .scaleAspectFill
-        if viewModel.user?.profileImage == nil {
-            if let profileImageUrl = viewModel.user?.profileImageUrl {
-                iv.kf.setImage(with: URL(string: profileImageUrl))
-            }
-        }
         iv.clipsToBounds = true
         iv.isUserInteractionEnabled = true
         iv.layer.masksToBounds = true
@@ -65,6 +69,7 @@ class ProfileViewController: UIViewController {
         
         configureUI()
         render()
+//        setProfileImage()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -73,7 +78,7 @@ class ProfileViewController: UIViewController {
         navigationItem.backButtonTitle = ""
         navigationController?.navigationBar.isHidden = false
 
-        profileImageView.image = viewModel.user?.profileImage ?? UIImage(named: "othersProfile")
+        profileImageView.image = nomad?.profileImage ?? UIImage(named: "othersProfile")
     }
     
     
@@ -81,7 +86,7 @@ class ProfileViewController: UIViewController {
     
     @objc func moveToCalendar() {
         //        if userFromListUid == viewModel.user?.userUid || FirebaseAuth와 지금 viewModel.user가 같은 uid인지 체크 {
-        CalendarViewController.checkInHistory = viewModel.user?.checkInHistory
+        CalendarViewController.checkInHistory = nomad?.checkInHistory
         navigationController?.pushViewController(CalendarViewController(), animated: true)
         //        } else {
         //            print("다른 사람의 캘린더뷰는 보지 못합니다")
@@ -89,7 +94,7 @@ class ProfileViewController: UIViewController {
     }
     
     @objc func moveToVisitCollection() {
-        VisitCardCollectionViewController.checkInHistory = viewModel.user?.checkInHistory
+        VisitCardCollectionViewController.checkInHistory = nomad?.checkInHistory
         navigationController?.pushViewController(VisitCardCollectionViewController(), animated: true)
     }
     
@@ -110,6 +115,20 @@ class ProfileViewController: UIViewController {
                                      height: 600)
         
     }
+    
+//    func setProfileImage() {
+//        if isMyProfile == true {
+//            guard let user = viewModel.user else { return }
+//            if user.profileImage == nil {
+//                guard let profileImageUrl = user.profileImageUrl else { return }
+//                profileImageView.kf.setImage(with: URL(string: profileImageUrl))
+//            }
+//        } else {
+//            guard let nomad = nomad else { return }
+//            guard let profileImageUrl = nomad.profileImageUrl else { return }
+//            profileImageView.kf.setImage(with: URL(string: profileImageUrl))
+//        }
+//    }
     
 }
 
@@ -137,7 +156,7 @@ extension ProfileViewController: UICollectionViewDelegate {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelfUserInfoCell.identifier , for: indexPath) as? SelfUserInfoCell else {
                 return UICollectionViewCell()
             }
-            cell.user = viewModel.user
+            cell.user = nomad
             cell.backgroundColor = .systemBackground
             cell.layer.cornerRadius = 20
             cell.delegate = self
@@ -149,7 +168,7 @@ extension ProfileViewController: UICollectionViewDelegate {
             }
             cell.layer.borderWidth = 2
             cell.layer.borderColor = CustomColor.nomadBlue?.cgColor
-            cell.checkInHistoryForProfile = viewModel.user?.checkInHistory
+            cell.checkInHistoryForProfile = nomad?.checkInHistory
             cell.backgroundColor = .systemBackground
             cell.layer.cornerRadius = 20
             return cell
@@ -158,7 +177,7 @@ extension ProfileViewController: UICollectionViewDelegate {
                 return UICollectionViewCell()
             }
             
-            cell.checkInHistory = viewModel.user?.checkInHistory
+            cell.checkInHistory = nomad?.checkInHistory
             
             cell.backgroundColor = .systemBackground
             cell.layer.cornerRadius = 20


### PR DESCRIPTION
## 관련 이슈들
- #256 

## 작업 내용
- 노마드 목록에서 한 명을 탭하면 그 사람의 프로필뷰로 넘어가도록 바인딩했습니다.
- 체크인뷰에서 보이는 프로필이미지들을 동그랗게 만들었습니다.

## 리뷰 노트
- 프로필뷰가 다시 대대적 수정이 되고있는듯하여 추후 제대로 동작하는지 다시 체크해 보아야 할 듯 합니다.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012157/202439884-6156610e-6746-4cfd-bb83-548bf474f7cd.gif" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
