### PR TITLE
[Enhancement] #257 로그아웃, 회원탈퇴 Firebase 업데이트 구현, SettingView 네비게이션 오류 고침

### DIFF
--- a/BNomad/API/FirebaseManager.swift
+++ b/BNomad/API/FirebaseManager.swift
@@ -342,8 +342,8 @@ class FirebaseManager {
         
         ref.child("meetUpUser/\(userUid)").observeSingleEvent(of: .value, with: { snapshots in
             for child in snapshots.children {
-                guard let snapshot = child as? DataSnapshot else { return }
-                guard let meetUpUid = snapshot.key as? String else { return }
+                guard let snapshot = child as? DataSnapshot else { return completion("noMeetUp") }
+                guard let meetUpUid = snapshot.key as? String else { return completion("noMeetUp") }
                 completion(meetUpUid)
             }
         })
@@ -536,5 +536,13 @@ class FirebaseManager {
                 print("review could not be saved: \(error).")
             }
         }
+    }
+    
+    /// meetUpUid로 placeUid 가져오기
+    func getPlaceUidWithMeetUpId(meetUpUid: String, completion: @escaping(String) -> Void) {
+        ref.child("meetUp/\(meetUpUid)/placeUid").observeSingleEvent(of: .value, with: { snapshot in
+            guard let placeUid = snapshot.value as? String else { return }
+            completion(placeUid)
+        })
     }
 }

--- a/BNomad/API/FirebaseManager.swift
+++ b/BNomad/API/FirebaseManager.swift
@@ -339,13 +339,14 @@ class FirebaseManager {
 
     /// 특정 유저가 참여한 모든 meetUp의 Uid 가져오기
     func fetchMeetUpUidAll(userUid: String, completion: @escaping(String) -> Void) {
-        
         ref.child("meetUpUser/\(userUid)").observeSingleEvent(of: .value, with: { snapshots in
-            for child in snapshots.children {
-                guard let snapshot = child as? DataSnapshot else { return completion("noMeetUp") }
-                guard let meetUpUid = snapshot.key as? String else { return completion("noMeetUp") }
-                completion(meetUpUid)
-            }
+            if snapshots.exists() {
+                for child in snapshots.children {
+                    guard let snapshot = child as? DataSnapshot else { return }
+                    guard let meetUpUid = snapshot.key as? String else { return }
+                    completion(meetUpUid)
+                }
+            } 
         })
     }
 

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -256,7 +256,6 @@ class MapViewController: UIViewController {
     
      override func viewWillAppear(_ animated: Bool) {
          super.viewWillAppear(true)
-         navigationController?.navigationBar.isHidden = true
          navigationItem.backButtonTitle = ""
          checkInFloating()
          map.addOverlay(circleOverlay)
@@ -269,6 +268,11 @@ class MapViewController: UIViewController {
         configueMapUI()
         checkInBinding()
         userCombine()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        navigationController?.navigationBar.isHidden = true
     }
     
     // MARK: - Actions
@@ -312,7 +316,7 @@ class MapViewController: UIViewController {
         /// 케이스 1 신규 유저 : 프로필 버튼 클릭 -> 로그인 화면 -> 가입 화면 -> 가입 후 로그인 -> 로그인 완료 -> 프로필 뷰
         /// 케이스 2 기존 유저 : 프로필 버튼 클릭 -> (비로그인 상태) -> 로그인 화면 -> 로그인 완료 -> 프로필 뷰
         /// 케이스 3 기존 유저 : 프로필 버튼 클릭 -> (로그인 상태) -> 프로필 뷰
-        if viewModel.isLogIn {
+        if viewModel.user != nil {
             navigationController?.pushViewController(ProfileViewController(), animated: true)
         } else {
             
@@ -441,7 +445,7 @@ class MapViewController: UIViewController {
     func userCombine() {
         viewModel.$user
             .sink { user in
-                guard let user = user else { return }
+                guard let user = user else { return self.checkInNow.isHidden = true }
                 self.checkInNow.isHidden = user.isChecked ? false : true
             }
             .store(in: &store)

--- a/BNomad/View/SettingView/SettingViewController.swift
+++ b/BNomad/View/SettingView/SettingViewController.swift
@@ -77,20 +77,43 @@ extension SettingViewController: UITableViewDelegate {
             let controller = WithdrawViewController()
             navigationController?.pushViewController(controller, animated: true)
         } else if selectedTitle == listTitle.logout {
-            let alert = UIAlertController(title: listTitle.logout, message: "로그아웃 하시겠습니까?", preferredStyle: .alert)
+            let alert = UIAlertController(title: listTitle.logout, message: "로그아웃하면 체크인 상태가 없어지고, 참여한 밋업도 자동으로 참여 취소됩니다.", preferredStyle: .alert)
             let cancel = UIAlertAction(title: "취소", style: .cancel)
             let logout = UIAlertAction(title: "확인", style: .destructive) { action in
                 if Auth.auth().currentUser != nil {
                     do {
-                        // 체크인 되어 있는 사람이 탈퇴하려할때, 어떻게 해주고 탈퇴시켜야 하나..?!
                         try Auth.auth().signOut()
-                        self.viewModel.user = nil
+                        if self.viewModel.user?.currentCheckIn == nil {
+                            self.viewModel.user = nil
+                        } else {
+                            guard let current = self.viewModel.user?.currentCheckIn else { return }
+                            let userUid = self.viewModel.user?.userUid
+                            FirebaseManager.shared.setCheckOut(checkIn: current) { checkIn in
+                                let index = self.viewModel.user?.checkInHistory?.firstIndex { $0.checkInUid == checkIn.checkInUid }
+                                guard let index = index else {
+                                    print("fail index")
+                                    return
+                                }
+                                self.viewModel.user?.checkInHistory?[index] = checkIn
+                                self.viewModel.user = nil
+                                FirebaseManager.shared.fetchMeetUpUidAll(userUid: userUid ?? "") { uid in
+                                    if uid == "noMeetUp" {
+                                        
+                                    } else {
+                                        FirebaseManager.shared.getPlaceUidWithMeetUpId(meetUpUid: uid) { placeUid in
+                                            FirebaseManager.shared.cancelMeetUp(userUid: userUid ?? "", meetUpUid: uid, placeUid: placeUid) {
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         self.navigationController?.popToRootViewController(animated: true)
                     } catch {
                         print("No current User now")
                     }
                 } else {
-                    print("로그아웃할 유저가 없습니다.")
+                    self.noUserAlert()
                     self.navigationController?.popToRootViewController(animated: true)
                 }
             }
@@ -100,6 +123,12 @@ extension SettingViewController: UITableViewDelegate {
         }
     }
     
+    func noUserAlert() {
+        let alert = UIAlertController(title: "로그아웃 오류", message: "로그인 되어 있지 않습니다.", preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "확인", style: .default)
+        alert.addAction(cancel)
+        self.present(alert, animated: true)
+    }
 }
 
 // MARK: - UITableViewDataSource

--- a/BNomad/View/SettingView/SettingViewController.swift
+++ b/BNomad/View/SettingView/SettingViewController.swift
@@ -97,12 +97,8 @@ extension SettingViewController: UITableViewDelegate {
                                 self.viewModel.user?.checkInHistory?[index] = checkIn
                                 self.viewModel.user = nil
                                 FirebaseManager.shared.fetchMeetUpUidAll(userUid: userUid ?? "") { uid in
-                                    if uid == "noMeetUp" {
-                                        
-                                    } else {
-                                        FirebaseManager.shared.getPlaceUidWithMeetUpId(meetUpUid: uid) { placeUid in
-                                            FirebaseManager.shared.cancelMeetUp(userUid: userUid ?? "", meetUpUid: uid, placeUid: placeUid) {
-                                            }
+                                    FirebaseManager.shared.getPlaceUidWithMeetUpId(meetUpUid: uid) { placeUid in
+                                        FirebaseManager.shared.cancelMeetUp(userUid: userUid ?? "", meetUpUid: uid, placeUid: placeUid) {
                                         }
                                     }
                                 }

--- a/BNomad/View/SettingView/WithdrawViewController.swift
+++ b/BNomad/View/SettingView/WithdrawViewController.swift
@@ -79,14 +79,10 @@ class WithdrawViewController: UIViewController {
                             }
                             self.viewModel.user?.checkInHistory?[index] = checkIn
                             self.viewModel.user = nil
-                            FirebaseManager.shared.fetchMeetUpUidAll(userUid: userUid ?? "") { uid in
-                                if uid == "noMeetUp" {
-                                    
-                                } else {
+                            FirebaseManager.shared.uploadUserWithdrawalReason(userUid: userUid ?? "", reason: self.reasonTextView.text) {
+                                FirebaseManager.shared.fetchMeetUpUidAll(userUid: userUid ?? "") { uid in
                                     FirebaseManager.shared.getPlaceUidWithMeetUpId(meetUpUid: uid) { placeUid in
                                         FirebaseManager.shared.cancelMeetUp(userUid: userUid ?? "", meetUpUid: uid, placeUid: placeUid) {
-                                            FirebaseManager.shared.uploadUserWithdrawalReason(userUid: userUid ?? "", reason: self.reasonTextView.text) {
-                                            }
                                         }
                                     }
                                 }

--- a/BNomad/View/SettingView/WithdrawViewController.swift
+++ b/BNomad/View/SettingView/WithdrawViewController.swift
@@ -53,30 +53,63 @@ class WithdrawViewController: UIViewController {
         title = "회원 탈퇴"
         navigationController?.navigationBar.prefersLargeTitles = false
         configUI()
+        hideKeyboardWhenTappedAround()
     }
     
     // MARK: - Actions
     
     @objc func withdraw() {
-        let alert = UIAlertController(title: "탈퇴하기", message: "탈퇴하시겠습니까?", preferredStyle: .alert)
+        let alert = UIAlertController(title: "탈퇴하기", message: "지금까지의 체크인, 밋업 기록이 삭제됩니다.", preferredStyle: .alert)
         let cancel = UIAlertAction(title: "취소", style: .cancel)
         let withdrawConfirm = UIAlertAction(title: "탈퇴", style: .destructive) { action in
             if Auth.auth().currentUser != nil {
                 Auth.auth().currentUser?.delete()
                 do {
                     try Auth.auth().signOut()
+                    if self.viewModel.user?.currentCheckIn == nil {
+                        self.viewModel.user = nil
+                    } else {
+                        guard let current = self.viewModel.user?.currentCheckIn else { return }
+                        let userUid = self.viewModel.user?.userUid
+                        FirebaseManager.shared.setCheckOut(checkIn: current) { checkIn in
+                            let index = self.viewModel.user?.checkInHistory?.firstIndex { $0.checkInUid == checkIn.checkInUid }
+                            guard let index = index else {
+                                print("fail index")
+                                return
+                            }
+                            self.viewModel.user?.checkInHistory?[index] = checkIn
+                            self.viewModel.user = nil
+                            FirebaseManager.shared.fetchMeetUpUidAll(userUid: userUid ?? "") { uid in
+                                if uid == "noMeetUp" {
+                                    
+                                } else {
+                                    FirebaseManager.shared.getPlaceUidWithMeetUpId(meetUpUid: uid) { placeUid in
+                                        FirebaseManager.shared.cancelMeetUp(userUid: userUid ?? "", meetUpUid: uid, placeUid: placeUid) {
+                                            FirebaseManager.shared.uploadUserWithdrawalReason(userUid: userUid ?? "", reason: self.reasonTextView.text) {
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    self.navigationController?.popToRootViewController(animated: true)
                 } catch {
-                    print("signOut 에러")
+                    print("SignOut ERROR")
                 }
-                self.viewModel.user = nil
             } else {
-                // 로그인되지 않았는데 탈퇴 버튼을 누를경우의 액션
+                self.noUserAlert()
             }
-            print("탈퇴합니다")
-            self.navigationController?.popToRootViewController(animated: true)
         }
         alert.addAction(cancel)
         alert.addAction(withdrawConfirm)
+        self.present(alert, animated: true)
+    }
+    
+    func noUserAlert() {
+        let alert = UIAlertController(title: "탈퇴 오류", message: "로그인 되어 있지 않습니다.", preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "확인", style: .default)
+        alert.addAction(cancel)
         self.present(alert, animated: true)
     }
     
@@ -95,7 +128,6 @@ class WithdrawViewController: UIViewController {
         withdrawButton.anchor(left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingLeft: Size.paddingNormal, paddingBottom: 50, paddingRight: Size.paddingNormal, height: 50)
         
     }
-
 }
 
 // MARK: - UITextViewDelegate


### PR DESCRIPTION
## 관련 이슈들
- #257

## 작업 내용
- `로그아웃`, `회원탈퇴`시, 현재 체크인 상태라면, 체크아웃으로 바꾸고, 밋업에 참가중이라면 밋업에서 나오게 만든 후, `로그아웃`, `회원탈퇴` 로직이 실행되도록 만들었습니다.
- 기존 `profileView`로 넘어가는 로직이 `viewModel.isLogIn`으로 검사를 했는데, 이를 `유저의 유무`로 바꾸었습니다.
    - 유저의 상태가 다양해져서, isLogin으로 커버가 안되었음 (예시: 애플로그인은 되었는데, 회원가입은 안된 상태)
- MapViewController의 viewWillAppear에서 네비게이션 바를 hidden 해서 SettingView를 닫으려다 다시 열면 네비게이션 타이틀이 없어지는 오류가 있었는데, 이를 고쳤습니다.


## 리뷰 노트
- FirebaseManager에서 `MeetUp`데이터가 없을때, String값을 던져서 없다는 것을 판단해도 될지요?!
- 현재 코드에 `업무중`인 상태에서 로그아웃을 해버리면, checkInHistory의 모든 데이터를 지워버리는데, 이유가 뭘까요..?
    - `업무중`이라면 체크아웃 -> 참여중인 밋업 삭제인 순서로 로직이 진행되는데, 유저의 checkInHistory가 왜 지워질까요..?
- 로그아웃, 회원탈퇴에서 불가피하게 많은 Firebase관련 함수들이 줄지어 있는데, 더 좋은 로직 있으면 알려주세요..
    - 지금 줄지어 코드가 확인하는 것은 `1.유저 유무`,` 2. 유저 현재 체크인 유무,` `3. 체크아웃`, `4. 밋업 유무` `5. 밋업 나오기` 순으로 짜여있어서 너무 보기 좀 그런 코드입니다..

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
