### PR TITLE
[FIX] 프로필뷰 스크롤 버그 픽스

### DIFF
--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -21,8 +21,19 @@ class ProfileViewController: UIViewController {
     let scrollView: UIScrollView = {
         let scroll = UIScrollView()
         scroll.backgroundColor = CustomColor.nomad2White
+        scroll.canCancelContentTouches = true
+        
         return scroll
     }()
+    
+    class myCollectionView: UIScrollView {
+        override func touchesShouldCancel(in view: UIView) -> Bool {
+            if view is UICollectionView {
+                return false
+            }
+            return super.touchesShouldCancel(in: view)
+        }
+    }
     
     let contentView: UIView = {
         let ui = UIView()
@@ -123,13 +134,13 @@ class ProfileViewController: UIViewController {
         contentViewHeight.priority = .defaultLow
         contentViewHeight.isActive = true
         
-        contentView.addSubview(profileCollectionView)
-        contentView.addSubview(profileImageView)
+        scrollView.addSubview(profileCollectionView)
+        scrollView.addSubview(profileImageView)
         
-        profileImageView.anchor(top: contentView.topAnchor, paddingTop: 25, width: 120, height: 120)
+        profileImageView.anchor(top: scrollView.topAnchor, paddingTop: 25, width: 120, height: 120)
         profileImageView.centerX(inView: view)
         
-        profileCollectionView.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: view.rightAnchor,
+        profileCollectionView.anchor(top: scrollView.topAnchor, left: scrollView.leftAnchor, right: view.rightAnchor,
                                              paddingTop: 100, paddingLeft: 16, paddingRight: 16,
                                              height: 600)
         

--- a/BNomad/View/ProfileView/VisitingInfoCell.swift
+++ b/BNomad/View/ProfileView/VisitingInfoCell.swift
@@ -125,6 +125,14 @@ class VisitingInfoCell: UICollectionViewCell {
         return label
     }()
     
+    private let dividerLine: UIView = {
+        let view = UIView()
+        view.backgroundColor = CustomColor.nomadGray1
+        view.layer.masksToBounds = false
+
+        return view
+    }()
+    
     // MARK: - LifeCycle
     
     override init(frame: CGRect) {
@@ -141,21 +149,26 @@ class VisitingInfoCell: UICollectionViewCell {
     func render() {
         
         contentView.addSubview(nameLabel)
-        nameLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 25, paddingLeft: 20, paddingRight: 20)
+        nameLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 16, paddingLeft: 20, paddingRight: 20)
         
         let stack = [UIStackView(arrangedSubviews: [checkinLabel, checkinTimeLabel]), UIStackView(arrangedSubviews: [stayedLabel, stayedTimeLabel])]
         stack.forEach {
             $0.axis = .vertical
             $0.spacing = 1
             $0.distribution = .fillEqually
+            $0.alignment = .center
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
         contentView.addSubview(stack[0])
-        stack[0].anchor(top: contentView.topAnchor, left: contentView.leftAnchor, paddingTop: 60, paddingLeft: 20)
+        stack[0].anchor(top: contentView.topAnchor, left: contentView.leftAnchor, paddingTop: 68, paddingLeft: 50)
         
         contentView.addSubview(stack[1])
-        stack[1].anchor(top: contentView.topAnchor, left: contentView.leftAnchor, paddingTop: 60, paddingLeft: 200)
+        stack[1].anchor(top: contentView.topAnchor, right: contentView.rightAnchor, paddingTop: 68, paddingRight: 50)
+        
+        contentView.addSubview(dividerLine)
+        dividerLine.anchor(top: contentView.topAnchor, paddingTop: 72, width: 1, height: 31)
+        dividerLine.centerX(inView: contentView)
         
     }
     


### PR DESCRIPTION
## 관련 이슈들
- (ex. #2, #3 ...)

## 작업 내용
- 기적적인 스크롤뷰 버그 픽스
- 카드 UI 약간 수정

## 리뷰 노트
- 이게 왜 되지? 의 대표격 픽스입니다
- contentView에 아무런 뷰도 add한 적이 없는데, contentView의 오토레이아웃을 지우면 스크롤이 불가합니다. 이유가 무언지 찾지 못했습니다

## 스크린샷(UX의 경우 gif)
<img width="300" alt="스크린샷 2022-11-18 13 29 22" src="https://user-images.githubusercontent.com/70618615/202617020-6063f52e-5ba2-4f33-afdc-424a299ebb10.png">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
