### PR TITLE
[Feat]프로필뷰 UI 수정 및 버그픽스

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		04054C9B2923B3D20030C80F /* ProfileHeaderCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04054C9A2923B3D20030C80F /* ProfileHeaderCollectionView.swift */; };
 		0413519F28FE534D005D19CC /* SelfUserInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0413519E28FE534D005D19CC /* SelfUserInfoCell.swift */; };
-		041351A128FF7E72005D19CC /* VisitingInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041351A028FF7E72005D19CC /* VisitingInfoCell.swift */; };
+		041351A128FF7E72005D19CC /* VisitCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041351A028FF7E72005D19CC /* VisitCardCell.swift */; };
 		041351A328FF7E98005D19CC /* ProfileGraphCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041351A228FF7E98005D19CC /* ProfileGraphCell.swift */; };
 		041351A528FF8EBE005D19CC /* LiteralContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041351A428FF8EBE005D19CC /* LiteralContents.swift */; };
 		041351A728FFF459005D19CC /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041351A628FFF459005D19CC /* CalendarViewController.swift */; };
@@ -86,7 +86,7 @@
 /* Begin PBXFileReference section */
 		04054C9A2923B3D20030C80F /* ProfileHeaderCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderCollectionView.swift; sourceTree = "<group>"; };
 		0413519E28FE534D005D19CC /* SelfUserInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfUserInfoCell.swift; sourceTree = "<group>"; };
-		041351A028FF7E72005D19CC /* VisitingInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitingInfoCell.swift; sourceTree = "<group>"; };
+		041351A028FF7E72005D19CC /* VisitCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitCardCell.swift; sourceTree = "<group>"; };
 		041351A228FF7E98005D19CC /* ProfileGraphCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileGraphCell.swift; sourceTree = "<group>"; };
 		041351A428FF8EBE005D19CC /* LiteralContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiteralContents.swift; sourceTree = "<group>"; };
 		041351A628FFF459005D19CC /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
@@ -291,7 +291,7 @@
 			children = (
 				DFE747C829000FAF0048E70A /* ProfileEditView */,
 				0413519E28FE534D005D19CC /* SelfUserInfoCell.swift */,
-				041351A028FF7E72005D19CC /* VisitingInfoCell.swift */,
+				041351A028FF7E72005D19CC /* VisitCardCell.swift */,
 				041351A228FF7E98005D19CC /* ProfileGraphCell.swift */,
 				041351AC29081D16005D19CC /* ProfileGraphCollectionCell.swift */,
 				04054C9A2923B3D20030C80F /* ProfileHeaderCollectionView.swift */,
@@ -526,7 +526,7 @@
 				7EC6F9F228FE3A19003D8A95 /* UILabel+Extension.swift in Sources */,
 				F6183CCA28FFC48F00185A1F /* CustomModalViewController.swift in Sources */,
 				7EC6F9F228FE3A19003D8A95 /* UILabel+Extension.swift in Sources */,
-				041351A128FF7E72005D19CC /* VisitingInfoCell.swift in Sources */,
+				041351A128FF7E72005D19CC /* VisitCardCell.swift in Sources */,
 				E25A675828F7E515004614B0 /* DummyData.swift in Sources */,
 				04054C9B2923B3D20030C80F /* ProfileHeaderCollectionView.swift in Sources */,
 				63159D1F291BD4A3000F41F5 /* ReviewSubCell.swift in Sources */,

--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -26,7 +26,7 @@ class CalendarViewController: UIViewController {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = CustomColor.nomad2White
         collectionView.isScrollEnabled = true
-        collectionView.register(VisitingInfoCell.self, forCellWithReuseIdentifier: VisitingInfoCell.identifier)
+        collectionView.register(VisitCardCell.self, forCellWithReuseIdentifier: VisitCardCell.identifier)
         
         return collectionView
     }()
@@ -49,7 +49,7 @@ class CalendarViewController: UIViewController {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.isScrollEnabled = false
         collectionView.backgroundColor = CustomColor.nomad2White
-        collectionView.register(VisitingInfoCell.self, forCellWithReuseIdentifier: VisitingInfoCell.identifier)
+        collectionView.register(VisitCardCell.self, forCellWithReuseIdentifier: VisitCardCell.identifier)
         
         return collectionView
     }()
@@ -323,7 +323,7 @@ extension CalendarViewController: UICollectionViewDelegate {
             return cell
             
         } else if collectionView == visitInfoView {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitingInfoCell.identifier , for: indexPath) as? VisitingInfoCell else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitCardCell.identifier , for: indexPath) as? VisitCardCell else {
                 return UICollectionViewCell()
             }
             
@@ -334,7 +334,7 @@ extension CalendarViewController: UICollectionViewDelegate {
             return cell
             
         } else {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitingInfoCell.identifier , for: indexPath) as? VisitingInfoCell else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitCardCell.identifier , for: indexPath) as? VisitCardCell else {
                 return UICollectionViewCell()
             }
             

--- a/BNomad/View/ProfileView/ProfileHeaderCollectionView.swift
+++ b/BNomad/View/ProfileView/ProfileHeaderCollectionView.swift
@@ -23,9 +23,18 @@ class ProfileHeaderCollectionView: UICollectionReusableView {
         return label
     }()
     
+    private let viewAllButton: UIButton = {
+       let button = UIButton()
+        button.setTitle("전체보기", for: .normal)
+        button.titleLabel?.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
+        button.setTitleColor(.gray, for: .normal)
+        return button
+    }()
+    
     private let plusWeek: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+        button.tintColor = CustomColor.nomadBlue
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
         return button
@@ -34,12 +43,20 @@ class ProfileHeaderCollectionView: UICollectionReusableView {
     private let minusWeek: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        button.tintColor = CustomColor.nomadBlue
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         button.setTitleColor(CustomColor.nomadSkyblue, for: .normal)
         return button
     }()
     
-    var profileGraphCellHeaderLabel: UILabel = {
+    private let profileGraphCellHeaderLabel: UILabel = {
+        let label = UILabel()
+        label.text = "주간 통계"
+        label.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
+        return label
+    }()
+    
+    var profileGraphCellWeekLabel: UILabel = {
         let label = UILabel()
         
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
@@ -51,10 +68,11 @@ class ProfileHeaderCollectionView: UICollectionReusableView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        ProfileHeaderCollectionView.profileGraphCellHeaderMaker(label: profileGraphCellHeaderLabel, weekAdded: -ProfileHeaderCollectionView.weekAddedMemory)
+        ProfileHeaderCollectionView.profileGraphCellHeaderMaker(label: profileGraphCellWeekLabel, weekAdded: -ProfileHeaderCollectionView.weekAddedMemory)
         
         plusWeek.addTarget(self, action: #selector(plusTapButton), for: .touchUpInside)
         minusWeek.addTarget(self, action: #selector(minusTapButton), for: .touchUpInside)
+        viewAllButton.addTarget(self, action: #selector(viewAllTap), for: .touchUpInside)
         
     }
     
@@ -85,38 +103,48 @@ class ProfileHeaderCollectionView: UICollectionReusableView {
     func setVisitCardHeader() {
         minusWeek.removeFromSuperview()
         plusWeek.removeFromSuperview()
+        profileGraphCellWeekLabel.removeFromSuperview()
         profileGraphCellHeaderLabel.removeFromSuperview()
         
         addSubview(visitCardCellHeaderLabel)
-        visitCardCellHeaderLabel.anchor(left: self.leftAnchor, paddingLeft: 20)
-        visitCardCellHeaderLabel.centerY(inView: self)
+        visitCardCellHeaderLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 28, paddingLeft: 20)
+        
+        addSubview(viewAllButton)
+        viewAllButton.anchor(top:self.topAnchor, right: self.rightAnchor, paddingTop: 28, paddingRight: 20)
     }
     
     func setGraphHeader() {
         visitCardCellHeaderLabel.removeFromSuperview()
+        viewAllButton.removeFromSuperview()
         
         addSubview(profileGraphCellHeaderLabel)
-        profileGraphCellHeaderLabel.centerX(inView: self)
-        profileGraphCellHeaderLabel.centerY(inView: self)
+        profileGraphCellHeaderLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 28, paddingLeft: 20)
+        
+        
+        addSubview(profileGraphCellWeekLabel)
+        profileGraphCellWeekLabel.centerX(inView: self)
+        profileGraphCellWeekLabel.anchor(top: self.topAnchor, paddingTop: 64)
         
         addSubview(minusWeek)
-        minusWeek.anchor(left: self.leftAnchor, paddingLeft: 20)
-        minusWeek.centerY(inView: self)
+        minusWeek.anchor(top: self.topAnchor, right: profileGraphCellWeekLabel.leftAnchor, paddingTop: 64, paddingRight: 20)
         
         addSubview(plusWeek)
-        plusWeek.anchor(right: self.rightAnchor, paddingRight: 20)
-        plusWeek.centerY(inView: self)
+        plusWeek.anchor(top: self.topAnchor, left: profileGraphCellWeekLabel.rightAnchor, paddingTop: 64, paddingLeft: 20)
     }
     
     @objc func plusTapButton() {
-        ProfileHeaderCollectionView.profileGraphCellHeaderMaker(label: profileGraphCellHeaderLabel, weekAdded: 1)
+        ProfileHeaderCollectionView.profileGraphCellHeaderMaker(label: profileGraphCellWeekLabel, weekAdded: 1)
         delegate?.plusTap()
     }
     
     @objc func minusTapButton() {
-        ProfileHeaderCollectionView.profileGraphCellHeaderMaker(label: profileGraphCellHeaderLabel, weekAdded: -1)
+        ProfileHeaderCollectionView.profileGraphCellHeaderMaker(label: profileGraphCellWeekLabel, weekAdded: -1)
 
         delegate?.minusTap()
+    }
+    
+    @objc func viewAllTap() {
+        delegate?.viewAllTap()
     }
 }
 
@@ -125,4 +153,5 @@ class ProfileHeaderCollectionView: UICollectionReusableView {
 protocol PlusMinusProtocol {
     func plusTap()
     func minusTap()
+    func viewAllTap()
 }

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -63,7 +63,7 @@ class ProfileViewController: UIViewController {
         collectionView.isScrollEnabled = false
         collectionView.backgroundColor = CustomColor.nomad2White
         collectionView.register(SelfUserInfoCell.self, forCellWithReuseIdentifier: SelfUserInfoCell.identifier)
-        collectionView.register(VisitingInfoCell.self, forCellWithReuseIdentifier: VisitingInfoCell.identifier)
+        collectionView.register(VisitCardCell.self, forCellWithReuseIdentifier: VisitCardCell.identifier)
         collectionView.register(ProfileGraphCell.self, forCellWithReuseIdentifier: ProfileGraphCell.identifier)
         
         collectionView.register(ProfileHeaderCollectionView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ProfileHeaderCollectionView.identifier)
@@ -179,7 +179,7 @@ extension ProfileViewController: UICollectionViewDelegate {
             return cell
             
         case 1:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitingInfoCell.identifier , for: indexPath) as? VisitingInfoCell else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitCardCell.identifier , for: indexPath) as? VisitCardCell else {
                 return UICollectionViewCell()
             }
             cell.layer.borderWidth = 2
@@ -249,12 +249,16 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        if section == 0 {
+        switch section {
+        case 0:
             return .zero
-        } else {
-            return CGSize(width: view.frame.size.width, height: 50)
+        case 1:
+            return CGSize(width: view.frame.size.width, height: 62)
+        case 2:
+            return CGSize(width: view.frame.size.width, height: 96)
+        default:
+            return .zero
         }
-        
     }
     
 }
@@ -264,16 +268,16 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
 extension ProfileViewController: PlusMinusProtocol {
     func plusTap() {
         ProfileGraphCell.editWeek(edit: 1)
-//        profileCollectionView.reloadData()
-        //TODO: reloadData 삭제하니까 정장작동되는데 이유가 대체 ??
         
     }
     
     func minusTap() {
         ProfileGraphCell.editWeek(edit: -1)
 
-//        profileCollectionView.reloadData()
-
+    }
+    
+    func viewAllTap() {
+        self.moveToCalendar()
     }
 }
 

--- a/BNomad/View/ProfileView/VisitCardCell.swift
+++ b/BNomad/View/ProfileView/VisitCardCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class VisitingInfoCell: UICollectionViewCell {
+class VisitCardCell: UICollectionViewCell {
     
     // MARK: - Properties
     
@@ -23,10 +23,15 @@ class VisitingInfoCell: UICollectionViewCell {
             nameLabel.text = place?.name
             
             let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "M월 d일"
+            
             dateFormatter.dateFormat = "HH:mm"
+            let checkInTime = dateFormatter.string(from: checkInHistory.checkInTime)
+            let checkOutTime = dateFormatter.string(from: checkInHistory.checkOutTime ?? Date())
+            self.checkInAndOutLabel.text = checkInTime + " - " + checkOutTime
 
             let checkinTime = dateFormatter.string(from: checkInHistory.checkInTime)
-            self.checkinTimeLabel.text = checkinTime
+            self.checkinDateLabel.text = checkinTime
             
             let stayedTime = Int((checkInHistory.checkOutTime?.timeIntervalSince(checkInHistory.checkInTime) ?? 0) / 60)
             self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
@@ -38,13 +43,18 @@ class VisitingInfoCell: UICollectionViewCell {
         didSet {
             guard let checkInHistory = checkInHistoryForCalendar else { return }
             let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "HH:mm"
+            dateFormatter.dateFormat = "M월 d일"
             
-                    let checkinTime = dateFormatter.string(from: checkInHistory.checkInTime)
-                    self.checkinTimeLabel.text = checkinTime
+            let checkinTime = dateFormatter.string(from: checkInHistory.checkInTime)
+            self.checkinDateLabel.text = checkinTime
+            
+            dateFormatter.dateFormat = "HH:mm"
+            let checkInTime = dateFormatter.string(from: checkInHistory.checkInTime)
+            let checkOutTime = dateFormatter.string(from: checkInHistory.checkOutTime ?? Date())
+            self.checkInAndOutLabel.text = checkInTime + " - " + checkOutTime
                     
-                    let stayedTime = Int((checkInHistory.checkOutTime?.timeIntervalSince(checkInHistory.checkInTime) ?? 0) / 60)
-                    self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
+            let stayedTime = Int((checkInHistory.checkOutTime?.timeIntervalSince(checkInHistory.checkInTime) ?? 0) / 60)
+            self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
                 
 
             let place = self.viewModel.places.first {$0.placeUid == checkInHistory.placeUid}
@@ -62,10 +72,15 @@ class VisitingInfoCell: UICollectionViewCell {
             }
             
             let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "HH:mm"
+            dateFormatter.dateFormat = "M월 d일"
             
             let checkinTime = dateFormatter.string(from: lastCheckIn.checkInTime)
-            self.checkinTimeLabel.text = checkinTime
+            self.checkinDateLabel.text = checkinTime
+            
+            dateFormatter.dateFormat = "HH:mm"
+            let checkInTime = dateFormatter.string(from: lastCheckIn.checkInTime)
+            let checkOutTime = dateFormatter.string(from: lastCheckIn.checkOutTime ?? Date())
+            self.checkInAndOutLabel.text = checkInTime + " - " + checkOutTime
             
             let stayedTime = Int((lastCheckIn.checkOutTime?.timeIntervalSince(lastCheckIn.checkInTime) ?? 0) / 60)
             self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
@@ -85,34 +100,30 @@ class VisitingInfoCell: UICollectionViewCell {
         }
         
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
-    private let checkinLabel: UILabel = {
+    private let checkinDateHeadLabel: UILabel = {
         let label = UILabel()
-        label.text = "체크인"
+        label.text = "날짜"
         label.textColor = .gray
         label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
-    private let stayedLabel: UILabel = {
+    private let stayedTimeHeadLabel: UILabel = {
         let label = UILabel()
         label.text = "이용시간"
         label.textColor = .gray
         label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
-    private let checkinTimeLabel: UILabel = {
+    private let checkinDateLabel: UILabel = {
         let label = UILabel()
         label.text = ""
         label.font = UIFont.systemFont(ofSize: 13)
         label.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -121,7 +132,15 @@ class VisitingInfoCell: UICollectionViewCell {
         label.text = ""
         label.font = UIFont.systemFont(ofSize: 13)
         label.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
-        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let checkInAndOutLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.font = UIFont.systemFont(ofSize: 13)
+        label.textColor = .gray
+        label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
         return label
     }()
     
@@ -151,7 +170,10 @@ class VisitingInfoCell: UICollectionViewCell {
         contentView.addSubview(nameLabel)
         nameLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 16, paddingLeft: 20, paddingRight: 20)
         
-        let stack = [UIStackView(arrangedSubviews: [checkinLabel, checkinTimeLabel]), UIStackView(arrangedSubviews: [stayedLabel, stayedTimeLabel])]
+        contentView.addSubview(checkInAndOutLabel)
+        checkInAndOutLabel.anchor(top: nameLabel.bottomAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 2, paddingLeft: 20, paddingRight: 20)
+        
+        let stack = [UIStackView(arrangedSubviews: [checkinDateHeadLabel, checkinDateLabel]), UIStackView(arrangedSubviews: [stayedTimeHeadLabel, stayedTimeLabel])]
         stack.forEach {
             $0.axis = .vertical
             $0.spacing = 1

--- a/BNomad/View/ProfileView/VisitCardCollectionViewController.swift
+++ b/BNomad/View/ProfileView/VisitCardCollectionViewController.swift
@@ -29,7 +29,7 @@ class VisitCardCollectionViewController: UIViewController {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = CustomColor.nomad2White
         collectionView.isScrollEnabled = true
-        collectionView.register(VisitingInfoCell.self, forCellWithReuseIdentifier: VisitingInfoCell.identifier)
+        collectionView.register(VisitCardCell.self, forCellWithReuseIdentifier: VisitCardCell.identifier)
         collectionView.register(VisitCardHeaderCollectionView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: VisitCardHeaderCollectionView.identifier)
         collectionView.alwaysBounceVertical = true
         
@@ -88,7 +88,7 @@ extension VisitCardCollectionViewController: UICollectionViewDelegate {
     
     //draw cells
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitingInfoCell.identifier , for: indexPath) as? VisitingInfoCell else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitCardCell.identifier , for: indexPath) as? VisitCardCell else {
                 return UICollectionViewCell()
             }
             


### PR DESCRIPTION
## 관련 이슈들
- (ex. #2, #3 ...)

## 작업 내용
- 프로필뷰 UI가 피그마와 같아졌습니다.
- 일부 로직을 수정했습니다.
- 프로필뷰 비짓카드의 체크인&체크아웃 시간의 경우, 아직 체크아웃하지 않았을 때는 현재 시간이 표기되도록 임의로 작성했습니다

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img width="300" alt="스크린샷 2022-11-18 15 36 54" src="https://user-images.githubusercontent.com/70618615/202637241-a2a8e103-6944-42e3-ba76-0924ecf02d01.png">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
