### PR TITLE
[Bug] #275 노마드 프로필 데이터 바인딩 수정

### DIFF
--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -28,18 +28,17 @@ class PlaceCheckInViewController: UIViewController {
             FirebaseManager.shared.fetchCheckInHistory(placeUid: place.placeUid) { checkInHistory in
                 let history = checkInHistory.filter { $0.checkOutTime == nil }
                 self.checkInHistory = history
-            }
-            FirebaseManager.shared.fetchMeetUpHistory(placeUid: place.placeUid) { meetUpHistory in
-                self.meetUpViewModels = []
-                print("meetUpViewModels", self.meetUpViewModels)
-                meetUpHistory.forEach { meetUp in
                     print("meetUpViewModels", meetUp)
-                    let meetUpViewModel = MeetUpViewModel()
-                    meetUpViewModel.meetUp = meetUp
-                    self.meetUpViewModels?.append(meetUpViewModel)
+                FirebaseManager.shared.fetchMeetUpHistory(placeUid: place.placeUid) { meetUpHistory in
+                    self.meetUpViewModels = []
+                    meetUpHistory.forEach { meetUp in
+                        print("meetUpViewModels", meetUp)
+                        let meetUpViewModel = MeetUpViewModel()
+                        meetUpViewModel.meetUp = meetUp
+                        self.meetUpViewModels?.append(meetUpViewModel)
+                    }
+                    self.collectionView.reloadData()
                 }
-                print("meetUpViewModels", self.meetUpViewModels)
-                self.collectionView.reloadData()
             }
         }
     }
@@ -176,7 +175,6 @@ extension PlaceCheckInViewController: UICollectionViewDelegateFlowLayout {
             guard let nomadUid = checkInHistory?[indexPath.row].userUid else { return }
             FirebaseManager.shared.fetchUser(id: nomadUid) { user in
                 controller.nomad = user
-                
                 FirebaseManager.shared.fetchCheckInHistory(userUid: nomadUid) { history in
                     controller.nomad?.checkInHistory = history
                 }

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -176,6 +176,10 @@ extension PlaceCheckInViewController: UICollectionViewDelegateFlowLayout {
             guard let nomadUid = checkInHistory?[indexPath.row].userUid else { return }
             FirebaseManager.shared.fetchUser(id: nomadUid) { user in
                 controller.nomad = user
+                
+                FirebaseManager.shared.fetchCheckInHistory(userUid: nomadUid) { history in
+                    controller.nomad?.checkInHistory = history
+                }
             }
             controller.isMyProfile = false
             navigationController?.pushViewController(controller, animated: true)

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -28,7 +28,6 @@ class PlaceCheckInViewController: UIViewController {
             FirebaseManager.shared.fetchCheckInHistory(placeUid: place.placeUid) { checkInHistory in
                 let history = checkInHistory.filter { $0.checkOutTime == nil }
                 self.checkInHistory = history
-                    print("meetUpViewModels", meetUp)
                 FirebaseManager.shared.fetchMeetUpHistory(placeUid: place.placeUid) { meetUpHistory in
                     self.meetUpViewModels = []
                     meetUpHistory.forEach { meetUp in

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -186,7 +186,6 @@ extension ProfileViewController: UICollectionViewDelegate {
             }
             cell.layer.borderWidth = 2
             cell.layer.borderColor = CustomColor.nomadBlue?.cgColor
-//            cell.nomad = nomad
             cell.checkInHistoryForProfile = nomad?.checkInHistory
             cell.backgroundColor = .systemBackground
             cell.layer.cornerRadius = 20

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -175,6 +175,7 @@ extension ProfileViewController: UICollectionViewDelegate {
             }
             cell.layer.borderWidth = 2
             cell.layer.borderColor = CustomColor.nomadBlue?.cgColor
+//            cell.nomad = nomad
             cell.checkInHistoryForProfile = nomad?.checkInHistory
             cell.backgroundColor = .systemBackground
             cell.layer.cornerRadius = 20

--- a/BNomad/View/ProfileView/VisitingInfoCell.swift
+++ b/BNomad/View/ProfileView/VisitingInfoCell.swift
@@ -27,7 +27,7 @@ class VisitingInfoCell: UICollectionViewCell {
 
             let checkinTime = dateFormatter.string(from: checkInHistory.checkInTime)
             self.checkinTimeLabel.text = checkinTime
-            
+
             let stayedTime = Int((checkInHistory.checkOutTime?.timeIntervalSince(checkInHistory.checkInTime) ?? 0) / 60)
             self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
 
@@ -39,13 +39,13 @@ class VisitingInfoCell: UICollectionViewCell {
             guard let checkInHistory = checkInHistoryForCalendar else { return }
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "HH:mm"
-            
+
                     let checkinTime = dateFormatter.string(from: checkInHistory.checkInTime)
                     self.checkinTimeLabel.text = checkinTime
-                    
+
                     let stayedTime = Int((checkInHistory.checkOutTime?.timeIntervalSince(checkInHistory.checkInTime) ?? 0) / 60)
                     self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
-                
+
 
             let place = self.viewModel.places.first {$0.placeUid == checkInHistory.placeUid}
             nameLabel.text = place?.name
@@ -61,13 +61,24 @@ class VisitingInfoCell: UICollectionViewCell {
                 return
             }
             
+            let place = self.viewModel.places.first {$0.placeUid == lastCheckIn.placeUid}
+            nameLabel.text = place?.name
+            
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "HH:mm"
             
             let checkinTime = dateFormatter.string(from: lastCheckIn.checkInTime)
             self.checkinTimeLabel.text = checkinTime
             
-            let stayedTime = Int((lastCheckIn.checkOutTime?.timeIntervalSince(lastCheckIn.checkInTime) ?? 0) / 60)
+            var lastTime = Date()
+            if let lastCheckedOutTime = lastCheckIn.checkOutTime {
+                lastTime = lastCheckedOutTime
+                print("마지막 체크아웃 시간: \(lastCheckIn.checkOutTime)")
+                print("마지막 체크아웃 시간: \(lastTime)")
+            }
+            
+            let stayedTime = Int((lastTime.timeIntervalSince(lastCheckIn.checkInTime) ?? 0) / 60)
+            print("이용시간: \(stayedTime)")
             self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
             
             nameLabel.reloadInputViews()
@@ -78,11 +89,11 @@ class VisitingInfoCell: UICollectionViewCell {
     private lazy var nameLabel: UILabel = {
         let label = UILabel()
         
-        if viewOption != "calendar" {
-            let lastCheckIn = self.viewModel.user?.checkInHistory?.last
-            let place = self.viewModel.places.first {$0.placeUid == lastCheckIn?.placeUid}
-            label.text = place?.name
-        }
+//        if viewOption != "calendar" {
+//            let lastCheckIn = self.nomad?.checkInHistory?.last
+//            let place = self.viewModel.places.first {$0.placeUid == lastCheckIn?.placeUid}
+//            label.text = place?.name
+//        }
         
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -574,11 +574,10 @@ class SignUpViewController: UIViewController {
         } else if profileImageButton.isHidden == false {
             if let nickname = nicknameField.text, let occupation = occupationField.text, let intro = introductionField.text, let image = profileImageButton.image(for: .normal) {
             
-                let user = setUser(nickname: nickname, occupation: occupation, intro: intro)
-                viewModel.user = user
-                FirebaseManager.shared.uploadUserProfileImage(userUid: userIdentifier, image: image) { url in
-                    self.viewModel.user?.profileImageUrl = url
-                    let user = User(userUid: self.userIdentifier, nickname: nickname, profileImageUrl: self.viewModel.user?.profileImageUrl)
+                FirebaseManager.shared.uploadUserProfileImage(userUid: userIdentifier, image: image) {[self] url in
+                    viewModel.user?.profileImageUrl = url
+                    let user = User(userUid: userIdentifier, nickname: nickname, occupation: occupation, introduction: intro, profileImageUrl: url)
+                    viewModel.user = user
                     FirebaseManager.shared.setUser(user: user)
                 }
                 


### PR DESCRIPTION
## 관련 이슈들
- #275 

## 작업 내용
- 체크인뷰에서 노마드 목록이 제대로 나오지 않던 문제를 수정했습니다.
- 노마드를 탭하면 프로필뷰에 체크인 히스토리가 나오지 않던 문제를 수정했습니다.

## 리뷰 노트
- 다른 노마드 프로필에서 체크인 기록을 보고 나오면 프로필 사진이 뜨지 않습니다.. 그런데 피그마 프로토타입 업데이트에 따라 추후 다른 노마드 프로필 보기는 체크인 기록을 한 depth 더 들어가서 보지 않으므로 일단 여기서 멈추었습니다.
- 버그리포트 중 특정 노마드는 프로필뷰에 데이터가 바인딩되지 않는 문제는 처음 가입하고 한번도 프로필수정 하지 않은 사람에게 발생하는 것 같습니다.. 도움 부탁 드립니다. @limhyoseok @sunshiningsoo 

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012157/202642370-940ae478-52f9-4961-a160-f65f24c5ea87.gif" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
