### PR TITLE
[Fix] 체크인 카드 바인딩 & 체크인 후 장소 모달 내 버튼 변경

### DIFF
--- a/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoCell.swift
@@ -12,6 +12,7 @@ import Combine
 protocol CheckInOut {
     func checkInTapped()
     func checkOutTapped()
+    func afterCheckInTapped()
 }
 
 class PlaceInfoCell: UICollectionViewCell {
@@ -154,29 +155,35 @@ class PlaceInfoCell: UICollectionViewCell {
         button.tintColor = .white
         button.backgroundColor = CustomColor.nomadBlue
         button.layer.cornerRadius = 8
+        button.titleLabel?.font = .preferredFont(forTextStyle: .body, weight: .bold)
         button.addTarget(self, action: #selector(checkInTapped), for: .touchUpInside)
         return button
     }()
     
-    lazy var checkOutButton: UIButton = {
+    lazy var afterCheckInButton: UIButton = {
         var button = UIButton()
-        button.setTitle("체크아웃 하기", for: .normal)
-        button.tintColor = .white
-        button.backgroundColor = CustomColor.nomadBlue
+        button.setTitle("이곳에 체크인 중", for: .normal)
+        button.setTitleColor(CustomColor.nomadBlue, for: .normal)
+        button.tintColor = CustomColor.nomadBlue
+        button.backgroundColor = CustomColor.nomad2White
+        button.layer.borderWidth = 1
+        button.layer.borderColor = CustomColor.nomadBlue?.cgColor
         button.layer.cornerRadius = 8
-        button.addTarget(self, action: #selector(checkOutTapped), for: .touchUpInside)
+        button.titleLabel?.font = .preferredFont(forTextStyle: .body, weight: .bold)
+        button.addTarget(self, action: #selector(afterCheckInTapped), for: .touchUpInside)
         return button
     }()
     
     private let alreadyCheckIn: UIView = {
         let alreadyView = UIView()
         let label = UILabel()
-        label.text = "다른 곳에 체크인 되어 있습니다."
-        label.textColor = .white
+        label.text = "다른 노마드스팟에 체크인 중"
+        label.textColor = CustomColor.nomadGray1
+        label.font = .preferredFont(forTextStyle: .body, weight: .bold)
         alreadyView.addSubview(label)
         label.centerX(inView: alreadyView)
         label.centerY(inView: alreadyView)
-        alreadyView.backgroundColor = CustomColor.nomadGray1
+        alreadyView.backgroundColor = CustomColor.nomadGray2
         alreadyView.layer.cornerRadius = 8
         return alreadyView
     }()
@@ -291,21 +298,21 @@ class PlaceInfoCell: UICollectionViewCell {
             .sink { user in
                 if user == nil {
                     self.checkInButton.isHidden = false
-                    self.checkOutButton.isHidden = true
+                    self.afterCheckInButton.isHidden = true
                     self.alreadyCheckIn.isHidden = true
                 } else {
                     guard let user = user else { return }
                     if user.isChecked && self.place?.placeUid == user.currentCheckIn?.placeUid {
                         self.checkInButton.isHidden = true
-                        self.checkOutButton.isHidden = false
+                        self.afterCheckInButton.isHidden = false
                         self.alreadyCheckIn.isHidden = true
                     } else if user.isChecked && self.place?.placeUid != user.currentCheckIn?.placeUid {
                         self.checkInButton.isHidden = true
-                        self.checkOutButton.isHidden = true
+                        self.afterCheckInButton.isHidden = true
                         self.alreadyCheckIn.isHidden = false
                     } else {
                         self.checkInButton.isHidden = false
-                        self.checkOutButton.isHidden = true
+                        self.afterCheckInButton.isHidden = true
                         self.alreadyCheckIn.isHidden = true
                     }
                 }
@@ -323,13 +330,17 @@ class PlaceInfoCell: UICollectionViewCell {
         delegate?.checkOutTapped()
     }
     
+    @objc func afterCheckInTapped() {
+        delegate?.afterCheckInTapped()
+    }
+    
     // MARK: - Helpers
     
     private func configureUI() {
         self.addSubview(grabber)
         self.addSubview(headerStack)
         self.addSubview(checkInButton)
-        self.addSubview(checkOutButton)
+        self.addSubview(afterCheckInButton)
         self.addSubview(bodyStack)
         self.addSubview(horizontalDivider)
         self.addSubview(horizontalDivider1)
@@ -347,7 +358,7 @@ class PlaceInfoCell: UICollectionViewCell {
         horizontalDivider.anchor(top: checkInButton.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 50, paddingLeft: 20, paddingRight: 20, height: 1)
         horizontalDivider1.anchor(top: horizontalDivider.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 34, paddingLeft: 20, paddingRight: 20, height: 1)
         checkInButton.anchor(top: headerStack.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 10, paddingLeft: 20, paddingRight: 20, height: 48)
-        checkOutButton.anchor(top: headerStack.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 10, paddingLeft: 20, paddingRight: 20, height: 48)
+        afterCheckInButton.anchor(top: headerStack.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 10, paddingLeft: 20, paddingRight: 20, height: 48)
         alreadyCheckIn.anchor(top: headerStack.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 10, paddingLeft: 20, paddingRight: 20, height: 48)
     }
     

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -330,6 +330,18 @@ extension PlaceInfoModalViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - CheckInOut
 
 extension PlaceInfoModalViewController: CheckInOut {
+    func afterCheckInTapped() {
+        let controller = PlaceCheckInViewController()
+        controller.delegate = self
+        controller.selectedPlace = selectedPlace
+        let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.modalPresentationStyle = .fullScreen
+        navigationController.navigationBar.tintColor = CustomColor.nomadBlue
+//        self.dismiss(animated: true) {
+            self.present(navigationController, animated: true, completion: nil)
+//        }
+    }
+    
     func checkInTapped() {
         checkIn()
     }


### PR DESCRIPTION
## 관련 이슈들
- #253 , #270 

## 작업 내용
- 체크인 카드 내 장소, 시간 바인딩 개선 (앱 재시작, 체크인 직후 등 모두 해결)
- 체크인 상태에서 체크인 한 장소 모달을 볼 때 체크아웃 대신 "이 곳에 체크인 중" 버튼 -> 체크인 뷰 모달 진입점
- 버튼 액션 수정

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012800/202644141-c562454c-e010-470d-b71a-ccacfa884974.gif" width="300">
<img src="https://user-images.githubusercontent.com/103012800/202644182-46ab016f-f28e-4e26-ba90-6af34e07b66d.gif" width="300">


## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
