### PR TITLE
[Bug, Enhancement] #289 탈퇴이유 default 업로드 막음, 탈퇴시 Storage이미지 삭제

### DIFF
--- a/BNomad/API/FirebaseManager.swift
+++ b/BNomad/API/FirebaseManager.swift
@@ -575,4 +575,19 @@ class FirebaseManager {
             completion(placeUid)
         })
     }
+    
+    /// 회원탈퇴시, 프로필 사진 Storage에서 삭제하기
+    func deleteUserProfileImage(userUid: String) {
+        let storageRef = Storage.storage().reference()
+        let imageRef = storageRef.child("userProfileImage/\(userUid)")
+        
+        imageRef.delete { error in
+            if let error = error {
+                print(error.localizedDescription)
+            } else {
+                print("user profile Image delete clearly")
+            }
+        }
+    }
+    
 }


### PR DESCRIPTION
## 관련 이슈들
- #289 

## 작업 내용
- 탈퇴이유를 건들이지 않고 `placeholder`인 상태로 탈퇴하기를 눌렀을 때, 서버에 `'탈퇴이유를 적어주세요.'`가 안올라게 막아놨습니다.
- 탈퇴시, `storage`에 저장되어 있는 유저 프로필이미지를 삭제합니다.

## 리뷰 노트
- 프로필이미지 Storage를 건들일 경우가, `1. 프로필 수정` `2. 탈퇴` 두가지 경우가 있는데, `1. 프로필 수정`은 `UserUid`를 활용해, 바뀌는 이미지를 덮어쓰는 형식이어서, `Storage`에서 이미지 삭제할 경우는, `2. 탈퇴`만 생각해서 `completion handler`를 사용하지 않았습니다.
- 지금 프로필 이미지 등록은 안하고 회원가입을 해도, 기본 UIImage가 storage에 업로드가 되네요..?!

## 우려되는 Side Effect
- 탈퇴하는 유저의 프로필 이미지를 삭제했을때, 해당 유저가 리뷰를 남긴 것이 있다면 로드가 안되거나 crash가 날 가능성이 있는 것 같네요..


## Reference
REF: [Firebase Auth delete](https://firebase.google.com/docs/auth/ios/manage-users)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
