### PR TITLE
[Bug] #291 user position 값으로 app crash되는 현상 Fix

### DIFF
--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -490,6 +490,27 @@ class MapViewController: UIViewController {
             }
             .store(in: &store)
     }
+    
+    func locationCheck(){
+        let status = CLLocationManager.authorizationStatus()
+        
+        if status == CLAuthorizationStatus.denied || status == CLAuthorizationStatus.restricted {
+            let alter = UIAlertController(title: "위치 접근 허용 설정이 제한되어 있습니다.", message: "해당 장소의 장소보기 및 체크인 기능을 사용하려면 위치 접근을 허용해주셔야 합니다. 앱 설정 화면으로 가시겠습니까?", preferredStyle: UIAlertController.Style.alert)
+            let logOkAction = UIAlertAction(title: "설정", style: UIAlertAction.Style.default){
+                (action: UIAlertAction) in
+                if #available(iOS 10.0, *) {
+                    UIApplication.shared.open(NSURL(string:UIApplication.openSettingsURLString)! as URL)
+                } else {
+                    UIApplication.shared.openURL(NSURL(string: UIApplication.openSettingsURLString)! as URL)
+                }
+            }
+            let logNoAction = UIAlertAction(title: "아니오", style: UIAlertAction.Style.destructive)
+            alter.addAction(logNoAction)
+            alter.addAction(logOkAction)
+            self.present(alter, animated: true, completion: nil)
+        }
+    }
+    
 }
 
 // MARK: - MKMapViewDelegate

--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -324,27 +324,6 @@ class MapViewController: UIViewController {
         navigationController?.pushViewController(SettingViewController(), animated: true)
     }
     
-    func locationCheck(){
-            let status = CLLocationManager.authorizationStatus()
-            
-            if status == CLAuthorizationStatus.denied || status == CLAuthorizationStatus.restricted {
-                let alter = UIAlertController(title: "위치 접근 허용 설정이 제한되어 있습니다.", message: "해당 장소의 장소보기 및 체크인 기능을 사용하려면 위치 접근을 허용해주셔야 합니다. 앱 설정 화면으로 가시겠습니까?", preferredStyle: UIAlertController.Style.alert)
-                let logOkAction = UIAlertAction(title: "설정", style: UIAlertAction.Style.default){
-                    (action: UIAlertAction) in
-                    if #available(iOS 10.0, *) {
-                        UIApplication.shared.open(NSURL(string:UIApplication.openSettingsURLString)! as URL)
-                    } else {
-                        UIApplication.shared.openURL(NSURL(string: UIApplication.openSettingsURLString)! as URL)
-                    }
-                }
-                let logNoAction = UIAlertAction(title: "아니오", style: UIAlertAction.Style.destructive)
-                alter.addAction(logNoAction)
-                alter.addAction(logOkAction)
-                self.present(alter, animated: true, completion: nil)
-        }
-    }
-    
-    
     // 방문했던/안했던 장소 분리하여 배열에 추가
     func visitedPlacesMapping() {
         self.visitedAnnotation.removeAll()
@@ -563,7 +542,6 @@ extension MapViewController: MKMapViewDelegate {
         if let view = view as? PlaceAnnotationView  {
             guard let annotation = view.annotation else { return }
             map.setRegion(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: annotation.coordinate.latitude - (0.002 / 0.01) * map.region.span.latitudeDelta, longitude: annotation.coordinate.longitude ), span: MKCoordinateSpan(latitudeDelta: map.region.span.latitudeDelta, longitudeDelta: map.region.span.longitudeDelta)), animated: true)
-            locationCheck()
             let controller = PlaceInfoModalViewController()
             let tempAnnotation = annotation as? MKAnnotationFromPlace
             let tempPlace = self.viewModel.places.first { place in

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -83,6 +83,7 @@ class PlaceInfoModalViewController: UIViewController {
     
     func checkIn() {
         print("CHECK IN")
+        locationCheck()
         if !viewModel.isLogIn {
             loginCheck()
         } else {
@@ -218,6 +219,26 @@ class PlaceInfoModalViewController: UIViewController {
             return true
         } else {
             return false
+        }
+    }
+    
+    func locationCheck(){
+        let status = CLLocationManager.authorizationStatus()
+        
+        if status == CLAuthorizationStatus.denied || status == CLAuthorizationStatus.restricted {
+            let alter = UIAlertController(title: "위치 접근 허용 설정이 제한되어 있습니다.", message: "해당 장소의 장소보기 및 체크인 기능을 사용하려면 위치 접근을 허용해주셔야 합니다. 앱 설정 화면으로 가시겠습니까?", preferredStyle: UIAlertController.Style.alert)
+            let logOkAction = UIAlertAction(title: "설정", style: UIAlertAction.Style.default){
+                (action: UIAlertAction) in
+                if #available(iOS 10.0, *) {
+                    UIApplication.shared.open(NSURL(string:UIApplication.openSettingsURLString)! as URL)
+                } else {
+                    UIApplication.shared.openURL(NSURL(string: UIApplication.openSettingsURLString)! as URL)
+                }
+            }
+            let logNoAction = UIAlertAction(title: "아니오", style: UIAlertAction.Style.destructive)
+            alter.addAction(logNoAction)
+            alter.addAction(logOkAction)
+            self.present(alter, animated: true, completion: nil)
         }
     }
     

--- a/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
+++ b/BNomad/View/PlaceViewBeforeCheckIn/CustomModalViewController.swift
@@ -67,10 +67,6 @@ class CustomModalViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let locationmanager = CLLocationManager()
-        locationmanager.delegate = self
-        
-        
         self.view.layer.backgroundColor = CustomColor.nomad2White?.cgColor
         self.view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         self.view.layer.shadowColor = UIColor.black.cgColor
@@ -88,24 +84,6 @@ class CustomModalViewController: UIViewController {
         collectionView.register(CustomCollectionViewCell.self, forCellWithReuseIdentifier: CustomCollectionViewCell.identifier)
     }
     
-    func locationCheck(){
-            let status = CLLocationManager.authorizationStatus()
-            if status == CLAuthorizationStatus.denied || status == CLAuthorizationStatus.restricted {
-                let alter = UIAlertController(title: "위치 접근 허용 설정이 제한되어 있습니다.", message: "해당 장소의 장소보기 및 체크인 기능을 사용하려면, 위치 접근을 허용해주셔야 합니다. 앱 설정으로 이동하시겠습니까?", preferredStyle: UIAlertController.Style.alert)
-                let logOkAction = UIAlertAction(title: "설정", style: UIAlertAction.Style.default){
-                    (action: UIAlertAction) in
-                    if #available(iOS 10.0, *) {
-                        UIApplication.shared.open(NSURL(string:UIApplication.openSettingsURLString)! as URL)
-                    } else {
-                        UIApplication.shared.openURL(NSURL(string: UIApplication.openSettingsURLString)! as URL)
-                    }
-                }
-                let logNoAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.destructive)
-                alter.addAction(logNoAction)
-                alter.addAction(logOkAction)
-                self.present(alter, animated: true, completion: nil)
-            }
-        }
 }
 
 // MARK: - UICollectionViewDataSource
@@ -119,9 +97,8 @@ extension CustomModalViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CustomCollectionViewCell.identifier, for: indexPath) as? CustomCollectionViewCell else  { return UICollectionViewCell() }
         guard var places = places else { return UICollectionViewCell() }
-        guard let position = self.position else { return UICollectionViewCell() }
-        let latitude: Double = position.coordinate.latitude
-        let longitude: Double = position.coordinate.longitude
+        let latitude: Double = position?.coordinate.latitude ?? 0.0
+        let longitude: Double = position?.coordinate.longitude ?? 0.0
         places.sort(by: { CustomCollectionViewCell.calculateDistance(latitude1: latitude, latitude2: $0.latitude, longitude1: longitude, longitude2: $0.longitude) < CustomCollectionViewCell.calculateDistance(latitude1: latitude, latitude2: $1.latitude, longitude1: longitude, longitude2: $1.longitude)})
         cell.place = places[indexPath.item]
         cell.position = position
@@ -140,14 +117,12 @@ extension CustomModalViewController: UICollectionViewDataSource {
 
 // MARK: - UICollectionViewDelegate
 
-extension CustomModalViewController: UICollectionViewDelegate, CLLocationManagerDelegate {
+extension CustomModalViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let controller = PlaceInfoModalViewController()
-        locationCheck()
         guard var places = places else { return }
-        guard let position = self.position else { return }
-        let latitude: Double = position.coordinate.latitude
-        let longitude: Double = position.coordinate.longitude
+        let latitude: Double = position?.coordinate.latitude ?? 0.0
+        let longitude: Double = position?.coordinate.longitude ?? 0.0
         places.sort(by: { CustomCollectionViewCell.calculateDistance(latitude1: latitude, latitude2: $0.latitude, longitude1: longitude, longitude2: $0.longitude) < CustomCollectionViewCell.calculateDistance(latitude1: latitude, latitude2: $1.latitude, longitude1: longitude, longitude2: $1.longitude)})
         controller.selectedPlace = places[indexPath.item]
         controller.delegateForFloating = self


### PR DESCRIPTION
## 관련 이슈들
- #291 

## 작업 내용
- user의 `position`값을 가져오지 못하면, app crash현상이 일어나는 것을 Fix함
    - 기존 position이 안들어오면 return해버리는 코드에서 default값을 주는 것으로 바꿈
- 위치서비스를 활성화하라는 알림을 기존 `1. place annotation 클릭`할때와 `2. custom 모달을 띄울때` 두가지에서, PlaceInfoViewController에서 `체크인 버튼을 누를때`로 변경함
    - 기존 locationCheck 함수가 CustomViewController에서 빠지고 PlaceInfoModalViewController에 추가됨

## 리뷰 노트
- position값이 전달안되면서 다른 변수값, 예를 들면 place data, 전화번호, 주소 등을 가져오지 못하는 **오류가 있습니다.**
    - 위 문제는 뷰 담당하는 분이 추후에 수정 부탁드립니다! @Willowwryu 
- @hardworking-nomad  위치설정이 켜지지 않았을때, 나침반 혹은 자신의 위치로 돌아가는 버튼이 눌렸을때,`locationCheck()` 를 사용해 줘야 할 것 같네요..?! MapViewController에 `locationCheck()` 함수 다시 올려놓겠습니다..!

## 스크린샷(UX의 경우 gif)
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-22 at 16 21 48](https://user-images.githubusercontent.com/72736657/203250403-d7d28dce-deda-4593-9459-4bbd4c8c0b66.gif)


## Reference
REF: [위치 활성화 확인](https://0urtrees.tistory.com/19)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
