### PR TITLE
[Feat] #293 PlaceCheckInView 밋업 없을 때 표시할 셀 추가

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		6383330E2900CDBA005AB0C3 /* PlaceInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383330D2900CDBA005AB0C3 /* PlaceInfoCell.swift */; };
 		7E5CF5D42906886A00641E74 /* CheckInCardViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5CF5D32906886A00641E74 /* CheckInCardViewCell.swift */; };
 		7E5CF5DA2918BE2E00641E74 /* ParticipantCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5CF5D92918BE2E00641E74 /* ParticipantCell.swift */; };
+		7E63E4EB292E7D2A000A931E /* NoMeetUpCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E63E4EA292E7D2A000A931E /* NoMeetUpCell.swift */; };
 		7E97254E2919160800AA9F44 /* NewMeetUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E97254D2919160800AA9F44 /* NewMeetUpViewController.swift */; };
 		7EC6F9EE28FE39CB003D8A95 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6F9ED28FE39CB003D8A95 /* UIFont+Extension.swift */; };
 		7EC6F9F028FE39F4003D8A95 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC6F9EF28FE39F4003D8A95 /* UIColor+Extension.swift */; };
@@ -106,6 +107,7 @@
 		7E5CF5D228FFB73400641E74 /* BNomad.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BNomad.entitlements; sourceTree = "<group>"; };
 		7E5CF5D32906886A00641E74 /* CheckInCardViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInCardViewCell.swift; sourceTree = "<group>"; };
 		7E5CF5D92918BE2E00641E74 /* ParticipantCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantCell.swift; sourceTree = "<group>"; };
+		7E63E4EA292E7D2A000A931E /* NoMeetUpCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoMeetUpCell.swift; sourceTree = "<group>"; };
 		7E97254D2919160800AA9F44 /* NewMeetUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMeetUpViewController.swift; sourceTree = "<group>"; };
 		7EC6F9ED28FE39CB003D8A95 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		7EC6F9EF28FE39F4003D8A95 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 				15B621FC2901469D00E31125 /* PlaceInfoViewCell.swift */,
 				7E5CF5D32906886A00641E74 /* CheckInCardViewCell.swift */,
 				DF561CAC291A02840099D41D /* QuestCollectionViewCell.swift */,
+				7E63E4EA292E7D2A000A931E /* NoMeetUpCell.swift */,
 			);
 			path = PlaceCheckInView;
 			sourceTree = "<group>";
@@ -532,6 +535,7 @@
 				63159D1F291BD4A3000F41F5 /* ReviewSubCell.swift in Sources */,
 				041351A728FFF459005D19CC /* CalendarViewController.swift in Sources */,
 				E2E6B23228FE757D005C0D77 /* Date+Extension.swift in Sources */,
+				7E63E4EB292E7D2A000A931E /* NoMeetUpCell.swift in Sources */,
 				E2E6B23428FE75F7005C0D77 /* String+Extension.swift in Sources */,
 				DF561CAD291A02840099D41D /* QuestCollectionViewCell.swift in Sources */,
 				04D095A82922165900F1AB3A /* VisitCardCollectionViewController.swift in Sources */,

--- a/BNomad/View/PlaceCheckInView/NoMeetUpCell.swift
+++ b/BNomad/View/PlaceCheckInView/NoMeetUpCell.swift
@@ -1,0 +1,64 @@
+//
+//  NoMeetUpCell.swift
+//  BNomad
+//
+//  Created by Eunbee Kang on 2022/11/24.
+//
+
+import UIKit
+
+class NoMeetUpCell: UICollectionViewCell {
+    
+    // MARK: - Properties
+    
+    static let identifier: String = String(describing: NoMeetUpCell.self)
+    
+    private let noMeetUpLabel: UILabel = {
+        let label = UILabel()
+        label.text = "아직 밋업이 없어요."
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = CustomColor.nomadGray1
+        
+        return label
+    }()
+    
+    private let makeNewMeetUpLabel: UILabel = {
+        let label = UILabel()
+        label.text = "새로운 밋업을 만들어보세요."
+        label.font = .preferredFont(forTextStyle: .footnote, weight: .semibold)
+        label.textColor = CustomColor.nomadGray1
+        
+        return label
+    }()
+    
+    private lazy var labelStack: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [noMeetUpLabel, makeNewMeetUpLabel])
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = 4
+        
+        return stackView
+    }()
+    
+    // MARK: - LifeCycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Helpers
+    
+    func configUI() {
+        self.backgroundColor = CustomColor.nomad2White
+        self.layer.cornerRadius = 12
+        
+        self.addSubview(labelStack)
+        labelStack.center(inView: self)
+    }
+}

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -31,8 +31,15 @@ class PlaceInfoViewCell: UICollectionViewCell {
     var meetUpViewModels: [MeetUpViewModel]? {
         didSet {
             guard let meetUpViewModels = meetUpViewModels else { return }
-            numberOfQuestLabel.text = "\(meetUpViewModels.count)"
+            self.numberOfMeetUp = meetUpViewModels.count
             self.collectionView.reloadData()
+        }
+    }
+    
+    var numberOfMeetUp: Int? {
+        didSet {
+            guard let numberOfMeetUp = numberOfMeetUp else { return }
+            numberOfQuestLabel.text = "\(numberOfMeetUp)"
         }
     }
     
@@ -49,7 +56,7 @@ class PlaceInfoViewCell: UICollectionViewCell {
     
     private let questLabel: UILabel = {
         let label = UILabel()
-        label.text = "밋업"
+        label.text = "오늘의 밋업"
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         label.textColor = CustomColor.nomadBlack
         return label
@@ -100,6 +107,7 @@ class PlaceInfoViewCell: UICollectionViewCell {
         collectionView.backgroundColor = .white
         collectionView.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor)
         collectionView.register(QuestCollectionViewCell.self, forCellWithReuseIdentifier: QuestCollectionViewCell.identifier)
+        collectionView.register(NoMeetUpCell.self, forCellWithReuseIdentifier: NoMeetUpCell.identifier)
         
         self.addSubview(plusButton)
         plusButton.anchor(top: collectionView.topAnchor, right: collectionView.rightAnchor, paddingTop: 10, paddingRight: 20, width: 24, height: 24)
@@ -134,13 +142,28 @@ extension PlaceInfoViewCell: UICollectionViewDelegateFlowLayout {
 
 extension PlaceInfoViewCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return meetUpViewModels?.count ?? 0
+        guard let numberOfMeetUp = numberOfMeetUp else { return 1 }
+        if numberOfMeetUp > 0 {
+            return numberOfMeetUp
+        } else {
+            return 1
+        }
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: QuestCollectionViewCell.identifier, for: indexPath) as? QuestCollectionViewCell else { return UICollectionViewCell() }
-        cell.meetUpViewModel = self.meetUpViewModels?[indexPath.item]
-        return cell
+        guard let meetUpCell = collectionView.dequeueReusableCell(withReuseIdentifier: QuestCollectionViewCell.identifier, for: indexPath) as? QuestCollectionViewCell else { return UICollectionViewCell() }
+        guard let noMeetUpcell = collectionView.dequeueReusableCell(withReuseIdentifier: NoMeetUpCell.identifier, for: indexPath) as? NoMeetUpCell else { return UICollectionViewCell() }
+        
+        if let numberOfMeetUp = numberOfMeetUp {
+            if numberOfMeetUp > 0 {
+                meetUpCell.meetUpViewModel = self.meetUpViewModels?[indexPath.item]
+                return meetUpCell
+            } else {
+                return noMeetUpcell
+            }
+        } else {
+            return noMeetUpcell
+        }
     }
 
 }

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -118,7 +118,7 @@ class QuestCollectionViewCell: UICollectionViewCell {
         configureUI()
         configCheckMark()
         configurePeopleUI()
-        self.backgroundColor = CustomColor.nomad2White
+        self.backgroundColor = .white
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## 관련 이슈들
- #293 

## 작업 내용
- 밋업이 없을 때 표시할 셀을 작업했습니다.
- 버그리스트트의 밋업셀 배경 색상 수정하였습니다. (`nomad2White` → `.white`)
- 피그마의 문구 수정사항 반영했습니다. (`"밋업"` → `"오늘의 밋업"`)

## 스크린샷(UX의 경우 gif)
### 밋업 없을 때(좌), 밋업 있을 때(우)
<p list="left">
<img width="300" alt="Screen Shot 2022-11-24 at 2 57 08 AM" src="https://user-images.githubusercontent.com/103012157/203616537-a9849d7e-2b2d-4de1-a1bf-93c1aa530b55.png">
<img width="300" alt="Screen Shot 2022-11-24 at 2 56 33 AM" src="https://user-images.githubusercontent.com/103012157/203616445-f6761799-03a8-4275-ad20-9373ba1c7170.png">
</p>

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
