### PR TITLE
[Enhancement] #304 로그인 로그아웃 toggle

### DIFF
--- a/BNomad/View/SettingView/SettingViewController.swift
+++ b/BNomad/View/SettingView/SettingViewController.swift
@@ -16,6 +16,7 @@ class SettingViewController: UIViewController {
         static let placeRequest = "장소 제안"
         static let withdrawUser = "회원 탈퇴"
         static let logout = "로그아웃"
+        static let login = "로그인"
     }
     
     var viewModel = CombineViewModel.shared
@@ -25,7 +26,7 @@ class SettingViewController: UIViewController {
         return table
     }()
     
-    private let settingListArr: [String] = [listTitle.placeRequest, listTitle.withdrawUser, listTitle.logout]
+    private var settingListArr: [String] = [listTitle.placeRequest, listTitle.withdrawUser]
     
     // MARK: - LifeCycle
     
@@ -50,6 +51,7 @@ class SettingViewController: UIViewController {
     
     func configureUI() {
         view.backgroundColor = .systemBackground
+        Auth.auth().currentUser == nil ? settingListArr.append(listTitle.login) : settingListArr.append(listTitle.logout)
     }
     
     func configureTable() {
@@ -116,6 +118,10 @@ extension SettingViewController: UITableViewDelegate {
             alert.addAction(cancel)
             alert.addAction(logout)
             self.present(alert, animated: true)
+        } else if selectedTitle == listTitle.login {
+            let controller = LoginViewController()
+            controller.sheetPresentationController?.detents = [.medium()]
+            self.present(controller, animated: true)
         }
     }
     
@@ -137,7 +143,7 @@ extension SettingViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell()
         let selectedTitle = settingListArr[indexPath.row]
-        if selectedTitle == listTitle.logout {
+        if selectedTitle == listTitle.logout || selectedTitle == listTitle.login {
             cell.textLabel?.textColor = CustomColor.nomadBlue
         } else {
             let image = UIImageView(image: UIImage(systemName: "chevron.right"))


### PR DESCRIPTION
## 관련 이슈들
- #304

## 작업 내용
- 유저가 로그인 혹은 로그아웃할 때, 테이블뷰의 리스트명을 토글해줍니다

## 리뷰 노트
- 회원탈퇴의 경우에 오른쪽에 chevron.right가 있어서, 디자인상 통일감으로(제 뇌피셜,,) 순서를 바꾸진 않았습니다.. 괜찮을까요?!

## 스크린샷(UX의 경우 gif)
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-24 at 12 06 50](https://user-images.githubusercontent.com/72736657/203685237-3077c1d7-bc57-4322-8fb8-45d6ba7d575a.gif)


## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
