### PR TITLE
[Bug] #303 밋업생성뷰, 장소제안뷰 키보드가 입력칸 가리는 문제 해결

### DIFF
--- a/BNomad/View/MeetUpView/NewMeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/NewMeetUpViewController.swift
@@ -34,7 +34,7 @@ class NewMeetUpViewController: UIViewController {
     var isNewMeetUp: Bool?
     
     private enum Value {
-        static let cornerRadius: CGFloat = 12.0
+        static let cornerRadius: CGFloat = 8.0
         static let paddingLeftRight: CGFloat = 20.0
     }
     
@@ -45,6 +45,9 @@ class NewMeetUpViewController: UIViewController {
     private var counter = 2
     
     private let contentPlaceholder = "내용을 입력하세요."
+    
+    private var keyboardHeight: CGFloat = 0
+    private var moveValue: CGFloat = 0
     
     private let subject: UILabel = {
         let label = UILabel()
@@ -298,6 +301,7 @@ class NewMeetUpViewController: UIViewController {
         locationField.delegate = self
         
         hideKeyboardWhenTappedAround()
+        setKeyboardObserver()
     }
     
     // MARK: - Actions
@@ -372,7 +376,18 @@ class NewMeetUpViewController: UIViewController {
         }
      }
     
+    @objc func keyboardWillShow(notification: NSNotification)  {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            keyboardHeight = keyboardRectangle.height
+        }
+    }
+    
     // MARK: - Helpers
+    
+    func setKeyboardObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+    }
     
     func checkIsInputFieldCompleted() -> Bool {
         var isCompleted = false
@@ -590,12 +605,32 @@ extension NewMeetUpViewController: UITextViewDelegate {
             textView.text = nil
             textView.textColor = CustomColor.nomadBlack
         }
+        
+        let screenHeight = UIScreen.main.bounds.height
+        let keyboardY = screenHeight - keyboardHeight
+        let contentY = contentRectangle.frame.minY + contentRectangle.frame.height
+
+        guard let window = UIApplication.shared.windows.first else { return }
+        let topSafeAreaHeight = window.safeAreaInsets.top
+        
+        if contentY > keyboardY {
+            moveValue = contentY - keyboardY + topSafeAreaHeight
+            UIView.animate(withDuration: 0.2) {
+                self.view.window?.frame.origin.y -= self.moveValue
+            }
+        } else {
+            moveValue = 0
+        }
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
             textView.text = contentPlaceholder
             textView.textColor = .tertiaryLabel
+        }
+        
+        UIView.animate(withDuration: 0.2) {
+            self.view.window?.frame.origin.y += self.moveValue
         }
     }
 }

--- a/BNomad/View/SettingView/RequestTextField.swift
+++ b/BNomad/View/SettingView/RequestTextField.swift
@@ -12,8 +12,8 @@ final class RequestTextField: UITextField {
     init(placehold: String) {
         super.init(frame: .zero)
         
-        self.backgroundColor = .systemGray6
-        self.layer.cornerRadius = 12
+        self.backgroundColor = CustomColor.nomadGray3
+        self.layer.cornerRadius = 8
         self.leftView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 20, height: 50)))
         self.leftViewMode = .always
         self.clearButtonMode = .whileEditing

--- a/BNomad/View/SettingView/SettingViewController.swift
+++ b/BNomad/View/SettingView/SettingViewController.swift
@@ -41,6 +41,7 @@ class SettingViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         title = "설정"
+        navigationController?.navigationBar.tintColor = CustomColor.nomadBlue
         navigationController?.navigationBar.prefersLargeTitles = true
     }
     
@@ -141,6 +142,7 @@ extension SettingViewController: UITableViewDataSource {
             cell.textLabel?.textColor = CustomColor.nomadBlue
         } else {
             let image = UIImageView(image: UIImage(systemName: "chevron.right"))
+            image.tintColor = CustomColor.nomadBlack
             cell.addSubview(image)
             image.anchor(right: cell.rightAnchor, paddingRight: 10)
             image.centerY(inView: cell)


### PR DESCRIPTION
## 관련 이슈들
- #303 

## 작업 내용
- NewMeetUpView, PlaceRequestView에서 화면 하단의 입력칸을 키보드가 가리는 문제를 해결했습니다.
- 피그마 프로토타입 고려하여 일부 UI 수정하였습니다.

## 리뷰 노트
- `PlaceRequestView`의 `UITextFieldDelegate`에서 입력칸의 y좌표를 구하기 위해 `configUI()` 함수 안에 생성했던 stack들을 밖에 프로퍼티로 꺼냈습니다.
- 유저가 위에서부터 입력칸에 작성해 나갈 때, 키보드가 가리지 않는 상단의 textField 활성화 시 키보드가 올라올 때 키보드 높이(기기마다 다름)가 구해지고, 그 다음 화면 하단의 입력칸에 작성할 때 키보드 높이(키보드 상단 y좌표)와 입력칸 하단의 y좌표 차이만큼 전체 뷰를 위로 올리고 있습니다. 
    - 그래서 유저가 `NewMeetUpView`, `PlaceRequestView`에 접근하자마자 맨 아래칸부터 탭하는 경우 뷰가 키보드 위로 올라가지 않습니다.. 
    - 지금처럼 한번 키보드를 올려서 기기마다 다른 키보드 높이(iPhone8: 260, iPhone14: 336, ...)를 구하는 것이 아니라 그냥 키보드 높이를 특정 값(350..?)이라고 고정하면 유저가 바로 화면 하단 입력칸을 탭하더라도 뷰가 올라가긴 할 것인데.. 좋은 방법은 아닌 것 같습니다ㅜㅜ
    - 일단은 위에서부터 순서대로 입력한다고 생각하고 그대로 진행했습니다.

## 스크린샷(UX의 경우 gif)
### 밋업생성뷰(좌), 장소제안뷰(우)
<p list="left">
<img src="https://user-images.githubusercontent.com/103012157/203723942-491c0224-b908-4f0d-b075-e8e59d9c429d.gif" width="300">
<img src="https://user-images.githubusercontent.com/103012157/203724296-8d98e630-4d62-4ab1-8f59-41d00859ed53.gif" width="300">
</p>

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
