### PR TITLE
[Enhancement] 프로필뷰 UI 개선

### DIFF
--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -386,6 +386,20 @@ extension CalendarViewController: UICollectionViewDelegateFlowLayout {
         return .zero
     }
     
+    //cell 횡간 간격
+       func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat{
+           return CGFloat(0)
+       }
+       
+       //cell 종간 간격
+       func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+           if collectionView == visitCardListView {
+               return CGFloat(20)
+           }
+           return CGFloat(0)
+       }
+    
+    
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         

--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -27,6 +27,8 @@ class CalendarViewController: UIViewController {
         collectionView.backgroundColor = CustomColor.nomad2White
         collectionView.isScrollEnabled = true
         collectionView.register(VisitCardCell.self, forCellWithReuseIdentifier: VisitCardCell.identifier)
+        collectionView.register(VisitCardHeaderCollectionView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: VisitCardHeaderCollectionView.identifier)
+
         
         return collectionView
     }()
@@ -54,41 +56,15 @@ class CalendarViewController: UIViewController {
         return collectionView
     }()
     
-    private let VisitInfoHeader: UILabel = {
-        let content = Contents.todayDate()
-        let day = String(content["month"] ?? 0) + "월 " + String(content["day"] ?? 0) + "일"
-        
-        let label = UILabel()
-        label.text = day
-        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
-        label.textColor = CustomColor.nomadBlue
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private let calendarCollectionYearHeader: UILabel = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy"
-        let year = formatter.string(from:Date())
-        
-        let label = UILabel()
-        label.text = year
-        label.font = .preferredFont(forTextStyle: .subheadline, weight: .semibold)
-        label.textColor = .gray
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
     private let calendarCollectionMonthHeader: UILabel = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "M월"
+        formatter.dateFormat = "y년 M월"
         let month = formatter.string(from:Date())
         
         let label = UILabel()
         label.text = month
         label.font = .preferredFont(forTextStyle: .title1, weight: .bold)
         label.textColor = .black
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -137,8 +113,8 @@ class CalendarViewController: UIViewController {
                 
         navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "calendar"), style: .plain, target: self, action: #selector(toggleTapButton))
         
-        
-        selectedCell = (Contents.todayDate()["day"] ?? 0)+calendarDateFormatter.getStartingDayOfWeek(addedMonth: 0)-1 // 오늘로 셀렉티드셀 초기화
+        // 오늘로 셀렉티드셀 초기화
+        selectedCell = (Contents.todayDate()["day"] ?? 0)+calendarDateFormatter.getStartingDayOfWeek(addedMonth: 0)-1
         let selectedPath = IndexPath(item: selectedCell ?? 0, section: 0)
         collectionView(calendarCollectionView, didSelectItemAt: selectedPath)
         
@@ -156,8 +132,6 @@ class CalendarViewController: UIViewController {
         
         configureUI()
         render()
-        
-        
     
     }
     
@@ -166,7 +140,7 @@ class CalendarViewController: UIViewController {
     
     @objc func plusMonthTapButton() {
         monthAddedMemory += 1
-        calendarCollectionMonthHeader.text = String(calendarDateFormatter.getTargetMonth(addedMonth: monthAddedMemory))+"월"
+        calendarCollectionMonthHeader.text = String(calendarDateFormatter.getTargetMonth(addedMonth: monthAddedMemory))
         
         selectedCell = nil
         
@@ -177,7 +151,7 @@ class CalendarViewController: UIViewController {
     
     @objc func minusMonthTapButton() {
         monthAddedMemory -= 1
-        calendarCollectionMonthHeader.text = String(calendarDateFormatter.getTargetMonth(addedMonth: monthAddedMemory))+"월"
+        calendarCollectionMonthHeader.text = String(calendarDateFormatter.getTargetMonth(addedMonth: monthAddedMemory))
         
         selectedCell = nil
 
@@ -204,8 +178,7 @@ class CalendarViewController: UIViewController {
             plusMonthButton.removeFromSuperview()
             
             view.addSubview(visitCardListView)
-            visitCardListView.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor,
-                                     paddingTop: 100, paddingLeft: 14, paddingRight: 14)
+            visitCardListView.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, paddingTop: 100, paddingLeft: 14, paddingRight: 14)
         }
     }
     
@@ -222,32 +195,22 @@ class CalendarViewController: UIViewController {
                                       paddingTop: 105, paddingLeft: 14, paddingRight: 14,
                                       height: 388)
         
-//        view.addSubview(calendarCollectionYearHeader)
-//        calendarCollectionYearHeader.anchor(top: CalendarCollectionView.topAnchor)
-//        calendarCollectionYearHeader.centerX(inView: view)
-        
         view.addSubview(calendarCollectionMonthHeader)
-        calendarCollectionMonthHeader.anchor(top: calendarCollectionView.topAnchor, paddingTop: 10)
+        calendarCollectionMonthHeader.anchor(top: calendarCollectionView.topAnchor, left: calendarCollectionView.leftAnchor, paddingTop: 10, paddingLeft: 20)
         calendarCollectionMonthHeader.centerX(inView: view)
-        
         
         view.addSubview(dayOfWeekStackView)
         dayOfWeekStackView.anchor(top: calendarCollectionMonthHeader.bottomAnchor, paddingTop: 15, width: 358-358/7)
         dayOfWeekStackView.centerX(inView: view)
         
         view.addSubview(minusMonthButton)
-        minusMonthButton.anchor(top: calendarCollectionView.topAnchor, left: dayOfWeekStackView.leftAnchor, paddingTop: 15)
+        minusMonthButton.anchor(top: calendarCollectionView.topAnchor, right: dayOfWeekStackView.rightAnchor, paddingTop: 15, paddingRight: 50)
         view.addSubview(plusMonthButton)
         plusMonthButton.anchor(top: calendarCollectionView.topAnchor, right: dayOfWeekStackView.rightAnchor, paddingTop: 15)
         
-        
         view.addSubview(visitInfoView)
-        visitInfoView.anchor(top: view.topAnchor, left: view.leftAnchor, right: view.rightAnchor,
-                                paddingTop: 557, paddingLeft: 14, paddingRight: 14, height: 256)
-        
-//        view.addSubview(VisitInfoHeader)
-//        VisitInfoHeader.anchor(top: CalendarCollectionView.bottomAnchor, paddingTop: 21)
-//        VisitInfoHeader.centerX(inView: view)
+        visitInfoView.anchor(top: calendarCollectionView.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor,
+                                paddingTop: 24, paddingLeft: 14, paddingRight: 14, height: 256)
         
     }
     
@@ -258,19 +221,29 @@ class CalendarViewController: UIViewController {
 extension CalendarViewController: UICollectionViewDataSource {
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
+        if collectionView == visitCardListView {
+            return CalendarViewController.checkInHistory?.count ?? 0
+        }
         return 1
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        if collectionView == calendarCollectionView {
+        
+        switch collectionView {
+            
+        case calendarCollectionView:
             return self.calendarDateFormatter.days.count
-        } else if collectionView == visitInfoView {
+
+        case visitInfoView:
             return max(cardDataList.count, 1)
-        } else {
-            return CalendarViewController.checkInHistory?.count ?? 0
+
+        case visitCardListView:
+            return 1
+
+        default: return 0
+            
         }
     }
-    
 }
 
 // MARK: - UICollectionViewDelegate
@@ -279,8 +252,10 @@ extension CalendarViewController: UICollectionViewDelegate {
     
     //draw cells
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        if collectionView == calendarCollectionView {
+        
+        switch collectionView {
             
+        case calendarCollectionView:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarCell.identifier , for: indexPath) as? CalendarCell else {
                 return UICollectionViewCell()
             }
@@ -324,7 +299,7 @@ extension CalendarViewController: UICollectionViewDelegate {
             
             return cell
             
-        } else if collectionView == visitInfoView {
+        case visitInfoView:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitCardCell.identifier , for: indexPath) as? VisitCardCell else {
                 return UICollectionViewCell()
             }
@@ -338,7 +313,7 @@ extension CalendarViewController: UICollectionViewDelegate {
             }
             return cell
             
-        } else {
+        case visitCardListView:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitCardCell.identifier , for: indexPath) as? VisitCardCell else {
                 return UICollectionViewCell()
             }
@@ -347,9 +322,12 @@ extension CalendarViewController: UICollectionViewDelegate {
             cell.layer.cornerRadius = 20
             
             let checkinHistoryCount = CalendarViewController.checkInHistory?.count
-            cell.checkinHistoryForList = CalendarViewController.checkInHistory?[(checkinHistoryCount ?? 0)-indexPath.item-1]
+            cell.checkInHistoryForCalendar = CalendarViewController.checkInHistory?[(checkinHistoryCount ?? 0)-indexPath.section-1]
             
             return cell
+            
+        default: return UICollectionViewCell()
+            
         }
     }
     
@@ -375,6 +353,18 @@ extension CalendarViewController: UICollectionViewDelegate {
         }
     }
     
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        if collectionView == visitCardListView {
+            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: VisitCardHeaderCollectionView.identifier, for: indexPath) as? VisitCardHeaderCollectionView else {
+                return UICollectionViewCell()
+            }
+            let index = (CalendarViewController.checkInHistory?.count ?? 0)-1-indexPath.section
+            header.configure(with: CalendarViewController.checkInHistory?[index].date ?? "")
+            return header
+        }
+        return UICollectionViewCell()
+    }
+    
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout
@@ -383,23 +373,17 @@ extension CalendarViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize{
         if collectionView == calendarCollectionView {
             return CGSize(width: 358/8, height: 358/7)
-        } else {
-            return CGSize(width: visitInfoView.frame.width, height: 119)
         }
+        
+        return CGSize(width: visitInfoView.frame.width, height: 119)
         
     }
     
-    //cell 횡간 간격
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat{
-        return CGFloat(0)
-    }
-    
-    //cell 종간 간격
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         if collectionView == visitCardListView {
-            return CGFloat(20)
+            return CGSize(width: view.frame.size.width, height: 50)
         }
-        return CGFloat(0)
+        return .zero
     }
     
     
@@ -407,12 +391,10 @@ extension CalendarViewController: UICollectionViewDelegateFlowLayout {
         
         if collectionView == calendarCollectionView {
             return UIEdgeInsets(top: 75, left: 358/14, bottom: 0, right: 358/14)
-        } else {
-            return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         }
+        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         
     }
-    
 }
 
 class CalendarDateFormatter {
@@ -437,12 +419,13 @@ class CalendarDateFormatter {
         return startingDay
     }
     
-    func getTargetMonth(addedMonth: Int) -> Int {
+    func getTargetMonth(addedMonth: Int) -> String {
         let month = self.calendar.date(byAdding: .month, value: addedMonth, to: self.nowCalendarDate)
 
-        guard let month = month else { return 0 }
+        guard let month = month else { return "" }
         let targetMonth = self.calendar.component(.month, from: month)
-        return targetMonth
+        let targetYear = self.calendar.component(.year, from: month)
+        return String(targetYear)+"년 "+String(targetMonth)+"월"
     }
 
     func getEndDateOfMonth(addedMonth: Int) -> Int {
@@ -466,6 +449,5 @@ class CalendarDateFormatter {
             }
         }
     }
-
 }
 

--- a/BNomad/View/ProfileView/ProfileGraphCell.swift
+++ b/BNomad/View/ProfileView/ProfileGraphCell.swift
@@ -25,12 +25,11 @@ class ProfileGraphCell: UICollectionViewCell {
     private let timeLabel: [UILabel] = {
         var label:[UILabel] = []
         
-        for index in 0...3 {
+        for index in 0...4 {
             let time = UILabel()
-            time.text = String(9 + index*3) //FIXME: 그래프 간격 어떻게 할건지? 현재는 데이터 로직 기준
+            time.text = String(0 + index*6) //FIXME: 그래프 간격 어떻게 할건지? 현재는 데이터 로직 기준
             time.textColor = .gray
             time.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
-            time.translatesAutoresizingMaskIntoConstraints = false
             label.append(time)
         }
         return label
@@ -50,7 +49,6 @@ class ProfileGraphCell: UICollectionViewCell {
             }
             
             day.font = .preferredFont(forTextStyle: .caption2, weight: .regular)
-            day.translatesAutoresizingMaskIntoConstraints = false
             label.append(day)
         }
         return label
@@ -88,21 +86,19 @@ class ProfileGraphCell: UICollectionViewCell {
         
         let timeStack = UIStackView(arrangedSubviews: timeLabel)
         timeStack.axis = .vertical
-        timeStack.spacing = 35
+        timeStack.spacing = 30
         timeStack.distribution = .fillEqually
-        timeStack.translatesAutoresizingMaskIntoConstraints = false
         
         let dayStack = UIStackView(arrangedSubviews: ProfileGraphCell.dayLabel)
         dayStack.axis = .horizontal
         dayStack.spacing = (CGFloat(contentView.frame.width)-55-24*7)/6
         dayStack.distribution = .fillEqually
-        dayStack.translatesAutoresizingMaskIntoConstraints = false
         
         contentView.addSubview(timeStack)
         timeStack.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, paddingTop: 10, paddingLeft: 10)
         
         contentView.addSubview(dayStack)
-        dayStack.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, paddingTop: 166, paddingLeft: 45)
+        dayStack.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, paddingTop: 196, paddingLeft: 45)
 
         contentView.addSubview(ProfileGraphCell.profileGraphCollectionView)
         ProfileGraphCell.profileGraphCollectionView.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, paddingTop: 10, paddingLeft: 42, width: contentView.frame.width, height: 154)

--- a/BNomad/View/ProfileView/ProfileGraphCollectionCell.swift
+++ b/BNomad/View/ProfileView/ProfileGraphCollectionCell.swift
@@ -34,8 +34,9 @@ class ProfileGraphCollectionCell: UICollectionViewCell {
                     self.checkoutTime = formatter.string(from: checkin.checkOutTime ?? Date()).components(separatedBy: "-")
                     
                     //그래프의 시작/끝 픽셀 위치 잡아주는 계산
-                    let startAnchorCalculater = (((Double(checkinTime[0]) ?? 0) + (Double(checkinTime[1]) ?? 0) * Double(1.0/60.0)) - Double(9)) * Double(154.0/9.0)
-                    let endAnchorCalculater = Double(154.0) - ((((Double(checkoutTime[0]) ?? 0) + (Double(checkoutTime[1]) ?? 0) * Double(1.0/60.0)) - Double(9)) * Double(154.0/9.0))
+                    
+                    let startAnchorCalculater = ((Double(checkinTime[0]) ?? 0) + (Double(checkinTime[1]) ?? 0) * Double(1.0/60.0)) * Double(184.0/24.0)
+                    let endAnchorCalculater = Double(154.0) - (((Double(checkoutTime[0]) ?? 0) + (Double(checkoutTime[1]) ?? 0) * Double(1.0/60.0)) * Double(184.0/24.0))
                     
                     startAnchor = CGFloat(Int(startAnchorCalculater))
                     endAnchor = CGFloat(Int(endAnchorCalculater))

--- a/BNomad/View/ProfileView/ProfileHeaderCollectionView.swift
+++ b/BNomad/View/ProfileView/ProfileHeaderCollectionView.swift
@@ -50,18 +50,10 @@ class ProfileHeaderCollectionView: UICollectionReusableView {
         return button
     }()
     
-    private let profileGraphCellHeaderLabel: UILabel = {
-        let label = UILabel()
-        label.text = "주간 통계"
-        label.textColor = .black
-        label.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
-        return label
-    }()
-    
     var profileGraphCellWeekLabel: UILabel = {
         let label = UILabel()
         
-        label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        label.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
         return label
     }()
     
@@ -87,18 +79,20 @@ class ProfileHeaderCollectionView: UICollectionReusableView {
     static func profileGraphCellHeaderMaker(label: UILabel, weekAdded: Int) {
         
         weekAddedMemory += weekAdded
-        print("DBG0:", weekAddedMemory)
         let weekCalculator = weekAddedMemory * 7
         let formatter = DateFormatter()
-        formatter.dateFormat = "M.d"
+        formatter.dateFormat = "M월 d일"
         
         let sundayCalculator = (86400 * (1-Contents.todayOfTheWeek + weekCalculator))
         let saturdayCalculator = (86400 * (1-Contents.todayOfTheWeek+6 + weekCalculator))
         
         let sundayDate = formatter.string(from: Date(timeIntervalSinceNow: TimeInterval(sundayCalculator)))
         let saturdayDate = formatter.string(from: Date(timeIntervalSinceNow: TimeInterval(saturdayCalculator)))
+        
+        formatter.dateFormat = "y년 "
+        let year = formatter.string(from: Date(timeIntervalSinceNow: TimeInterval(sundayCalculator)))
 
-        label.text = sundayDate+" ~ "+saturdayDate
+        label.text = year+sundayDate+" ~ "+saturdayDate
         label.textColor = .black
         
     }
@@ -107,33 +101,27 @@ class ProfileHeaderCollectionView: UICollectionReusableView {
         minusWeek.removeFromSuperview()
         plusWeek.removeFromSuperview()
         profileGraphCellWeekLabel.removeFromSuperview()
-        profileGraphCellHeaderLabel.removeFromSuperview()
         
         addSubview(visitCardCellHeaderLabel)
-        visitCardCellHeaderLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 28, paddingLeft: 20)
+        visitCardCellHeaderLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 28, paddingLeft: 10)
         
         addSubview(viewAllButton)
-        viewAllButton.anchor(top:self.topAnchor, right: self.rightAnchor, paddingTop: 28, paddingRight: 20)
+        viewAllButton.anchor(top:self.topAnchor, right: self.rightAnchor, paddingTop: 28, paddingRight: 10)
     }
     
     func setGraphHeader() {
         visitCardCellHeaderLabel.removeFromSuperview()
         viewAllButton.removeFromSuperview()
         
-        addSubview(profileGraphCellHeaderLabel)
-        profileGraphCellHeaderLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 28, paddingLeft: 20)
-        
-        
         addSubview(profileGraphCellWeekLabel)
-        profileGraphCellWeekLabel.centerX(inView: self)
-        profileGraphCellWeekLabel.anchor(top: self.topAnchor, paddingTop: 64)
+        profileGraphCellWeekLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 28, paddingLeft: 10)
         
         addSubview(minusWeek)
-        minusWeek.anchor(left: self.leftAnchor, paddingLeft: 90)
+        minusWeek.anchor(right: self.rightAnchor, paddingRight: 60)
         minusWeek.centerY(inView: profileGraphCellWeekLabel)
         
         addSubview(plusWeek)
-        plusWeek.anchor(right: self.rightAnchor, paddingRight: 90)
+        plusWeek.anchor(right: self.rightAnchor, paddingRight: 10)
         plusWeek.centerY(inView: profileGraphCellWeekLabel)
     }
     

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -30,19 +30,9 @@ class ProfileViewController: UIViewController {
     let scrollView: UIScrollView = {
         let scroll = UIScrollView()
         scroll.backgroundColor = CustomColor.nomad2White
-        scroll.canCancelContentTouches = true
         
         return scroll
     }()
-    
-    class myCollectionView: UIScrollView {
-        override func touchesShouldCancel(in view: UIView) -> Bool {
-            if view is UICollectionView {
-                return false
-            }
-            return super.touchesShouldCancel(in: view)
-        }
-    }
     
     let contentView: UIView = {
         let ui = UIView()
@@ -56,7 +46,8 @@ class ProfileViewController: UIViewController {
         iv.clipsToBounds = true
         iv.isUserInteractionEnabled = true
         iv.layer.masksToBounds = true
-        iv.layer.cornerRadius = 78 / 2
+        iv.frame = CGRect(origin: .zero, size: CGSize(width: 120, height: 120))
+        iv.layer.cornerRadius = iv.frame.height/2
         return iv
     }()
     
@@ -89,6 +80,8 @@ class ProfileViewController: UIViewController {
         
         profileCollectionView.dataSource = self
         profileCollectionView.delegate = self
+        
+        profileImageView.image = nomad?.profileImage ?? UIImage(named: "othersProfile")
         
         configureUI()
         render()
@@ -141,7 +134,7 @@ class ProfileViewController: UIViewController {
         scrollView.addSubview(profileCollectionView)
         scrollView.addSubview(profileImageView)
         
-        profileImageView.anchor(top: scrollView.topAnchor, paddingTop: 25, width: 120, height: 120)
+        profileImageView.anchor(top: scrollView.topAnchor, paddingTop: 20, width: 120, height: 120)
         profileImageView.centerX(inView: view)
         
         profileCollectionView.anchor(top: scrollView.topAnchor, left: scrollView.leftAnchor, right: view.rightAnchor,
@@ -219,7 +212,7 @@ extension ProfileViewController: UICollectionViewDelegate {
             return UICollectionViewCell()
         }
         
-        header.delegate = self //FIXME: 매 로드때마다 딜리게이트 설정해주는게 맞는지?
+        header.delegate = self
 
         switch indexPath.section {
         case 1:
@@ -240,11 +233,14 @@ extension ProfileViewController: UICollectionViewDelegate {
 extension ProfileViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize{
-        if indexPath.section == 0 {
+        switch indexPath.section {
+        case 0:
             return CGSize(width: profileCollectionView.frame.width, height: 182)
-        } else if indexPath.section == 1 {
+        case 1:
             return CGSize(width: profileCollectionView.frame.width, height: 119)
-        } else {
+        case 2:
+            return CGSize(width: profileCollectionView.frame.width, height: 220)
+        default:
             return CGSize(width: profileCollectionView.frame.width, height: 190)
         }
         
@@ -257,7 +253,7 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
         case 1:
             return CGSize(width: view.frame.size.width, height: 62)
         case 2:
-            return CGSize(width: view.frame.size.width, height: 96)
+            return CGSize(width: view.frame.size.width, height: 62)
         default:
             return .zero
         }
@@ -270,12 +266,10 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
 extension ProfileViewController: PlusMinusProtocol {
     func plusTap() {
         ProfileGraphCell.editWeek(edit: 1)
-        
     }
     
     func minusTap() {
         ProfileGraphCell.editWeek(edit: -1)
-
     }
     
     func viewAllTap() {

--- a/BNomad/View/ProfileView/SelfUserInfoCell.swift
+++ b/BNomad/View/ProfileView/SelfUserInfoCell.swift
@@ -32,7 +32,6 @@ class SelfUserInfoCell: UICollectionViewCell {
         label.text = DummyData.user1.nickname
         label.font = .preferredFont(forTextStyle: .title1, weight: .bold)
         label.textColor = .black
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -51,7 +50,6 @@ class SelfUserInfoCell: UICollectionViewCell {
         label.text = "iOS Developer"
         label.textColor = .gray
         label.font = .preferredFont(forTextStyle: .body, weight: .semibold)
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -69,7 +67,6 @@ class SelfUserInfoCell: UICollectionViewCell {
         label.text = "안녕하세요 반가워요 윌로우에요 ios 개발 하고있어요, 디자인에도 관심이 많아서 대화 나누기 좋아해요"
         label.textColor = .black
         label.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
-        label.translatesAutoresizingMaskIntoConstraints = false
 
         return label
     }()
@@ -100,7 +97,7 @@ class SelfUserInfoCell: UICollectionViewCell {
         nameLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 40, paddingLeft: 20)
         
         contentView.addSubview(editingButton)
-        editingButton.anchor(top: contentView.topAnchor, right: contentView.rightAnchor, paddingTop: 33, paddingRight: 12, width: 55, height: 13)
+        editingButton.anchor(top: contentView.topAnchor, right: contentView.rightAnchor, paddingTop: 12, paddingRight: 12, width: 55, height: 13)
         
         contentView.addSubview(jobLabel)
         jobLabel.anchor(top: contentView.topAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 75, paddingLeft: 20, paddingRight: 20)

--- a/BNomad/View/ProfileView/VisitCardCell.swift
+++ b/BNomad/View/ProfileView/VisitCardCell.swift
@@ -16,36 +16,6 @@ class VisitCardCell: UICollectionViewCell {
     var viewOption: String = ""
     lazy var viewModel = CombineViewModel.shared
     
-    var checkinHistoryForList: CheckIn? {
-        didSet {
-            guard let checkInHistory = checkinHistoryForList else {
-                nilHistory()
-                return
-                
-            }
-            
-                rectView.removeFromSuperview()
-                nilLabel.removeFromSuperview()
-            let place = self.viewModel.places.first {$0.placeUid == checkInHistory.placeUid}
-            nameLabel.text = place?.name
-            
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "M월 d일"
-            
-            dateFormatter.dateFormat = "HH:mm"
-            let checkInTime = dateFormatter.string(from: checkInHistory.checkInTime)
-            let checkOutTime = dateFormatter.string(from: checkInHistory.checkOutTime ?? Date())
-            self.checkInAndOutLabel.text = checkInTime + " - " + checkOutTime
-
-            let checkinTime = dateFormatter.string(from: checkInHistory.checkInTime)
-            self.checkinDateLabel.text = checkinTime
-            
-            let stayedTime = Int((checkInHistory.checkOutTime?.timeIntervalSince(checkInHistory.checkInTime) ?? 0) / 60)
-            self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
-
-        }
-    }
-    
     var checkInHistoryForCalendar: CheckIn? {
         didSet {
             guard let checkInHistory = checkInHistoryForCalendar else {
@@ -100,8 +70,17 @@ class VisitCardCell: UICollectionViewCell {
             let checkOutTime = dateFormatter.string(from: lastCheckIn.checkOutTime ?? Date())
             self.checkInAndOutLabel.text = checkInTime + " - " + checkOutTime
             
-            let stayedTime = Int((lastCheckIn.checkOutTime?.timeIntervalSince(lastCheckIn.checkInTime) ?? 0) / 60)
-            self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간"+String(stayedTime%60)+"분"
+            guard let checkOutTime = lastCheckIn.checkOutTime else {
+                let stayedTime = Int((lastCheckIn.checkOutTime ?? Date()).timeIntervalSince(lastCheckIn.checkInTime) / 60)
+                self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간 "+String(stayedTime%60)+"분째"
+                
+                self.checkInAndOutLabel.text = checkInTime + " ~"
+                
+                return
+            }
+            
+            let stayedTime = Int(checkOutTime.timeIntervalSince(lastCheckIn.checkInTime) / 60)
+            self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간 "+String(stayedTime%60)+"분"
             
             nameLabel.reloadInputViews()
         }
@@ -215,7 +194,6 @@ class VisitCardCell: UICollectionViewCell {
             $0.spacing = 1
             $0.distribution = .fillEqually
             $0.alignment = .center
-            $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
         contentView.addSubview(stack[0])

--- a/BNomad/View/ProfileView/VisitCardCollectionViewController.swift
+++ b/BNomad/View/ProfileView/VisitCardCollectionViewController.swift
@@ -96,7 +96,7 @@ extension VisitCardCollectionViewController: UICollectionViewDelegate {
             cell.layer.cornerRadius = 20
             
             let checkinHistoryCount = VisitCardCollectionViewController.checkInHistory?.count
-            cell.checkinHistoryForList = VisitCardCollectionViewController.checkInHistory?[(checkinHistoryCount ?? 0)-indexPath.section-1]
+            cell.checkInHistoryForCalendar = VisitCardCollectionViewController.checkInHistory?[(checkinHistoryCount ?? 0)-indexPath.section-1]
             
             return cell
         

--- a/BNomad/View/ProfileView/VisitCardHeaderCollectionView.swift
+++ b/BNomad/View/ProfileView/VisitCardHeaderCollectionView.swift
@@ -24,7 +24,6 @@ class VisitCardHeaderCollectionView: UICollectionReusableView {
         label.text = day
         label.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         label.textColor = CustomColor.nomadBlue
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -40,7 +39,7 @@ class VisitCardHeaderCollectionView: UICollectionReusableView {
     
     private func setUI() {
         addSubview(VisitInfoHeader)
-        VisitInfoHeader.anchor(left: self.leftAnchor, paddingLeft: 20)
+        VisitInfoHeader.anchor(left: self.leftAnchor, paddingLeft: 10)
         VisitInfoHeader.centerY(inView: self)
     }
     


### PR DESCRIPTION
## 관련 이슈들
- #316 

## 작업 내용
- 프로필뷰 UI를 개선했습니다
- 체크하웃하지 않은 상태에서 프로필뷰 진입 시, 비짓카드의 시간을 "체크인시간 ~" 으로 표시되게 수정했습니다 (ex: 17:30 ~)
- 프로필뷰의 통계 섹션에서, 그래프 세로축 시간 범위를 00시~24시로 수정했습니다
- 캘린더뷰의 리스트 보기 모드에서 헤더를 생성했습니다 (현재 모든 셀에 대해 헤더가 생성됨, 같은 날자별로 묶어줘야 함)
- 

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img src="https://이미지링크를넣어주세요" width="300">
<img width="440" alt="스크린샷 2022-11-24 16 54 36" src="https://user-images.githubusercontent.com/70618615/203724864-09a31ef4-a715-4270-92ef-1c6cd457abd9.png">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
