### PR TITLE
[Feat] #320 밋업 모임 시간 지나면 회색 & 선택 시 alert

### DIFF
--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -271,4 +271,10 @@ extension PlaceCheckInViewController: PlaceInfoViewCellDelegate {
         vc.meetUpViewModel = meetUpViewModel
         navigationController?.pushViewController(vc, animated: true)
     }
+    
+    func didTapPastMeetUpCell(_ cell: PlaceInfoViewCell) {
+        let alert = UIAlertController(title: "지난 밋업입니다.", message: "지난 밋업은 볼 수 없습니다.", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
 }

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -13,6 +13,7 @@ protocol NewMeetUpViewShowable {
 
 protocol PlaceInfoViewCellDelegate: AnyObject {
     func didTapMeetUpCell(_ cell: PlaceInfoViewCell, meetUpViewModel: MeetUpViewModel)
+    func didTapPastMeetUpCell(_ cell: PlaceInfoViewCell)
 }
 
 class PlaceInfoViewCell: UICollectionViewCell {
@@ -133,8 +134,12 @@ extension PlaceInfoViewCell: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard (meetUpViewModels?[indexPath.item]) != nil else { return }
-        placeInfoViewCelldelegate?.didTapMeetUpCell(self, meetUpViewModel: (meetUpViewModels?[indexPath.item])!)
+        guard let meetUp = meetUpViewModels?[indexPath.item] else { return }
+        if meetUp.meetUp?.time.compare(Date()) == .orderedAscending {
+            placeInfoViewCelldelegate?.didTapPastMeetUpCell(self)
+        } else {
+            placeInfoViewCelldelegate?.didTapMeetUpCell(self, meetUpViewModel: meetUp)
+        }
     }
 }
 

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -134,11 +134,14 @@ extension PlaceInfoViewCell: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let meetUp = meetUpViewModels?[indexPath.item] else { return }
-        if meetUp.meetUp?.time.compare(Date()) == .orderedAscending {
-            placeInfoViewCelldelegate?.didTapPastMeetUpCell(self)
-        } else {
-            placeInfoViewCelldelegate?.didTapMeetUpCell(self, meetUpViewModel: meetUp)
+        guard let numberOfMeetUp = numberOfMeetUp else { return }
+        if numberOfMeetUp > 0 {
+            guard let meetUp = meetUpViewModels?[indexPath.item] else { return }
+            if meetUp.meetUp?.time.compare(Date()) == .orderedAscending {
+                placeInfoViewCelldelegate?.didTapPastMeetUpCell(self)
+            } else {
+                placeInfoViewCelldelegate?.didTapMeetUpCell(self, meetUpViewModel: meetUp)
+            }
         }
     }
 }

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -32,6 +32,12 @@ class QuestCollectionViewCell: UICollectionViewCell {
 
             guard let userUid = viewModel.user?.userUid else { return }
             isParticipated = meetUp.currentPeopleUids?.contains(userUid)
+            
+            if meetUp.time.compare(Date()) == .orderedAscending {
+                self.backgroundColor = CustomColor.nomadGray3
+            } else {
+                self.backgroundColor = .white
+            }
         }
     }
     


### PR DESCRIPTION
## 관련 이슈들
- #320 

## 작업 내용
- 현재 시간과 밋업 시간을 비교해서 밋업 시간이 이전이면 해당 밋업 셀 배경을 회색으로 만들고, 선택 시 지난 밋업이라는 alert가 뜨게 했습니다.

## 리뷰 노트
- @YeeunKim-archive 모임 시간이 지난 밋업 셀에 대한 피그마 프로토타입이 없어서 우선 배경만 nomadGray3으로 바꾸는 것으로 했습니다. 또, 지난 밋업 선택 시 alert와 문구는 제가 임의로 넣은 것인데, 아예 아무것도 안뜨고 선택도 안되는 것이 좋을지.. 협의 필요할 것 같습니다. 
- @sunshiningsoo 오전에 이야기한 `guard (meetUpViewModels?[indexPath.item]) != nil else { return }` 부분(@limhyoseok 밋업 데이터 바인딩 시 작성)을 건드렸습니다. 제가 확인할 때는 잘 동작하는 것 같은데 확인 부탁드립니다.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012157/203746299-e324b09d-a09c-4b48-838d-5d2f58041e6c.gif" width="300">

## Reference
- [Date끼리 비교](https://wiwi-pe.tistory.com/214)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
