### PR TITLE
[Feat] #322 밋업 모집인원 다 차면 참여불가

### DIFF
--- a/BNomad/View/MeetUpView/MeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/MeetUpViewController.swift
@@ -175,16 +175,24 @@ class MeetUpViewController: UIViewController {
         let alert = UIAlertController(title: "\(meetUpTitleLabel.text ?? "")에 참여 하시겠습니까?", message: "MeetUp에 참여합니다.", preferredStyle: .alert)
         let cancel = UIAlertAction(title: "취소", style: .cancel)
         let join = UIAlertAction(title: "확인", style: .default, handler: { action in
-            // TODO: 인원수 유효성 검사 필요
             guard
                 let userUid = self.viewModel.user?.userUid,
                 let meetUpUid = self.meetUpViewModel?.meetUp?.meetUpUid,
-                let placeUid = self.meetUpViewModel?.meetUp?.placeUid
+                let placeUid = self.meetUpViewModel?.meetUp?.placeUid,
+                let currentPeopleUids = self.meetUpViewModel?.meetUp?.currentPeopleUids,
+                let maxPeopleNum = self.meetUpViewModel?.meetUp?.maxPeopleNum
             else { return }
-            FirebaseManager.shared.participateMeetUp(userUid: userUid, meetUpUid: meetUpUid, placeUid: placeUid) {
-                self.meetUpViewModel?.meetUp?.currentPeopleUids?.append(userUid)
+            
+            if maxPeopleNum > currentPeopleUids.count {
+                FirebaseManager.shared.participateMeetUp(userUid: userUid, meetUpUid: meetUpUid, placeUid: placeUid) {
+                    self.meetUpViewModel?.meetUp?.currentPeopleUids?.append(userUid)
+                }
+                self.navigationController?.popToRootViewController(animated: true)
+            } else {
+                let maxAlert = UIAlertController(title: "모집인원 초과", message: "모집인원을 초과하여 참여할 수 없습니다.", preferredStyle: .alert)
+                maxAlert.addAction(UIAlertAction(title: "확인", style: .default))
+                self.present(maxAlert, animated: true)
             }
-            self.navigationController?.popToRootViewController(animated: true)
         })
         alert.addAction(cancel)
         alert.addAction(join)


### PR DESCRIPTION
## 관련 이슈들
- #322 

## 작업 내용
- 밋업 모집인원이 다 찼을 때 참여하기 - 확인을 누르면 참여할 수 없다는 alert가 뜨도록 했습니다.

## 리뷰 노트
- 밋업 상세보기로 들어갈 때 가져오는 `meetUpViewModel`의 `currentPeopleUids.count`와 `maxPeopleNum`을 단순 비교하여 참여/불가를 구분했습니다. 이전에 @limhyoseok 가 이야기한 것처럼 여러사람이 동시에 참여하기를 누르는 경우는 이걸로 제한할 수 없을 것 같고, 추가적인 조치가 필요할 것 같습니다.

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012157/203881197-807de6a5-de95-4a6c-8c5a-5ff7674e2ea8.gif" width="300">

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
