### PR TITLE
[Feat] 파이어 베이스 캐시 처리

### DIFF
--- a/BNomad/API/FirebaseManager.swift
+++ b/BNomad/API/FirebaseManager.swift
@@ -17,7 +17,12 @@ class FirebaseManager {
 
     // 실사용시 withPath: "Dummy" 제거 필요.
     let ref = Database.database().reference(withPath: "Dummy")
-
+    let refMeetUpPlace = Database.database().reference(withPath: "Dummy/meetUpPlace")
+    
+    private init() {
+        refMeetUpPlace.keepSynced(true)
+    }
+    
     // MARK: place
     // firebase
     //    places
@@ -338,7 +343,7 @@ class FirebaseManager {
     /// place의 특정 날짜의 meetUp들 가져오기
     func fetchMeetUpHistory(placeUid: String, date: Date = Date(), completion: @escaping([MeetUp]) -> Void) {
         let date = date.toDateString()        
-        ref.child("meetUpPlace/\(placeUid)/\(date)").observe(.value, with: { snapshots in
+        refMeetUpPlace.child("\(placeUid)/\(date)").observe(.value, with: { snapshots in
             var meetUpHistory: [MeetUp] = []
             for child in snapshots.children {
                 guard let snapshot = child as? DataSnapshot else { return }

--- a/BNomad/Application/SceneDelegate.swift
+++ b/BNomad/Application/SceneDelegate.swift
@@ -17,7 +17,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         _ = RCValue.shared
-        
+        Database.database().isPersistenceEnabled = true
+
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
         


### PR DESCRIPTION
## 작업 내용
- 불필요한 네트워크 비용을 줄이기 위해서 캐시 처리를 했습니다.
- 실시간으로 변경이 필요한 meetUpPlace 부분은 캐시 처리를 제외시켰습니다.
- 캐시 처리로 인해 오프라인에서도 작동을 합니다.
- meetUpPlace를 제외하고는 동기화 속도가 느려질 수 있습니다.

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
