### PR TITLE
[Enhancement] Spot 아이콘 변경

### DIFF
--- a/BNomad/View/MapView/MapViewController.swift
+++ b/BNomad/View/MapView/MapViewController.swift
@@ -187,18 +187,21 @@ class MapViewController: UIViewController {
         let allPlaceAction = UIAction(title: "모든 스팟", handler: { _ in
             self.map.removeAnnotations(self.map.annotations)
             self.map.addAnnotations(self.allAnnotation)
+            self.visitedPlaceMenu.setImage(UIImage(systemName: "pin"), for: .normal)
         })
         
         let visitedPlaceAction = UIAction(title: "방문한 스팟", handler: { _ in
             self.map.removeAnnotations(self.map.annotations)
             self.visitedPlacesMapping()
             self.map.addAnnotations(self.visitedAnnotation)
+            self.visitedPlaceMenu.setImage(UIImage(systemName: "pin.fill"), for: .normal)
         })
         
         let newPlaceAction = UIAction(title: "새로운 스팟", handler: { _ in
             self.map.removeAnnotations(self.map.annotations)
             self.visitedPlacesMapping()
             self.map.addAnnotations(self.newAnnotation)
+            self.visitedPlaceMenu.setImage(UIImage(systemName: "pin.fill"), for: .normal)
         })
         
         allPlaceAction.state = .on // 기본적으로는 '모든 스팟'에 체크되어 있음
@@ -209,7 +212,7 @@ class MapViewController: UIViewController {
         btn.showsMenuAsPrimaryAction = true
         btn.menu = menu
         btn.backgroundColor = mapBtnBackgroundColor
-        btn.setImage(UIImage(systemName: "square.on.square"), for: .normal)
+        btn.setImage(UIImage(systemName: "pin"), for: .normal)
         btn.tintColor = CustomColor.nomadBlue
         btn.layer.cornerRadius = 4
         btn.layer.borderColor = CustomColor.nomadBlue?.cgColor

--- a/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
+++ b/BNomad/View/PlaceInfoView/PlaceInfoModalViewController.swift
@@ -33,6 +33,8 @@ class PlaceInfoModalViewController: UIViewController {
     
     lazy var viewModel: CombineViewModel = CombineViewModel.shared
     
+//    var distanceCheckTimer = Timer()
+    
     let placeInfoCollectionView: UICollectionView = {
         let flowlayout = UICollectionViewFlowLayout()
         let placeInfoCollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowlayout)
@@ -81,6 +83,25 @@ class PlaceInfoModalViewController: UIViewController {
         }
     }
     
+    
+    // 타이머 방식으로 시도했으나 추후 수정하여 재반영 예정
+//    func startDistanceChecker() {
+//        print("스타트")
+//        distanceCheckTimer = Timer.scheduledTimer(timeInterval: 5, target: self, selector: #selector(distanceCheckerInterval), userInfo: nil, repeats: true)
+//    }
+//
+//    // 600초 -> 10분 간격으로 체크인한 장소와의 거리를 측정해서 500m 이상 멀어지면 자동 체크아웃
+//    @objc func distanceCheckerInterval() {
+//        print("인터벌")
+//        guard let userLocation = currentLocation?.coordinate else { return }
+//        print("user")
+//        guard let checkedPlace = viewModel.checkInPlace else { return }
+//        print("place")
+//
+//        let distance = CustomCollectionViewCell.calculateDistance(latitude1: userLocation.latitude, latitude2: checkedPlace.latitude, longitude1: userLocation.longitude, longitude2: checkedPlace.longitude)
+//        print("checkInDistance: ", distance)
+//    }
+    
     func checkIn() {
         print("CHECK IN")
         locationCheck()
@@ -105,7 +126,6 @@ class PlaceInfoModalViewController: UIViewController {
                     self.checkInFirebase()
                     self.delegateForFloating?.checkInFloating()
                     self.presentPlaceCheckInView()
-                    
                     print(checkInAlert.textFields?[0].text)
                 }))
                 
@@ -146,6 +166,7 @@ class PlaceInfoModalViewController: UIViewController {
             }
             self.delegateForFloating?.checkInFloating()
         }
+//        startDistanceChecker()
     }
     
     func checkOut() {
@@ -213,7 +234,7 @@ class PlaceInfoModalViewController: UIViewController {
     }
     
     func distanceChecker() -> Bool {
-        let boundary = CLCircularRegion(center: currentLocation?.coordinate ?? CLLocationCoordinate2D(latitude: 0, longitude: 0), radius: 1000, identifier: "반경 500m")
+        let boundary = CLCircularRegion(center: currentLocation?.coordinate ?? CLLocationCoordinate2D(latitude: 0, longitude: 0), radius: 500, identifier: "반경 500m")
         guard let selectedPlace = selectedPlace else { return false }
         if boundary.contains(CLLocationCoordinate2D(latitude: selectedPlace.latitude, longitude: selectedPlace.longitude)) {
             return true
@@ -223,6 +244,7 @@ class PlaceInfoModalViewController: UIViewController {
     }
     
     func locationCheck(){
+        // authorizationStatus가 iOS14 이후로 삭제된다고 하는데 대체 코드 필요
         let status = CLLocationManager.authorizationStatus()
         
         if status == CLAuthorizationStatus.denied || status == CLAuthorizationStatus.restricted {


### PR DESCRIPTION
## 관련 이슈들
- #314 

## 작업 내용
- 아이콘 변경, 스팟 골라보기 선택 시 색상 변경하여 선택 중임을 표시
- 자동 체크아웃 위한 타이머 기능은 추후 구현

## 리뷰 노트
- 자동 체크아웃을 구현하는 방식을 기존에는 시간대별로 (10분? 30분?) 주기적으로 체크하려고 했는데 background에서 처리를 하려면 시간 체크 방식이 유효하지 않은 것 같습니다. (앱을 1시간만에 켰을 때 그때서 즉시 체크아웃 처리를 해준다면 애초에 10분, 30분 주기가 무의미)
- 오히려 거리를 크게 벗어났을 때 이벤트 처리를 해주는 방식이 시간대 체크보다는 의미가 있을 것 같은데, 대신 거리 체크를 하려면 위치정보 항상 제공, 백그라운드에서 위치 체크 허용 등 유저가 젠리 수준으로 받아들여야 하는 부분이 많은 것 같습니다. (아래 참조 링크들 기반으로 추가 논의 필요)

## 스크린샷(UX의 경우 gif)


## Reference
- https://developer.apple.com/documentation/corelocation/handling_location_updates_in_the_background
- https://aircook.tistory.com/entry/Location-updates-in-Background-Modes
- https://hyesunzzang.tistory.com/257

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
