### PR TITLE
[Feat] #329 지난 밋업 관련 수정

### DIFF
--- a/BNomad/View/MeetUpView/MeetUpViewController.swift
+++ b/BNomad/View/MeetUpView/MeetUpViewController.swift
@@ -27,11 +27,14 @@ class MeetUpViewController: UIViewController {
             
             guard let participants = currentPeopleUids else { return }
             guard let user = viewModel.user?.userUid else { return }
-                
-            if participants.contains(user) {
-                configJoinCancelButton()
+               
+            if meetUp.time.compare(Date()) == .orderedAscending {
+                configPastMeetUpButton()
+            } else {
+                if participants.contains(user) {
+                    configJoinCancelButton()
+                }
             }
-            
         }
     }
     
@@ -228,6 +231,16 @@ class MeetUpViewController: UIViewController {
         joinButton.setTitleColor(CustomColor.nomadBlue, for: .normal)
         joinButton.removeTarget(self, action: #selector(joinMeetUp), for: .touchUpInside)
         joinButton.addTarget(self, action: #selector(cancelJoinMeetUp), for: .touchUpInside)
+    }
+    
+    func configPastMeetUpButton() {
+        joinButton.setTitle("모임시간이 지났습니다.", for: .normal)
+        joinButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        joinButton.backgroundColor = CustomColor.nomadGray1
+        joinButton.setTitleColor(UIColor.white, for: .normal)
+        joinButton.layer.borderWidth = 0
+        joinButton.removeTarget(self, action: #selector(joinMeetUp), for: .touchUpInside)
+        joinButton.removeTarget(self, action: #selector(cancelJoinMeetUp), for: .touchUpInside)
     }
     
     func configUI() {

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -239,12 +239,20 @@ extension PlaceCheckInViewController: CheckOutAlert {
         alert.addAction(UIAlertAction(title: "취소", style: .cancel))
         alert.addAction(UIAlertAction(title: "확인", style: .default, handler: { action in
             self.checkOut()
+            guard let meetUpViewModels = self.meetUpViewModels else { return }
             FirebaseManager.shared.fetchMeetUpUidAll(userUid: self.viewModel.user?.userUid ?? "") { meetUpUid in
-                FirebaseManager.shared.getPlaceUidWithMeetUpId(meetUpUid: meetUpUid) { placeUid in
-                    FirebaseManager.shared.cancelMeetUp(userUid: self.viewModel.user?.userUid ?? "", meetUpUid: meetUpUid, placeUid: placeUid) {
+                FirebaseManager.shared.fetchMeetUp(meetUpUid: meetUpUid) { meetUp in
+                    if meetUp.time.compare(Date()) != .orderedAscending {
+                        FirebaseManager.shared.getPlaceUidWithMeetUpId(meetUpUid: meetUpUid) { placeUid in
+                            FirebaseManager.shared.cancelMeetUp(userUid: self.viewModel.user?.userUid ?? "", meetUpUid: meetUpUid, placeUid: placeUid) {
+                            }
+                        }
                     }
+                    
                 }
             }
+            
+            
         }))
         present(alert, animated: true)
     }

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -271,10 +271,4 @@ extension PlaceCheckInViewController: PlaceInfoViewCellDelegate {
         vc.meetUpViewModel = meetUpViewModel
         navigationController?.pushViewController(vc, animated: true)
     }
-    
-    func didTapPastMeetUpCell(_ cell: PlaceInfoViewCell) {
-        let alert = UIAlertController(title: "지난 밋업입니다.", message: "지난 밋업은 볼 수 없습니다.", preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "확인", style: .default))
-        present(alert, animated: true)
-    }
 }

--- a/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceInfoViewCell.swift
@@ -13,7 +13,6 @@ protocol NewMeetUpViewShowable {
 
 protocol PlaceInfoViewCellDelegate: AnyObject {
     func didTapMeetUpCell(_ cell: PlaceInfoViewCell, meetUpViewModel: MeetUpViewModel)
-    func didTapPastMeetUpCell(_ cell: PlaceInfoViewCell)
 }
 
 class PlaceInfoViewCell: UICollectionViewCell {
@@ -32,10 +31,13 @@ class PlaceInfoViewCell: UICollectionViewCell {
     var meetUpViewModels: [MeetUpViewModel]? {
         didSet {
             guard let meetUpViewModels = meetUpViewModels else { return }
+            self.sortedMeetUpViewModels = meetUpViewModels.sorted(by: { $0.meetUp?.time ?? Date() > $1.meetUp?.time ?? Date() })
             self.numberOfMeetUp = meetUpViewModels.count
             self.collectionView.reloadData()
         }
     }
+    
+    var sortedMeetUpViewModels: [MeetUpViewModel]?
     
     var numberOfMeetUp: Int? {
         didSet {
@@ -134,15 +136,8 @@ extension PlaceInfoViewCell: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let numberOfMeetUp = numberOfMeetUp else { return }
-        if numberOfMeetUp > 0 {
-            guard let meetUp = meetUpViewModels?[indexPath.item] else { return }
-            if meetUp.meetUp?.time.compare(Date()) == .orderedAscending {
-                placeInfoViewCelldelegate?.didTapPastMeetUpCell(self)
-            } else {
-                placeInfoViewCelldelegate?.didTapMeetUpCell(self, meetUpViewModel: meetUp)
-            }
-        }
+        guard let meetUp = sortedMeetUpViewModels?[indexPath.item] else { return }
+        placeInfoViewCelldelegate?.didTapMeetUpCell(self, meetUpViewModel: meetUp)
     }
 }
 
@@ -164,7 +159,7 @@ extension PlaceInfoViewCell: UICollectionViewDataSource {
         
         if let numberOfMeetUp = numberOfMeetUp {
             if numberOfMeetUp > 0 {
-                meetUpCell.meetUpViewModel = self.meetUpViewModels?[indexPath.item]
+                meetUpCell.meetUpViewModel = self.sortedMeetUpViewModels?[indexPath.item]
                 return meetUpCell
             } else {
                 return noMeetUpcell

--- a/BNomad/View/SettingView/SettingViewController.swift
+++ b/BNomad/View/SettingView/SettingViewController.swift
@@ -100,8 +100,12 @@ extension SettingViewController: UITableViewDelegate {
                                 self.viewModel.user?.checkInHistory?[index] = checkIn
                                 self.viewModel.user = nil
                                 FirebaseManager.shared.fetchMeetUpUidAll(userUid: userUid ?? "") { uid in
-                                    FirebaseManager.shared.getPlaceUidWithMeetUpId(meetUpUid: uid) { placeUid in
-                                        FirebaseManager.shared.cancelMeetUp(userUid: userUid ?? "", meetUpUid: uid, placeUid: placeUid) {
+                                    FirebaseManager.shared.fetchMeetUp(meetUpUid: uid) { meetUp in
+                                        if meetUp.time.compare(Date()) != .orderedAscending {
+                                            FirebaseManager.shared.getPlaceUidWithMeetUpId(meetUpUid: uid) { placeUid in
+                                                FirebaseManager.shared.cancelMeetUp(userUid: userUid ?? "", meetUpUid: uid, placeUid: placeUid) {
+                                                }
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
## 관련 이슈들
- #329 

## 작업 내용
- 밋업을 시간 순으로 정렬했습니다. (지난 밋업이 맨 나중에 보이도록)
- 지난 밋업을 누르면 참여하기/취소 버튼이 아니라 지난 모임이라는 버튼으로 나오고 눌리지 않습니다.
- 로그아웃, 체크아웃을 해도 지난 밋업은 참여 취소가 되지 않습니다.

## 리뷰 포인트
- 체크아웃 시 Firebase.shared 함수가 4중, 5중으로 들어가 있습니다..

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
