### PR TITLE
[Bug] #341 체크인뷰 오늘의 목표 데이터 바인딩 오류 수정

### DIFF
--- a/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
@@ -30,7 +30,7 @@ class CheckInCardViewCell: UICollectionViewCell {
         didSet {
             userNameLabel.text = user?.nickname
             userOccupationLabel.text = user?.occupation
-            userStatusMessage.text = user?.introduction
+            userStatusMessage.text = user?.currentCheckIn?.todayGoal
             if let profileImageUrl = user?.profileImageUrl {
                 self.profileImageView.kf.setImage(with: URL(string: profileImageUrl))
             } else {

--- a/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
+++ b/BNomad/View/PlaceCheckInView/PlaceCheckInViewController.swift
@@ -134,13 +134,15 @@ extension PlaceCheckInViewController: UICollectionViewDataSource {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CheckedProfileListViewCell.identifier, for: indexPath) as? CheckedProfileListViewCell else { return UICollectionViewCell() }
             guard let checkIn = checkInHistory else { return UICollectionViewCell() }
             var userUids = checkIn.compactMap {$0.userUid}
+            var goals = checkIn.compactMap {$0.todayGoal}
             if let myUid = viewModel.user?.userUid {
                 if let index = userUids.firstIndex(of: myUid) {
                     userUids.remove(at: index)
+                    goals.remove(at: index)
                 }
             }
             cell.userUid = userUids[indexPath.row]
-            cell.todayGoal = checkIn[indexPath.row].todayGoal
+            cell.todayGoal = goals[indexPath.row]
             return cell
         }
         return UICollectionViewCell()


### PR DESCRIPTION
## 관련 이슈들
- #341 

## 작업 내용
- 체크인뷰의 오늘의 목표 데이터 바인딩을 수정했습니다.
    - 상단에 자기 자신의 자기소개가 나오고 있어서 오늘의 목표로 수정했습니다.
    - 하단 노마드 목록에는 자기 자신이 제외되었는데, 오늘의 목표는 자기 자신의 것을 포함해서 표시하고 있던 것을 수정했습니다.

## 스크린샷(UX의 경우 gif)
<img width="300" alt="Screen Shot 2022-11-29 at 12 07 13 PM" src="https://user-images.githubusercontent.com/103012157/204428984-3ebcf8a8-77fd-41ca-85e8-d6999187ba13.png">

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
