### PR TITLE
[Feat] 캘린더뷰 스크롤 및 버그픽스, 비짓카드 데이터 바인딩

### DIFF
--- a/BNomad/View/ProfileView/CalendarViewController.swift
+++ b/BNomad/View/ProfileView/CalendarViewController.swift
@@ -45,7 +45,7 @@ class CalendarViewController: UIViewController {
         return collectionView
     }()
     
-    private let visitInfoView: UICollectionView = {
+    private let visitCardView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
@@ -93,7 +93,7 @@ class CalendarViewController: UIViewController {
         let button = UIButton()
         button.setImage(UIImage(systemName: "chevron.right"), for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
-        button.tintColor = .gray
+        button.tintColor = CustomColor.nomadBlue
         return button
     }()
     
@@ -101,10 +101,22 @@ class CalendarViewController: UIViewController {
         let button = UIButton()
         button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
-        button.tintColor = .gray
+        button.tintColor = CustomColor.nomadBlue
         return button
     }()
     
+    let scrollView: UIScrollView = {
+        let scroll = UIScrollView()
+        scroll.backgroundColor = CustomColor.nomad2White
+        
+        return scroll
+    }()
+    
+    let contentView: UIView = {
+        let ui = UIView()
+        ui.backgroundColor = CustomColor.nomad2White
+        return ui
+    }()
     
     // MARK: - Lifecycle
     
@@ -121,8 +133,8 @@ class CalendarViewController: UIViewController {
         calendarCollectionView.dataSource = self
         calendarCollectionView.delegate = self
         
-        visitInfoView.dataSource = self
-        visitInfoView.delegate = self
+        visitCardView.dataSource = self
+        visitCardView.delegate = self
         
         visitCardListView.dataSource = self
         visitCardListView.delegate = self
@@ -172,7 +184,7 @@ class CalendarViewController: UIViewController {
             
             calendarCollectionView.removeFromSuperview()
             calendarCollectionMonthHeader.removeFromSuperview()
-            visitInfoView.removeFromSuperview()
+            visitCardView.removeFromSuperview()
             dayOfWeekStackView.removeFromSuperview()
             minusMonthButton.removeFromSuperview()
             plusMonthButton.removeFromSuperview()
@@ -190,27 +202,37 @@ class CalendarViewController: UIViewController {
     
     func render() {
         
-        view.addSubview(calendarCollectionView)
-        calendarCollectionView.anchor(top: view.topAnchor, left: view.leftAnchor, right: view.rightAnchor,
-                                      paddingTop: 105, paddingLeft: 14, paddingRight: 14,
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+        
+        scrollView.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
+        contentView.anchor(top: scrollView.topAnchor, left: scrollView.leftAnchor, bottom: scrollView.bottomAnchor, right: scrollView.rightAnchor)
+
+        let contentViewHeight = contentView.heightAnchor.constraint(greaterThanOrEqualTo: view.heightAnchor)
+        contentViewHeight.priority = .defaultLow
+        contentViewHeight.isActive = true
+        
+        scrollView.addSubview(calendarCollectionView)
+        calendarCollectionView.anchor(top: scrollView.topAnchor, left: view.leftAnchor, right: view.rightAnchor,
+                                      paddingTop: 20, paddingLeft: 14, paddingRight: 14,
                                       height: 388)
         
-        view.addSubview(calendarCollectionMonthHeader)
+        scrollView.addSubview(calendarCollectionMonthHeader)
         calendarCollectionMonthHeader.anchor(top: calendarCollectionView.topAnchor, left: calendarCollectionView.leftAnchor, paddingTop: 10, paddingLeft: 20)
-        calendarCollectionMonthHeader.centerX(inView: view)
+        calendarCollectionMonthHeader.centerX(inView: scrollView)
         
-        view.addSubview(dayOfWeekStackView)
+        scrollView.addSubview(dayOfWeekStackView)
         dayOfWeekStackView.anchor(top: calendarCollectionMonthHeader.bottomAnchor, paddingTop: 15, width: 358-358/7)
-        dayOfWeekStackView.centerX(inView: view)
+        dayOfWeekStackView.centerX(inView: scrollView)
         
-        view.addSubview(minusMonthButton)
+        scrollView.addSubview(minusMonthButton)
         minusMonthButton.anchor(top: calendarCollectionView.topAnchor, right: dayOfWeekStackView.rightAnchor, paddingTop: 15, paddingRight: 50)
-        view.addSubview(plusMonthButton)
+        scrollView.addSubview(plusMonthButton)
         plusMonthButton.anchor(top: calendarCollectionView.topAnchor, right: dayOfWeekStackView.rightAnchor, paddingTop: 15)
         
-        view.addSubview(visitInfoView)
-        visitInfoView.anchor(top: calendarCollectionView.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor,
-                                paddingTop: 24, paddingLeft: 14, paddingRight: 14, height: 256)
+        scrollView.addSubview(visitCardView)
+        visitCardView.anchor(top: calendarCollectionView.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor,
+                                paddingTop: 24, paddingLeft: 14, paddingRight: 14, height: 1000)
         
     }
     
@@ -234,7 +256,7 @@ extension CalendarViewController: UICollectionViewDataSource {
         case calendarCollectionView:
             return self.calendarDateFormatter.days.count
 
-        case visitInfoView:
+        case visitCardView:
             return max(cardDataList.count, 1)
 
         case visitCardListView:
@@ -299,7 +321,7 @@ extension CalendarViewController: UICollectionViewDelegate {
             
             return cell
             
-        case visitInfoView:
+        case visitCardView:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitCardCell.identifier , for: indexPath) as? VisitCardCell else {
                 return UICollectionViewCell()
             }
@@ -322,7 +344,7 @@ extension CalendarViewController: UICollectionViewDelegate {
             cell.layer.cornerRadius = 20
             
             let checkinHistoryCount = CalendarViewController.checkInHistory?.count
-            cell.checkInHistoryForCalendar = CalendarViewController.checkInHistory?[(checkinHistoryCount ?? 0)-indexPath.item-1]
+            cell.checkInHistoryForCalendar = CalendarViewController.checkInHistory?[(checkinHistoryCount ?? 0)-indexPath.section-1]
             
             return cell
             
@@ -349,7 +371,7 @@ extension CalendarViewController: UICollectionViewDelegate {
             }
             
             calendarCollectionView.reloadData()
-            visitInfoView.reloadData()
+            visitCardView.reloadData()
         }
     }
     
@@ -375,20 +397,23 @@ extension CalendarViewController: UICollectionViewDelegateFlowLayout {
             return CGSize(width: 358/8, height: 358/7)
         }
         
-        return CGSize(width: visitInfoView.frame.width, height: 119)
+        return CGSize(width: visitCardView.frame.width, height: 100)
         
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         if collectionView == visitCardListView {
-            return CGSize(width: view.frame.size.width, height: 50)
+            return CGSize(width: view.frame.size.width, height: 40)
         }
         return .zero
     }
     
     //cell 횡간 간격
        func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat{
-           return CGFloat(0)
+           if collectionView == visitCardView {
+               return CGFloat(10)
+           }
+           return 0
        }
        
        //cell 종간 간격

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -206,8 +206,8 @@ extension ProfileViewController: UICollectionViewDelegate {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: VisitCardCell.identifier , for: indexPath) as? VisitCardCell else {
                 return UICollectionViewCell()
             }
-            cell.layer.borderWidth = 2
-            cell.layer.borderColor = CustomColor.nomadBlue?.cgColor
+//            cell.layer.borderWidth = 2
+//            cell.layer.borderColor = CustomColor.nomadBlue?.cgColor
             cell.checkInHistoryForProfile = nomad?.checkInHistory
             cell.backgroundColor = .white
             cell.layer.cornerRadius = 20
@@ -266,7 +266,7 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
         case 0:
             return CGSize(width: profileCollectionView.frame.width, height: 182)
         case 1:
-            return CGSize(width: profileCollectionView.frame.width, height: 119)
+            return CGSize(width: profileCollectionView.frame.width, height: 100)
         case 2:
             return CGSize(width: profileCollectionView.frame.width, height: 220)
         default:

--- a/BNomad/View/ProfileView/VisitCardCell.swift
+++ b/BNomad/View/ProfileView/VisitCardCell.swift
@@ -24,8 +24,11 @@ class VisitCardCell: UICollectionViewCell {
                 
             }
             
-                rectView.removeFromSuperview()
-                nilLabel.removeFromSuperview()
+            rectView.removeFromSuperview()
+            nilLabel.removeFromSuperview()
+            
+            checkinCommentLabel.text = checkInHistory.todayGoal
+            
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "M월 d일"
             
@@ -56,8 +59,10 @@ class VisitCardCell: UICollectionViewCell {
                 
             }
             
-                rectView.removeFromSuperview()
-                nilLabel.removeFromSuperview()
+            rectView.removeFromSuperview()
+            nilLabel.removeFromSuperview()
+            
+            checkinCommentLabel.text = lastCheckIn.todayGoal
             
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "M월 d일"
@@ -83,6 +88,8 @@ class VisitCardCell: UICollectionViewCell {
             self.stayedTimeLabel.text = String(Int(stayedTime/60))+"시간 "+String(stayedTime%60)+"분"
             
             nameLabel.reloadInputViews()
+            
+
         }
     }
     static let identifier = "VisitingInfoCell"
@@ -138,7 +145,16 @@ class VisitCardCell: UICollectionViewCell {
         let label = UILabel()
         label.text = ""
         label.font = UIFont.systemFont(ofSize: 13)
-        label.textColor = .gray
+        label.textColor = CustomColor.nomadGray1
+        label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
+        return label
+    }()
+    
+    private let checkinCommentLabel: UILabel = {
+        let label = UILabel()
+        label.text = "오늘의 목표를 입력하면 여기에 나타납니다."
+        label.font = UIFont.systemFont(ofSize: 13)
+        label.textColor = CustomColor.nomadBlack
         label.font = .preferredFont(forTextStyle: .subheadline, weight: .regular)
         return label
     }()
@@ -188,23 +204,26 @@ class VisitCardCell: UICollectionViewCell {
         contentView.addSubview(checkInAndOutLabel)
         checkInAndOutLabel.anchor(top: nameLabel.bottomAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 2, paddingLeft: 20, paddingRight: 20)
         
-        let stack = [UIStackView(arrangedSubviews: [checkinDateHeadLabel, checkinDateLabel]), UIStackView(arrangedSubviews: [stayedTimeHeadLabel, stayedTimeLabel])]
-        stack.forEach {
-            $0.axis = .vertical
-            $0.spacing = 1
-            $0.distribution = .fillEqually
-            $0.alignment = .center
-        }
+        contentView.addSubview(checkinCommentLabel)
+        checkinCommentLabel.anchor(top: checkInAndOutLabel.bottomAnchor, left: contentView.leftAnchor, right: contentView.rightAnchor, paddingTop: 2, paddingLeft: 20, paddingRight: 20)
         
-        contentView.addSubview(stack[0])
-        stack[0].anchor(top: contentView.topAnchor, left: contentView.leftAnchor, paddingTop: 68, paddingLeft: 50)
-        
-        contentView.addSubview(stack[1])
-        stack[1].anchor(top: contentView.topAnchor, right: contentView.rightAnchor, paddingTop: 68, paddingRight: 50)
-        
-        contentView.addSubview(dividerLine)
-        dividerLine.anchor(top: contentView.topAnchor, paddingTop: 72, width: 1, height: 31)
-        dividerLine.centerX(inView: contentView)
+//        let stack = [UIStackView(arrangedSubviews: [checkinDateHeadLabel, checkinDateLabel]), UIStackView(arrangedSubviews: [stayedTimeHeadLabel, stayedTimeLabel])]
+//        stack.forEach {
+//            $0.axis = .vertical
+//            $0.spacing = 1
+//            $0.distribution = .fillEqually
+//            $0.alignment = .center
+//        }
+//
+//        contentView.addSubview(stack[0])
+//        stack[0].anchor(top: contentView.topAnchor, left: contentView.leftAnchor, paddingTop: 68, paddingLeft: 50)
+//
+//        contentView.addSubview(stack[1])
+//        stack[1].anchor(top: contentView.topAnchor, right: contentView.rightAnchor, paddingTop: 68, paddingRight: 50)
+//
+//        contentView.addSubview(dividerLine)
+//        dividerLine.anchor(top: contentView.topAnchor, paddingTop: 72, width: 1, height: 31)
+//        dividerLine.centerX(inView: contentView)
         
     }
     


### PR DESCRIPTION
## 관련 이슈들


## 작업 내용
- 캘린더뷰 스크롤이 가능합니다
- 캘린더뷰에서 세개 이상의 카드를 볼 수 있습니다
- 프로필뷰 이하 뷰에서 note가 바인딩되어 나옵니다
- Todo: 캘린더, 리스트 순서변경

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img width="300" alt="스크린샷 2022-12-07 13 18 49" src="https://user-images.githubusercontent.com/70618615/206087239-f7e5712e-dc0c-422b-b24f-56694d2df4bd.png">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
