### PR TITLE
[Enhancement] #350 annotation load 로드 시간 단축

### DIFF
--- a/BNomad/API/FirebaseManager.swift
+++ b/BNomad/API/FirebaseManager.swift
@@ -35,7 +35,7 @@ class FirebaseManager {
     //            address
 
     /// 모든 PlaceData를 가져오기
-    func fetchPlaceAll(completion: @escaping(Place) -> Void) {
+    func fetchPlaceAll(completion: @escaping(Place) -> Void) async {
         ref.child("places").observeSingleEvent(of: .value, with: { snapshot in
             for child in snapshot.children {
                 guard

--- a/BNomad/API/FirebaseTestVC.swift
+++ b/BNomad/API/FirebaseTestVC.swift
@@ -60,8 +60,8 @@ class FirebaseTestVC: UIViewController {
         uploadUserProfileImage()
     }
     
-    func fetchPlaceAll() {
-        FirebaseManager.shared.fetchPlaceAll { place in
+    func fetchPlaceAll() async {
+        await FirebaseManager.shared.fetchPlaceAll { place in
             print(place)
         }
     }


### PR DESCRIPTION
## 관련 이슈들
- #350 

## 작업 내용
- Place를 로드할때마다 binding체크를 해주던 이전의 코드에서 모든 place를 로드한 이후, binding 체크해주는 방향으로 바꾸어서 초기 로드 시간을 줄였습니다.
- `fetchAllPlaces()` 함수에 `async await` 로 모든 place가 로드되는 것을 보장하도록 만들어주었습니다.
- 사용하지 않을 것 같은 주석은 조금 삭제해 두었습니다.

## 리뷰 노트
- 비동기로 들어가야 async, await 를 사용할 수 있기에 `bindingPlaceLocationStatus()`에서 `Task`를 사용해 주었는데, 이를 제외하고 더 좋은 방법이 있다면 알려주심 감사하겠씁니다!

## 스크린샷(UX의 경우 gif)
기존: 
![Simulator Screen Recording - iPhone 14 Pro - 2022-12-10 at 17 15 56](https://user-images.githubusercontent.com/72736657/206841698-cfebc439-7674-4ecd-bb4d-1878fccc57da.gif)

현재:
![Simulator Screen Recording - iPhone 14 Pro - 2022-12-10 at 17 44 00](https://user-images.githubusercontent.com/72736657/206841720-a78fd780-498f-4203-a7cd-cb4bcf8ea957.gif)

## Reference
- [Async Await](https://www.youtube.com/watch?v=-5kIzkBqAzc&t=20s)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
