### PR TITLE
[Bug+Enhancement] 프로필 이미지를 위한 class 만들고, UIImageView들 교체

### DIFF
--- a/BNomad.xcodeproj/project.pbxproj
+++ b/BNomad.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		8C21CC4528FF89BA009043AF /* MapData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C21CC4428FF89BA009043AF /* MapData.swift */; };
 		8CC750912919F330009F9C91 /* RegionSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC750902919F330009F9C91 /* RegionSelectViewController.swift */; };
 		8CC750932919F3BE009F9C91 /* RegionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC750922919F3BE009F9C91 /* RegionCollectionViewCell.swift */; };
+		DF0C2E0229582FD9004B3F09 /* ProfileUIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0C2E0129582FD9004B3F09 /* ProfileUIImageView.swift */; };
 		DF288B4F28F7D70F002838A4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF288B4E28F7D70F002838A4 /* AppDelegate.swift */; };
 		DF288B5128F7D70F002838A4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF288B5028F7D70F002838A4 /* SceneDelegate.swift */; };
 		DF288B5828F7D710002838A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DF288B5728F7D710002838A4 /* Assets.xcassets */; };
@@ -116,6 +117,7 @@
 		8C21CC4428FF89BA009043AF /* MapData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapData.swift; sourceTree = "<group>"; };
 		8CC750902919F330009F9C91 /* RegionSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionSelectViewController.swift; sourceTree = "<group>"; };
 		8CC750922919F3BE009F9C91 /* RegionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCollectionViewCell.swift; sourceTree = "<group>"; };
+		DF0C2E0129582FD9004B3F09 /* ProfileUIImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUIImageView.swift; sourceTree = "<group>"; };
 		DF288B4B28F7D70F002838A4 /* BNomad.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BNomad.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF288B4E28F7D70F002838A4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DF288B5028F7D70F002838A4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 				DF9618A128FCEF0D00E21D30 /* LoginView */,
 				DF9618A228FCEF1200E21D30 /* SignUpView */,
 				DF9618A028FCEF0500E21D30 /* ProfileView */,
+				DF0C2E0129582FD9004B3F09 /* ProfileUIImageView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -545,6 +548,7 @@
 				DF288B4F28F7D70F002838A4 /* AppDelegate.swift in Sources */,
 				8C21CC4128FF8018009043AF /* PlaceAnnotation.swift in Sources */,
 				F6DFE0B7291B2CF900C808AF /* ReviewDetailViewController.swift in Sources */,
+				DF0C2E0229582FD9004B3F09 /* ProfileUIImageView.swift in Sources */,
 				041351A328FF7E98005D19CC /* ProfileGraphCell.swift in Sources */,
 				DF561CA52918A0B40099D41D /* MeetUpViewController.swift in Sources */,
 				7EC6F9EE28FE39CB003D8A95 /* UIFont+Extension.swift in Sources */,

--- a/BNomad/View/MeetUpView/ParticipantCell.swift
+++ b/BNomad/View/MeetUpView/ParticipantCell.swift
@@ -47,7 +47,7 @@ class ParticipantCell: UICollectionViewCell {
     }()
     
     private let profileImageView: ProfileUIImageView = {
-        let imageView = ProfileUIImageView(widthToRadius: Size.screenAspectProfile)
+        let imageView = ProfileUIImageView(widthRatio: Size.screenAspectProfile)
         imageView.tintColor = CustomColor.nomadGray1
         return imageView
     }()

--- a/BNomad/View/MeetUpView/ParticipantCell.swift
+++ b/BNomad/View/MeetUpView/ParticipantCell.swift
@@ -14,6 +14,10 @@ class ParticipantCell: UICollectionViewCell {
     
     static let identifier = "ParticipantCell"
     
+    enum Size {
+        static let screenAspectProfile = UIScreen.main.bounds.width * 58/390
+    }
+    
     var userUid: String? {
         didSet {
             guard let userUid = userUid else { return }
@@ -21,8 +25,6 @@ class ParticipantCell: UICollectionViewCell {
                 self.nicknameLabel.text = user.nickname
                 if let profileImageUrl = user.profileImageUrl {
                     self.profileImageView.kf.setImage(with: URL(string: profileImageUrl))
-                } else {
-                    self.profileImageView.image = UIImage(systemName: "person.crop.circle.fill")
                 }
             }
             
@@ -44,13 +46,10 @@ class ParticipantCell: UICollectionViewCell {
         return image
     }()
     
-    private let profileImageView: UIImageView = {
-        let image = UIImageView()
-        image.tintColor = CustomColor.nomadGray1
-        image.clipsToBounds = true
-        image.contentMode = .scaleAspectFill
-        
-        return image
+    private let profileImageView: ProfileUIImageView = {
+        let imageView = ProfileUIImageView(widthToRadius: Size.screenAspectProfile)
+        imageView.tintColor = CustomColor.nomadGray1
+        return imageView
     }()
     
     private let nicknameLabel: UILabel = {
@@ -79,13 +78,9 @@ class ParticipantCell: UICollectionViewCell {
         crownView.anchor(top: self.topAnchor, width: 22, height: 18)
         crownView.centerX(inView: self)
         
-        let screenWidth = UIScreen.main.bounds.width
-        let profileImageSize = screenWidth * 58/390
-        
         self.addSubview(profileImageView)
-        profileImageView.anchor(top: crownView.bottomAnchor, paddingTop: 8, width: profileImageSize, height: profileImageSize)
+        profileImageView.anchor(top: crownView.bottomAnchor, paddingTop: 8, width: Size.screenAspectProfile, height: Size.screenAspectProfile)
         profileImageView.centerX(inView: self)
-        profileImageView.layer.cornerRadius = profileImageSize / 2
         
         self.addSubview(nicknameLabel)
         nicknameLabel.anchor(top: profileImageView.bottomAnchor, paddingTop: 14)

--- a/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
@@ -83,7 +83,7 @@ class CheckInCardViewCell: UICollectionViewCell {
     }()
 
     private let profileImageView: ProfileUIImageView = {
-        let imageView = ProfileUIImageView(widthToRadius: 80)
+        let imageView = ProfileUIImageView(widthRatio: 80)
         imageView.anchor(width: 80, height: 80)
         imageView.tintColor = CustomColor.nomadGray2
         return imageView

--- a/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckInCardViewCell.swift
@@ -33,8 +33,6 @@ class CheckInCardViewCell: UICollectionViewCell {
             userStatusMessage.text = user?.currentCheckIn?.todayGoal
             if let profileImageUrl = user?.profileImageUrl {
                 self.profileImageView.kf.setImage(with: URL(string: profileImageUrl))
-            } else {
-                self.profileImageView.image = UIImage(systemName: "person.circle.fill")
             }
         }
     }
@@ -84,16 +82,11 @@ class CheckInCardViewCell: UICollectionViewCell {
         return view
     }()
 
-    private let profileImageView: UIImageView = {
-        let view = UIImageView()
-        view.image = UIImage(systemName: "person.circle.fill")
-        view.tintColor = CustomColor.nomadGray2
-        view.anchor(width: 80, height: 80)
-        view.layer.cornerRadius = 80/2
-        view.contentMode = .scaleAspectFill
-        view.clipsToBounds = true
-        
-        return view
+    private let profileImageView: ProfileUIImageView = {
+        let imageView = ProfileUIImageView(widthToRadius: 80)
+        imageView.anchor(width: 80, height: 80)
+        imageView.tintColor = CustomColor.nomadGray2
+        return imageView
     }()
     
     private lazy var userNameLabel: UILabel = {

--- a/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
@@ -37,19 +37,14 @@ class CheckedProfileListViewCell: UICollectionViewCell {
             occupationLabel.text = user.occupation
             if let profileImageUrl = user.profileImageUrl {
                 self.userProfileImg.kf.setImage(with: URL(string: profileImageUrl))
-            } else {
-                self.userProfileImg.image = UIImage(systemName: "person.circle.fill")
             }
         }
     }
     
-    private let userProfileImg: UIImageView = {
-        let userProfileImg = UIImageView()
-        userProfileImg.tintColor = CustomColor.nomadGray2
-        userProfileImg.translatesAutoresizingMaskIntoConstraints = false
-        userProfileImg.clipsToBounds = true
-        userProfileImg.contentMode = .scaleAspectFill
-        return userProfileImg
+    private let userProfileImg: ProfileUIImageView = {
+        let imageView = ProfileUIImageView(widthToRadius: 50)
+        imageView.tintColor = CustomColor.nomadGray2
+        return imageView
     }()
     
     private let usernameLabel: UILabel = {
@@ -92,7 +87,6 @@ class CheckedProfileListViewCell: UICollectionViewCell {
         self.addSubview(userProfileImg)
         userProfileImg.anchor(left: self.leftAnchor, paddingLeft: 14, width: 50, height: 50)
         userProfileImg.centerY(inView: self)
-        userProfileImg.layer.cornerRadius = 50/2
         
         let nameJobStack = UIStackView(arrangedSubviews: [usernameLabel, occupationLabel])
         nameJobStack.axis = .horizontal

--- a/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/CheckedProfileListViewCell.swift
@@ -42,7 +42,7 @@ class CheckedProfileListViewCell: UICollectionViewCell {
     }
     
     private let userProfileImg: ProfileUIImageView = {
-        let imageView = ProfileUIImageView(widthToRadius: 50)
+        let imageView = ProfileUIImageView(widthRatio: 50)
         imageView.tintColor = CustomColor.nomadGray2
         return imageView
     }()

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -110,7 +110,7 @@ class QuestCollectionViewCell: UICollectionViewCell {
     }()
     
     var organizerImage: ProfileUIImageView = {
-        let imageView = ProfileUIImageView(widthToRadius: Size.screenAspectProfile)
+        let imageView = ProfileUIImageView(widthRatio: Size.screenAspectProfile)
         imageView.tintColor = CustomColor.nomadGray1
         return imageView
     }()

--- a/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
+++ b/BNomad/View/PlaceCheckInView/QuestCollectionViewCell.swift
@@ -14,6 +14,10 @@ class QuestCollectionViewCell: UICollectionViewCell {
     
     static let identifier: String = String(describing: QuestCollectionViewCell.self)
     
+    enum Size {
+        static let screenAspectProfile = UIScreen.main.bounds.width * 36/390
+    }
+    
     let viewModel = CombineViewModel.shared
     
     var meetUpViewModel: MeetUpViewModel? {
@@ -105,14 +109,10 @@ class QuestCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
-    var organizerImage: UIImageView = {
-        let image = UIImageView()
-        image.image = UIImage(systemName: "person.crop.circle.fill")
-        image.tintColor = CustomColor.nomadGray1
-        image.clipsToBounds = true
-        image.contentMode = .scaleAspectFill
-        
-        return image
+    var organizerImage: ProfileUIImageView = {
+        let imageView = ProfileUIImageView(widthToRadius: Size.screenAspectProfile)
+        imageView.tintColor = CustomColor.nomadGray1
+        return imageView
     }()
     
     // MARK: - LifeCycle
@@ -184,12 +184,8 @@ class QuestCollectionViewCell: UICollectionViewCell {
     }
     
     func configurePeopleUI() {
-        let screenWidth = UIScreen.main.bounds.width
-        let organizerImageSize = screenWidth * 36/390
-        
         self.addSubview(organizerImage)
-        organizerImage.anchor(bottom: self.bottomAnchor, right: self.rightAnchor, paddingBottom: 13, paddingRight: 14, width: organizerImageSize, height: organizerImageSize)
-        organizerImage.layer.cornerRadius = organizerImageSize / 2
+        organizerImage.anchor(bottom: self.bottomAnchor, right: self.rightAnchor, paddingBottom: 13, paddingRight: 14, width: Size.screenAspectProfile, height: Size.screenAspectProfile)
         
         self.addSubview(checkedPeople)
         checkedPeople.anchor(bottom: self.bottomAnchor, right: organizerImage.leftAnchor, paddingBottom: 15, paddingRight: 11)

--- a/BNomad/View/PlaceInfoView/ReviewSubCell/ReviewSubCell.swift
+++ b/BNomad/View/PlaceInfoView/ReviewSubCell/ReviewSubCell.swift
@@ -48,7 +48,7 @@ class ReviewSubCell: UICollectionViewCell {
         return reviewImageView
     }()
     
-    var profileImageView = ProfileUIImageView(widthToRadius: 20)
+    var profileImageView = ProfileUIImageView(widthRatio: 20)
     
     lazy var userNameLabel: UILabel = {
         let userNameLabel = UILabel()

--- a/BNomad/View/PlaceInfoView/ReviewSubCell/ReviewSubCell.swift
+++ b/BNomad/View/PlaceInfoView/ReviewSubCell/ReviewSubCell.swift
@@ -21,8 +21,6 @@ class ReviewSubCell: UICollectionViewCell {
                 self.userNameLabel.text = user.nickname
                 if let profileImageUrl = user.profileImageUrl {
                     self.profileImageView.kf.setImage(with: URL(string: profileImageUrl))
-                } else {
-                    self.profileImageView.image = UIImage(systemName: "person.crop.circle.fill")
                 }
             }
             if let reviewImageUrl = review.imageUrl {
@@ -50,13 +48,7 @@ class ReviewSubCell: UICollectionViewCell {
         return reviewImageView
     }()
     
-    var profileImageView: UIImageView = {
-        let profileImageView = UIImageView()
-        profileImageView.layer.cornerRadius = 10
-        profileImageView.clipsToBounds = true
-        profileImageView.contentMode = .scaleAspectFill
-        return profileImageView
-    }()
+    var profileImageView = ProfileUIImageView(widthToRadius: 20)
     
     lazy var userNameLabel: UILabel = {
         let userNameLabel = UILabel()
@@ -87,9 +79,7 @@ class ReviewSubCell: UICollectionViewCell {
     
     private func setAttributes() {
         reviewTextLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 8, paddingLeft: 7)
-        NSLayoutConstraint.activate([
-            reviewImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
-            ])
+        reviewImageView.centerY(inView: self)
         reviewImageView.anchor(right: self.rightAnchor, paddingRight: 7, width: 60, height: 60)
         profileImageView.anchor(top: reviewTextLabel.bottomAnchor, left: self.leftAnchor, paddingTop: 8, paddingLeft: 7, width: 20, height: 20)
         userNameLabel.anchor(top: reviewTextLabel.bottomAnchor, left: profileImageView.rightAnchor, paddingTop: 10, paddingLeft: 8)

--- a/BNomad/View/ProfileUIImageView.swift
+++ b/BNomad/View/ProfileUIImageView.swift
@@ -9,13 +9,13 @@ import UIKit
 
 final class ProfileUIImageView: UIImageView {
     
-    init(widthToRadius: CGFloat) {
+    init(widthRatio: CGFloat) {
         super.init(frame: .zero)
         
         self.image = UIImage(systemName: "person.crop.circle.fill")
         self.contentMode = .scaleAspectFill
         self.clipsToBounds = true
-        self.layer.cornerRadius = widthToRadius / 2
+        self.layer.cornerRadius = widthRatio / 2
     }
     
     required init?(coder: NSCoder) {

--- a/BNomad/View/ProfileUIImageView.swift
+++ b/BNomad/View/ProfileUIImageView.swift
@@ -1,0 +1,25 @@
+//
+//  ProfileUIImageView.swift
+//  BNomad
+//
+//  Created by 박성수 on 2022/12/25.
+//
+
+import UIKit
+
+final class ProfileUIImageView: UIImageView {
+    
+    init(widthToRadius: CGFloat) {
+        super.init(frame: .zero)
+        
+        self.image = UIImage(systemName: "person.crop.circle.fill")
+        self.contentMode = .scaleAspectFill
+        self.clipsToBounds = true
+        self.layer.cornerRadius = widthToRadius / 2
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}

--- a/BNomad/View/ProfileView/ProfileEditView/ProfileEditViewController.swift
+++ b/BNomad/View/ProfileView/ProfileEditView/ProfileEditViewController.swift
@@ -22,11 +22,11 @@ class ProfileEditViewController: UIViewController {
     
     private lazy var profileImageButton: UIButton = {
         let button = UIButton(type: .custom)
-
         button.setImage(self.viewModel.user?.profileImage ?? UIImage(named: "othersProfile"), for: .normal)
         button.addTarget(self, action: #selector(profileImageChange), for: .touchUpInside)
         button.layer.masksToBounds = true
         button.layer.cornerRadius = 78 / 2
+        button.imageView?.contentMode = .scaleAspectFill
         return button
     }()
     

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -50,22 +50,7 @@ class ProfileViewController: UIViewController {
         return ui
     }()
     
-    private lazy var profileImageView: UIImageView = {
-        let iv = UIImageView()
-        iv.contentMode = .scaleAspectFill
-//        if viewModel.user?.profileImage == nil {
-//            if let profileImageUrl = viewModel.user?.profileImageUrl {
-//                iv.kf.setImage(with: URL(string: profileImageUrl))
-//            }
-//        }
-        iv.frame = CGRect(origin: .zero, size: CGSize(width: 120,height: 120))
-        iv.clipsToBounds = true
-        iv.isUserInteractionEnabled = true
-        iv.layer.masksToBounds = true
-        iv.frame = CGRect(origin: .zero, size: CGSize(width: 120, height: 120))
-        iv.layer.cornerRadius = iv.frame.height/2
-        return iv
-    }()
+    private lazy var profileImageView = ProfileUIImageView(widthToRadius: 120)
     
     private let profileCollectionView:  UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -162,7 +147,7 @@ class ProfileViewController: UIViewController {
         scrollView.addSubview(profileImageView)
         scrollView.addSubview(editingButton)
         
-        profileImageView.anchor(top: scrollView.topAnchor, paddingTop: 20, width: profileImageView.frame.width, height: profileImageView.frame.height)
+        profileImageView.anchor(top: scrollView.topAnchor, paddingTop: 20, width: 120, height: 120)
         profileImageView.centerX(inView: view)
         
         profileCollectionView.anchor(top: scrollView.topAnchor, left: scrollView.leftAnchor, right: view.rightAnchor,

--- a/BNomad/View/ProfileView/ProfileViewController.swift
+++ b/BNomad/View/ProfileView/ProfileViewController.swift
@@ -50,7 +50,7 @@ class ProfileViewController: UIViewController {
         return ui
     }()
     
-    private lazy var profileImageView = ProfileUIImageView(widthToRadius: 120)
+    private lazy var profileImageView = ProfileUIImageView(widthRatio: 120)
     
     private let profileCollectionView:  UICollectionView = {
         let layout = UICollectionViewFlowLayout()

--- a/BNomad/View/ProfileView/VisitCardHeaderCollectionView.swift
+++ b/BNomad/View/ProfileView/VisitCardHeaderCollectionView.swift
@@ -9,12 +9,6 @@ import UIKit
 
 class VisitCardHeaderCollectionView: UICollectionReusableView {
     static let identifier = "VisitCardHeaderCollectionView"
-    private let imageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.clipsToBounds = true
-        imageView.contentMode = .scaleAspectFill
-        return imageView
-    }()
     
     private let VisitInfoHeader: UILabel = {
         let content = Contents.todayDate()

--- a/BNomad/View/ReviewView/ReviewCell.swift
+++ b/BNomad/View/ReviewView/ReviewCell.swift
@@ -56,14 +56,8 @@ class ReviewCellWithImage: UICollectionViewCell {
         text.textAlignment = .left
         return text
     }()
-
-    private var userImage: UIImageView = {
-        let image = UIImage(named: "AppIcon")
-        let imageView = UIImageView(image: image)
-        imageView.layer.cornerRadius = imageView.bounds.width/2
-        imageView.clipsToBounds = true
-        return imageView
-    }()
+    
+    private var userImage = ProfileUIImageView(widthToRadius: 20)
     
     private var userName: UILabel = {
         let text = UILabel()
@@ -137,12 +131,9 @@ class ReviewCellWithoutImage: UICollectionViewCell {
         text.textAlignment = .left
         return text
     }()
-
-    private var userImage: UIImageView = {
-        let image = UIImage(named: "AppIcon")
-        let imageView = UIImageView(image: image)
-        imageView.layer.cornerRadius = imageView.bounds.width/2
-        imageView.clipsToBounds = true
+    
+    private var userImage: ProfileUIImageView = {
+        let imageView = ProfileUIImageView(widthToRadius: 20)
         return imageView
     }()
     

--- a/BNomad/View/ReviewView/ReviewCell.swift
+++ b/BNomad/View/ReviewView/ReviewCell.swift
@@ -57,7 +57,7 @@ class ReviewCellWithImage: UICollectionViewCell {
         return text
     }()
     
-    private var userImage = ProfileUIImageView(widthToRadius: 20)
+    private var userImage = ProfileUIImageView(widthRatio: 20)
     
     private var userName: UILabel = {
         let text = UILabel()
@@ -133,7 +133,7 @@ class ReviewCellWithoutImage: UICollectionViewCell {
     }()
     
     private var userImage: ProfileUIImageView = {
-        let imageView = ProfileUIImageView(widthToRadius: 20)
+        let imageView = ProfileUIImageView(widthRatio: 20)
         return imageView
     }()
     

--- a/BNomad/View/SignUpView/SignUpViewController.swift
+++ b/BNomad/View/SignUpView/SignUpViewController.swift
@@ -192,8 +192,9 @@ class SignUpViewController: UIViewController {
     
     private lazy var profileImageButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(systemName: "person.circle.fill"), for: .normal)
+        button.setImage(UIImage(systemName: "person.crop.circle.fill"), for: .normal)
         button.tintColor = CustomColor.nomadGray2
+        button.imageView?.contentMode = .scaleAspectFill
         button.addTarget(self, action: #selector(didTapProfileImageButton), for: .touchUpInside)
         button.layer.masksToBounds = true
         
@@ -228,11 +229,7 @@ class SignUpViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-//        Analytics.logEvent("signUpViewLoaded", parameters: [
-//            AnalyticsParameterItemName: "signUpViewLoaded",
-//          ])
-
+        
         configUI()
         
         view.addSubview(dotsStackView)
@@ -580,8 +577,6 @@ class SignUpViewController: UIViewController {
                     viewModel.user = user
                     FirebaseManager.shared.setUser(user: user)
                 }
-                
-//                Analytics.logEvent("signUpCompleted", parameters: nil)
                 
                 let completedAlert = UIAlertController(title: "회원가입 완료", message: "회원가입이 완료되었습니다.", preferredStyle: .alert)
                 completedAlert.addAction(UIAlertAction(title: "확인", style: .default, handler: { action in


### PR DESCRIPTION
## 관련 이슈들
- #352 

## 작업 내용
- 회원가입시(SignUpVIewController) + 프로필 변경(ProfileEditViewController), scaleAspectFill로 되지 않은 것들을 교체해 주었습니다.
- 프로필 이미지가 들어가는 UIImageView부분이 width, height를 제외하면 동일한 부분이 많아서 프로필 이미지만 따로 관리하는 ProfileUIImageView를 만들어 주었습니다.

### 사용법
<img width="445" alt="스크린샷 2022-12-26 14 31 00" src="https://user-images.githubusercontent.com/72736657/209506861-44333f64-3955-4d16-a473-23feeb0cfcdd.png">

- 위처럼 생성할때, 이미지 프레임의 width값을 주면 cornerRadius 알아서 계산함
- 프로필 이미지가 없는 경우를 대비해, default 이미지를 넣었습니다.

## 리뷰 노트
- init 값으로 frame의 width값을 받는게 괜찮을까요? 더 좋은 방법이 있을 것만 같습니다..
- 하다보니까 전체적으로 다듬어야 될 부분이 많이 보이네요ㅎㅎ,,,

## 스크린샷(UX의 경우 gif)

<img width="466" alt="스크린샷 2022-12-26 14 29 20" src="https://user-images.githubusercontent.com/72736657/209506717-52928d8f-6256-474f-9689-f4ba2a8ec0ed.png">


## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
